### PR TITLE
feat: route client_key through handshake to all downstream services

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,3 +1,13 @@
-ORCHESTRATOR_WS_URL=ws://jota_orchestrator:8000/api/chat/ws
-TRANSCRIBER_WS_URL=ws://transcription_api:9000
-TTS_WS_URL=ws://tts_api:8000/synthesize
+# Orchestrator
+ORCHESTRATOR_BASE_URL=http://jota-orchestrator:8000
+
+# Transcriber (jota-transcriber)
+TRANSCRIBER_WS_URL=ws://jota-transcriber:9000
+
+# TTS (jota-speaker)
+TTS_WS_URL=ws://jota-speaker:8005/ws
+TTS_TOKEN=gateway
+
+# Behaviour
+BARGE_IN_MIN_CHARS=5
+TRANSCRIBER_SILENCE_TIMEOUT_S=25

--- a/src/api/routes.py
+++ b/src/api/routes.py
@@ -10,36 +10,35 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
-@router.websocket("/ws/stream/{client_id}")
-async def gateway_websocket(websocket: WebSocket, client_id: str):
+@router.websocket("/ws/stream")
+async def gateway_websocket(websocket: WebSocket):
     await websocket.accept()
-    
+
     # 1. FASE DE HANDSHAKE INITIAL
     try:
-        # El primer mensaje esperado siempre es la config de modos JSON.
         raw_msg = await websocket.receive_text()
         msg_data = json.loads(raw_msg)
         handshake = Handshake(**msg_data)
+        client_id = handshake.client_key  # label de logs hasta que Fase 1 resuelva el UUID real
         logger.info(f"[{client_id}] Handshake completado exitosamente: {handshake}")
     except (json.JSONDecodeError, ValidationError) as e:
-        logger.error(f"[{client_id}] Payload inicial inválido de handshake. {e}")
+        logger.error(f"Payload inicial inválido de handshake. {e}")
         await websocket.close(code=1008, reason="Handshake invalido. Se esperaba JSON de configuración.")
         return
     except WebSocketDisconnect:
-        logger.info(f"[{client_id}] Se desconecto inmediatamente antes o durante el handshake.")
+        logger.info(f"Cliente desconectado antes o durante el handshake.")
         return
 
     # 2. INSTANCIAR EL PUENTE DE MICROSERVICIOS
     bridge = JotaBridge(client_id=client_id, client_ws=websocket)
     bridge.handshake = handshake
-    
+
     try:
-         # Tira las conexiones concurrentes a Orchestrator, Transcriber, TTS
-         await bridge.connect_internal_services()
+        await bridge.connect_internal_services()
     except Exception as e:
-         logger.error(f"[{client_id}] Fallo al inicializar puentes internos red docker. {e}")
-         await websocket.close(code=1011, reason="Problema estableciendo microservicios internos del hub.")
-         return
+        logger.error(f"[{client_id}] Fallo al inicializar puentes internos. {e}")
+        await websocket.close(code=1011, reason="Problema estableciendo microservicios internos del hub.")
+        return
 
     # 2.5 HEALTH CHECK — verifica disponibilidad de servicios antes de abrir la sesión
     if not await bridge.health_check():
@@ -49,18 +48,14 @@ async def gateway_websocket(websocket: WebSocket, client_id: str):
 
     # 3. LANZAR LOOPS CONCURRENTES
     try:
-        # Este thread se queda en el método run() asíncronamente mientras los bucles corren.
         await bridge.run()
     except Exception as e:
         logger.error(f"[{client_id}] Error crítico de Runtime en el Puente Principal: {e}")
     finally:
-        # Limpieza. bridge.run() o sus bucles detectaron quiebre / desconexión.
-        # Desconecta cliente si aún esta activo.
         if "DISCONNECTED" not in websocket.client_state.name:
-            # client_state se mapea de starlette, asumiendo lo cerramos si podemos
-           try:
-               await websocket.close()
-           except Exception:
-               pass
-               
-        logger.info(f"[{client_id}] --- Sesión de entrada WebSocket Concluida --- ")
+            try:
+                await websocket.close()
+            except Exception:
+                pass
+
+        logger.info(f"[{client_id}] --- Sesión de entrada WebSocket Concluida ---")

--- a/src/core/config.py
+++ b/src/core/config.py
@@ -2,12 +2,10 @@ from pydantic_settings import BaseSettings
 
 class Settings(BaseSettings):
     # URL base HTTP del JotaOrchestrator (sin trailing slash)
-    # El cliente usará POST {ORCHESTRATOR_BASE_URL}/api/quick
     ORCHESTRATOR_BASE_URL: str = "http://localhost:8000"
-    # Clave de cliente QUICK registrada en JotaDB para este gateway
-    ORCHESTRATOR_API_KEY: str = "jota_internal_default_key"
-    
+
     TRANSCRIBER_WS_URL: str = "ws://localhost:9000"
+
     TTS_WS_URL: str = "ws://localhost:8005/ws"
     TTS_TOKEN: str = "gateway"
 

--- a/src/models/schemas.py
+++ b/src/models/schemas.py
@@ -10,9 +10,10 @@ class Handshake(BaseModel):
     Configuración inicial que el ESP32 o la Web envían al Gateway al conectar
     por WebSocket. Define qué patas internas del ecosistema se deben encender.
     """
+    client_key: str
     input_mode: Literal["audio", "text"]
     output_mode: List[Literal["audio", "text", "status"]]
-    
+
     model_config = ConfigDict(extra="allow")
 
 # =====================================================================

--- a/src/services/bridge.py
+++ b/src/services/bridge.py
@@ -40,7 +40,7 @@ class JotaBridge:
         # 1. Orchestrator — siempre activo (es el cerebro)
         self.orchestrator = OrchestratorClient(
             base_url=settings.ORCHESTRATOR_BASE_URL,
-            api_key=settings.ORCHESTRATOR_API_KEY,
+            api_key=self.handshake.client_key,
             client_id=self.client_id,
         )
         connect_tasks.append(self.orchestrator.connect())
@@ -51,7 +51,10 @@ class JotaBridge:
                 url=settings.TRANSCRIBER_WS_URL,
                 client_id=self.client_id
             )
-            connect_tasks.append(self.transcriber.connect(language="es"))
+            connect_tasks.append(self.transcriber.connect(
+                language=getattr(self.handshake, "language", "es"),
+                token=self.handshake.client_key,
+            ))
 
         await asyncio.gather(*connect_tasks)
 

--- a/src/services/transcriber_client.py
+++ b/src/services/transcriber_client.py
@@ -23,19 +23,16 @@ class TranscriberClient:
         self._dropped_unexpectedly: bool = False
         self._last_transcription_at: Optional[float] = None
 
-    async def connect(self, language: str = "es"):
+    async def connect(self, language: str = "es", token: str = ""):
         """Abre el socket y manda el Handshake inicial de config"""
         try:
             logger.info(f"[{self.client_id}] Conectado a Transcriber WS ({self.url})")
-            
-            # El Transcriber requiere un JSON de configuración antes de recibir audio binario
-            # config_msg = TranscriberConfig(language=language)
+
             handshake = {
                 "type": "config",
                 "language": language,
-                "token": "pene",
-                "publish_mqtt": False,
-                "vad_thold": 0.0
+                "token": token,
+                "vad_thold": 0.0,
             }
             logger.info(f"[{self.client_id}] Configuracion transcriber: {handshake}")
 


### PR DESCRIPTION
Closes #5
Related to #2

## Summary

- Añade `client_key: str` al schema `Handshake` — el cliente envía su key al conectar
- Elimina `{client_id}` del path `/ws/stream` — la identidad ya no la elige el cliente en la URL
- El gateway reenvía `client_key` como `x-client-key` al orchestrator y como `token` al transcriber — cada servicio la valida por su cuenta contra jota-db
- Elimina `ORCHESTRATOR_API_KEY` de config — era una clave compartida por todos los clientes, sustituida por las keys individuales
- Limpia `transcriber_client.py`: quita token hardcodeado y campo muerto `publish_mqtt`
- Sincroniza `.env.sample` con las variables reales de config

## Lo que queda para Fase 1 (#2)

`client_id` interno sigue siendo `handshake.client_key` (un string, no un UUID). La Fase 1 añadirá la llamada a `GET /auth/client` en jota-db durante el handshake para resolver el UUID real y propagarlo a todos los servicios.

## Test plan

- [ ] Cliente envía handshake sin `client_key` → conexión rechazada con `1008`
- [ ] Cliente envía `client_key` válida → orchestrator recibe `x-client-key` con esa key
- [ ] Cliente en modo audio → transcriber recibe `token` con la `client_key` del cliente
- [ ] Key inválida → orchestrator y/o transcriber rechazan la sesión con sus propios errores de auth
- [ ] Endpoint ahora es `ws://gateway:8004/ws/stream` (sin path param)

🤖 Generated with [Claude Code](https://claude.com/claude-code)