### PR TITLE
fix: forward partial transcriptions to client in real time

### DIFF
--- a/src/services/bridge.py
+++ b/src/services/bridge.py
@@ -242,6 +242,12 @@ class JotaBridge:
         All client_ws sends are guarded — the client may disconnect at any time.
         """
         if not is_final:
+            # Forward partial to client for live display
+            try:
+                await self.client_ws.send_json({"type": "transcription_partial", "text": text})
+            except Exception:
+                return  # client disconnected
+
             # Barge-in: interrupt active turn if partial is substantial enough
             if len(text) >= settings.BARGE_IN_MIN_CHARS:
                 if await self._cancel_active_turn():


### PR DESCRIPTION
Closes #4

## Summary

- En `_on_transcription()`, cada evento `is_final=False` ahora envía `{"type": "transcription_partial", "text": text}` al cliente antes de la lógica de barge-in
- Si el cliente se desconecta durante un parcial, el loop termina limpiamente (return en el except)
- Los finales siguen enviando `{"type": "transcription", "text": text}` sin cambios

## Comportamiento anterior vs nuevo

| Evento | Antes | Ahora |
|---|---|---|
| `is_final=False` | Solo barge-in interno, cliente no ve nada | Cliente recibe `transcription_partial` en tiempo real |
| `is_final=True` | Cliente recibe `transcription` + orchestrator | Sin cambios |

## Test plan

- [ ] Hablar durante una sesión de audio → el cliente recibe mensajes `transcription_partial` mientras habla
- [ ] El texto parcial se actualiza progresivamente (el transcriber envía texto acumulativo)
- [ ] Al terminar de hablar → cliente recibe `transcription` final
- [ ] Barge-in sigue funcionando: parcial sustancial durante respuesta activa → `interrupted` + turno cancelado
- [ ] Cliente en modo texto → sin cambios de comportamiento

🤖 Generated with [Claude Code](https://claude.com/claude-code)