### PR TITLE
feat: notify client when transcriber drops or goes silent

### DIFF
--- a/docs/superpowers/specs/2026-03-14-transcriber-failure-handling-design.md
+++ b/docs/superpowers/specs/2026-03-14-transcriber-failure-handling-design.md
@@ -1,0 +1,160 @@
+# Transcriber Failure Handling — Gateway Design
+
+**Date:** 2026-03-14
+**Status:** Approved
+
+## Problem
+
+When the transcriber service closes its WebSocket unexpectedly (e.g. rate limit exceeded), the gateway's `listen_loop` exits silently via `ConnectionClosed`. `bridge.run()` detects the task completion via `asyncio.wait(FIRST_COMPLETED)` and calls `close_all()`, disconnecting the client with no explanation.
+
+A second failure mode occurs when the transcriber is alive but hallucinating — it never emits a transcription message to the gateway. The client streams audio into a black hole until the transcriber eventually dies, at which point the first failure mode triggers.
+
+## Goals
+
+1. Send a descriptive `service_status` message to the client before closing the session when the transcriber drops unexpectedly.
+2. Detect prolonged silence from the transcriber (no transcription received within N seconds) and proactively notify + close the session.
+
+## Non-Goals
+
+- Automatic transcriber reconnect (out of scope; transcriber is being fixed separately).
+- Degraded mode (keep session open without transcriber).
+
+## Design
+
+### 1. TranscriberClient — `transcriber_client.py`
+
+Add two new attributes in `__init__`:
+
+```python
+self._dropped_unexpectedly: bool = False
+self._last_transcription_at: Optional[float] = None  # time.monotonic()
+```
+
+**Unexpected drop detection** — in `listen_loop`, distinguish between a normal close (bridge called `close()` which sets `_is_ready = False` first) and an unexpected one:
+
+```python
+except ConnectionClosed:
+    if self._is_ready:          # still ready → nobody called close() explicitly
+        self._dropped_unexpectedly = True
+    self._is_ready = False
+    logger.info(...)
+```
+
+**Transcription timestamp** — update `_last_transcription_at` whenever a valid transcription arrives:
+
+```python
+if t_msg.type == "transcription" and t_msg.text:
+    self._last_transcription_at = time.monotonic()
+    await on_transcription_callback(...)
+```
+
+### 2. JotaBridge — `bridge.py`
+
+**`_session_start`** — record `time.monotonic()` at the start of `run()` so the watchdog can measure elapsed time before any transcription arrives.
+
+**`_transcription_watchdog()`** — new async method, launched as a task in `run()` (only when `input_mode == "audio"`):
+
+```python
+async def _transcription_watchdog(self):
+    timeout = settings.TRANSCRIBER_SILENCE_TIMEOUT_S
+    await asyncio.sleep(timeout)   # initial grace period
+
+    while True:
+        await asyncio.sleep(2)
+        if not self.transcriber or not self.transcriber._is_ready:
+            return  # transcriber already closed; other mechanism handles it
+
+        last = self.transcriber._last_transcription_at
+        elapsed = time.monotonic() - last if last else time.monotonic() - self._session_start
+
+        if elapsed > timeout:
+            logger.warning(f"[{self.client_id}] Watchdog: {elapsed:.1f}s sin transcripción")
+            try:
+                await self.client_ws.send_json({
+                    "type": "service_status",
+                    "service": "transcriber",
+                    "status": "degraded",
+                    "message": "No transcription received — check microphone or audio quality",
+                })
+            except Exception:
+                pass
+            return  # causes asyncio.wait(FIRST_COMPLETED) to fire → session closes
+```
+
+**`run()` changes:**
+
+```python
+async def run(self):
+    self._session_start = time.monotonic()
+    self.tasks.append(asyncio.create_task(self._client_input_loop()))
+
+    if self.transcriber:
+        self.tasks.append(asyncio.create_task(
+            self.transcriber.listen_loop(on_transcription_callback=self._on_transcription)
+        ))
+        self.tasks.append(asyncio.create_task(self._transcription_watchdog()))
+
+    try:
+        done, pending = await asyncio.wait(self.tasks, return_when=asyncio.FIRST_COMPLETED)
+        for task in done:
+            try:
+                task.result()
+            except asyncio.CancelledError:
+                pass
+            except Exception as e:
+                logger.error(f"[{self.client_id}] Loop crasheó: {e}")
+
+        # Notify client if the transcriber dropped unexpectedly
+        if self.transcriber and self.transcriber._dropped_unexpectedly:
+            try:
+                await self.client_ws.send_json({
+                    "type": "service_status",
+                    "service": "transcriber",
+                    "status": "unavailable",
+                    "message": "Transcriber connection lost unexpectedly",
+                })
+            except Exception:
+                pass
+    finally:
+        await self.close_all()
+```
+
+### 3. Config — `core/config.py`
+
+```python
+TRANSCRIBER_SILENCE_TIMEOUT_S: int = 10
+```
+
+## Data Flow
+
+```
+Transcriber closes (rate limit / crash)
+  → listen_loop catches ConnectionClosed
+  → _is_ready was True → sets _dropped_unexpectedly = True
+  → task exits
+  → asyncio.wait(FIRST_COMPLETED) fires in bridge.run()
+  → _dropped_unexpectedly is True → send service_status(unavailable) to client
+  → close_all() → session ends cleanly
+```
+
+```
+Transcriber alive but silent (hallucinations suppressed internally)
+  → watchdog sleeps TRANSCRIBER_SILENCE_TIMEOUT_S
+  → checks _last_transcription_at, elapsed > timeout
+  → sends service_status(degraded) to client
+  → watchdog returns
+  → asyncio.wait(FIRST_COMPLETED) fires
+  → close_all() → session ends cleanly
+```
+
+## Files Changed
+
+| File | Change |
+|---|---|
+| `src/services/transcriber_client.py` | Add `_dropped_unexpectedly`, `_last_transcription_at`; update `listen_loop` |
+| `src/services/bridge.py` | Add `_session_start`, `_transcription_watchdog()`; update `run()` |
+| `src/core/config.py` | Add `TRANSCRIBER_SILENCE_TIMEOUT_S` |
+
+## Open Questions
+
+- None. Transcriber reconnect is explicitly out of scope.

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ websockets>=11.0.3
 pydantic>=2.0.0
 pydantic-settings>=2.0.0
 python-multipart>=0.0.6
+httpx>=0.24.0

--- a/src/core/config.py
+++ b/src/core/config.py
@@ -12,6 +12,7 @@ class Settings(BaseSettings):
     TTS_TOKEN: str = "gateway"
 
     BARGE_IN_MIN_CHARS: int = 5
+    TRANSCRIBER_SILENCE_TIMEOUT_S: int = 25
 
     class Config:
         env_file = ".env"

--- a/src/services/bridge.py
+++ b/src/services/bridge.py
@@ -1,5 +1,7 @@
 import asyncio
+import json
 import logging
+import time
 from typing import Optional
 from fastapi import WebSocket, WebSocketDisconnect
 
@@ -27,6 +29,8 @@ class JotaBridge:
 
         self.tasks: list[asyncio.Task] = []
         self._active_turn: Optional[asyncio.Task] = None
+        self._session_start: float = 0.0
+        self._first_audio_at: Optional[float] = None
 
     async def connect_internal_services(self):
         """Inicializa clientes de microservicios dependiendo del handshake."""
@@ -125,7 +129,42 @@ class JotaBridge:
             return True
         return False
 
+    async def _transcription_watchdog(self):
+        """Cierra la sesión si el transcriptor no emite nada en TRANSCRIBER_SILENCE_TIMEOUT_S segundos
+        contados desde que el cliente empezó a enviar audio."""
+        from src.core.config import settings
+        timeout = settings.TRANSCRIBER_SILENCE_TIMEOUT_S
+
+        # Esperar a que el cliente empiece a enviar audio antes de vigilar
+        while self._first_audio_at is None:
+            await asyncio.sleep(0.5)
+            if not self.transcriber or not self.transcriber._is_ready:
+                return
+
+        while True:
+            await asyncio.sleep(2)
+            if not self.transcriber or not self.transcriber._is_ready:
+                return
+
+            last = self.transcriber._last_transcription_at
+            elapsed = time.monotonic() - last if last else time.monotonic() - self._first_audio_at
+
+            if elapsed > timeout:
+                logger.warning(f"[{self.client_id}] Watchdog: {elapsed:.1f}s sin transcripción del transcriptor")
+                try:
+                    await self.client_ws.send_json({
+                        "type": "service_status",
+                        "service": "transcriber",
+                        "status": "degraded",
+                        "message": "No transcription received — check microphone or audio quality",
+                    })
+                except Exception:
+                    pass
+                return
+
     async def run(self):
+        self._session_start = time.monotonic()
+
         # Loop principal de lectura del cliente
         self.tasks.append(asyncio.create_task(self._client_input_loop()))
 
@@ -134,6 +173,7 @@ class JotaBridge:
             self.tasks.append(asyncio.create_task(
                 self.transcriber.listen_loop(on_transcription_callback=self._on_transcription)
             ))
+            self.tasks.append(asyncio.create_task(self._transcription_watchdog()))
 
         try:
             done, pending = await asyncio.wait(self.tasks, return_when=asyncio.FIRST_COMPLETED)
@@ -141,6 +181,18 @@ class JotaBridge:
                 try: task.result()
                 except asyncio.CancelledError: pass
                 except Exception as e: logger.error(f"[{self.client_id}] Loop crasheó: {e}")
+
+            # Notificar al cliente si el transcriptor cayó inesperadamente
+            if self.transcriber and self.transcriber._dropped_unexpectedly:
+                try:
+                    await self.client_ws.send_json({
+                        "type": "service_status",
+                        "service": "transcriber",
+                        "status": "unavailable",
+                        "message": "Transcriber connection lost unexpectedly",
+                    })
+                except Exception:
+                    pass
         finally:
             await self.close_all()
 
@@ -157,12 +209,23 @@ class JotaBridge:
                 # AUDIO → Transcriber
                 if "bytes" in message:
                     if self.handshake.input_mode == "audio" and self.transcriber:
+                        if self._first_audio_at is None:
+                            self._first_audio_at = time.monotonic()
                         await self.transcriber.send_audio(message["bytes"])
 
                 # TEXTO → Orchestrator (prompt directo desde un cliente de texto)
                 elif "text" in message:
                     text_data = message["text"]
-                    if self.orchestrator:
+                    try:
+                        json_msg = json.loads(text_data)
+                    except Exception:
+                        json_msg = None
+
+                    if json_msg and json_msg.get("type") == "end":
+                        # Cliente terminó de hablar → señalizar fin al transcriber
+                        if self.handshake.input_mode == "audio" and self.transcriber:
+                            await self.transcriber.send_end()
+                    elif self.orchestrator:
                         await self._call_orchestrator(text_data)
 
         except WebSocketDisconnect:

--- a/src/services/transcriber_client.py
+++ b/src/services/transcriber_client.py
@@ -1,6 +1,7 @@
 import asyncio
 import json
 import logging
+import time
 import websockets
 from websockets.exceptions import ConnectionClosed
 from typing import Optional, Callable, Awaitable
@@ -19,6 +20,8 @@ class TranscriberClient:
         self.client_id = client_id
         self.ws: Optional[websockets.WebSocketClientProtocol] = None
         self._is_ready = False
+        self._dropped_unexpectedly: bool = False
+        self._last_transcription_at: Optional[float] = None
 
     async def connect(self, language: str = "es"):
         """Abre el socket y manda el Handshake inicial de config"""
@@ -85,6 +88,8 @@ class TranscriberClient:
                     t_msg = TranscriberMessage(**data)
 
                     if t_msg.type == "transcription" and t_msg.text:
+                        self._last_transcription_at = time.monotonic()
+                        logger.debug(f"[{self.client_id}] Transcripción recibida: is_final={t_msg.is_final!r} text='{t_msg.text[:40]}'")
                         await on_transcription_callback(t_msg.text, bool(t_msg.is_final))
 
                     elif t_msg.type == "error":
@@ -95,6 +100,8 @@ class TranscriberClient:
                 except json.JSONDecodeError:
                     logger.warning(f"[{self.client_id}] Transcriber mandó un non-JSON: {message}")
         except ConnectionClosed:
+            if self._is_ready:
+                self._dropped_unexpectedly = True
             self._is_ready = False
             logger.info(f"[{self.client_id}] Loop de escucha del Transcriber finalizado.")
 
@@ -134,6 +141,15 @@ class TranscriberClient:
             raise e
         finally:
             await self.close()
+
+    async def send_end(self):
+        """Señaliza al transcriber que el audio terminó, disparando la transcripción final."""
+        if not self._is_ready or not self.ws:
+            return
+        try:
+            await self.ws.send(json.dumps({"type": "end"}))
+        except ConnectionClosed:
+            self._is_ready = False
 
     async def close(self):
         self._is_ready = False


### PR DESCRIPTION
## Summary

- Detects when the transcriber WebSocket drops unexpectedly and sends a `service_status` (unavailable) message to the client before closing the session
- Adds a watchdog task that fires `service_status` (degraded) if no transcription arrives within `TRANSCRIBER_SILENCE_TIMEOUT_S` seconds after the client starts sending audio
- Adds `send_end()` to `TranscriberClient` and handles `{"type": "end"}` JSON from the client to signal audio stream completion

Implements the approved design spec at `docs/superpowers/specs/2026-03-14-transcriber-failure-handling-design.md`.

> No hay issue abierta para esta feature — implementa directamente el spec aprobado.

## Test plan

- [ ] Connect a client in audio mode, kill the transcriber mid-session → client receives `{"type": "service_status", "service": "transcriber", "status": "unavailable"}`
- [ ] Connect a client in audio mode, send audio but transcriber emits nothing for 25s → client receives `{"type": "service_status", "service": "transcriber", "status": "degraded"}`
- [ ] Connect a client, send `{"type": "end"}` over text channel → `send_end()` called on transcriber, no crash
- [ ] Text-mode client unaffected (watchdog not started when `input_mode != "audio"`)
- [ ] `TRANSCRIBER_SILENCE_TIMEOUT_S` overridable via env var

🤖 Generated with [Claude Code](https://claude.com/claude-code)