### PR TITLE
fix: deduplicate final transcriptions before calling orchestrator

### DIFF
--- a/src/services/bridge.py
+++ b/src/services/bridge.py
@@ -31,6 +31,7 @@ class JotaBridge:
         self._active_turn: Optional[asyncio.Task] = None
         self._session_start: float = 0.0
         self._first_audio_at: Optional[float] = None
+        self._last_final_text: Optional[str] = None
 
     async def connect_internal_services(self):
         """Inicializa clientes de microservicios dependiendo del handshake."""
@@ -250,6 +251,12 @@ class JotaBridge:
                     except Exception:
                         pass
             return  # partials never reach the orchestrator
+
+        # Final: deduplicate — transcriber may emit the same text more than once
+        if text == self._last_final_text:
+            logger.debug(f"[{self.client_id}] Transcripción final duplicada descartada: '{text[:40]}'")
+            return
+        self._last_final_text = text
 
         # Final: cancel any running turn, notify client, start new turn
         await self._cancel_active_turn()


### PR DESCRIPTION
Closes #3

## Summary

- Añade `_last_final_text` en `JotaBridge.__init__` para rastrear la última transcripción final procesada
- En `_on_transcription()`, descarta duplicados exactos (`is_final=True` con el mismo texto) antes de llamar al orchestrator
- El log de debug registra cada descarte para facilitar el diagnóstico

## Causa raíz

El transcriptor puede emitir `is_final=True` más de una vez para el mismo utterance, probablemente por una race condition entre `flushLoop` y `handleEnd` en jota-transcriber. Se ha abierto Jota-project/jota-transcriber#27 con el análisis detallado y el fix sugerido en el transcriptor.

Este fix es la defensa mínima necesaria en el gateway — independientemente de si el transcriptor se corrige.

## Test plan

- [ ] Hablar una frase → el orchestrator recibe exactamente una llamada
- [ ] Si el transcriptor emite el mismo texto final dos veces → segunda llamada descartada, log `DEBUG` visible
- [ ] Frases distintas consecutivas → cada una llega al orchestrator sin descarte
- [ ] Cliente en modo texto (sin transcriber) → sin cambios de comportamiento

🤖 Generated with [Claude Code](https://claude.com/claude-code)