### PR TITLE
feat: Fase 1 — DbClient + resolver identidad en el handshake

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,3 +1,7 @@
+# jota-db (identidad y configuración)
+JOTA_DB_BASE_URL=http://jota-db:8001
+JOTA_DB_API_KEY=changeme
+
 # Orchestrator
 ORCHESTRATOR_BASE_URL=http://jota-orchestrator:8000
 

--- a/src/api/routes.py
+++ b/src/api/routes.py
@@ -1,10 +1,12 @@
 from fastapi import APIRouter, WebSocket, WebSocketDisconnect
 from pydantic import ValidationError
+import httpx
 import logging
 import json
 
 from src.models.schemas import Handshake
 from src.services.bridge import JotaBridge
+from src.services.db_client import db_client
 
 logger = logging.getLogger(__name__)
 
@@ -19,38 +21,50 @@ async def gateway_websocket(websocket: WebSocket):
         raw_msg = await websocket.receive_text()
         msg_data = json.loads(raw_msg)
         handshake = Handshake(**msg_data)
-        client_id = handshake.client_key  # label de logs hasta que Fase 1 resuelva el UUID real
-        logger.info(f"[{client_id}] Handshake completado exitosamente: {handshake}")
     except (json.JSONDecodeError, ValidationError) as e:
         logger.error(f"Payload inicial inválido de handshake. {e}")
         await websocket.close(code=1008, reason="Handshake invalido. Se esperaba JSON de configuración.")
         return
     except WebSocketDisconnect:
-        logger.info(f"Cliente desconectado antes o durante el handshake.")
+        logger.info("Cliente desconectado antes o durante el handshake.")
         return
 
-    # 2. INSTANCIAR EL PUENTE DE MICROSERVICIOS
-    bridge = JotaBridge(client_id=client_id, client_ws=websocket)
+    # 2. RESOLVER IDENTIDAD EN JOTA-DB
+    try:
+        client, config = await db_client.get_session(handshake.client_key)
+    except httpx.HTTPStatusError as e:
+        logger.warning(f"[{handshake.client_key}] Handshake rechazado por jota-db ({e.response.status_code})")
+        await websocket.close(code=1008, reason="Clave de cliente invalida o inactiva.")
+        return
+    except httpx.RequestError as e:
+        logger.error(f"[{handshake.client_key}] jota-db no disponible durante handshake: {e}")
+        await websocket.close(code=1011, reason="Servicio de identidad no disponible.")
+        return
+
+    logger.info(f"[{client.id}] Handshake verificado: key={handshake.client_key!r}")
+
+    # 3. INSTANCIAR EL PUENTE DE MICROSERVICIOS
+    bridge = JotaBridge(client=client, config=config, client_ws=websocket)
     bridge.handshake = handshake
 
     try:
         await bridge.connect_internal_services()
     except Exception as e:
-        logger.error(f"[{client_id}] Fallo al inicializar puentes internos. {e}")
+        logger.error(f"[{client.id}] Fallo al inicializar puentes internos. {e}")
         await websocket.close(code=1011, reason="Problema estableciendo microservicios internos del hub.")
         return
 
-    # 2.5 HEALTH CHECK — verifica disponibilidad de servicios antes de abrir la sesión
+    # 3.5 HEALTH CHECK — verifica disponibilidad de servicios antes de abrir la sesión
     if not await bridge.health_check():
-        logger.warning(f"[{client_id}] Health check falló. Cerrando sesión.")
+        logger.warning(f"[{client.id}] Health check falló. Cerrando sesión.")
         await websocket.close(code=1011, reason="Servicio crítico no disponible.")
         return
 
-    # 3. LANZAR LOOPS CONCURRENTES
+    # 4. LANZAR LOOPS CONCURRENTES
     try:
         await bridge.run()
     except Exception as e:
-        logger.error(f"[{client_id}] Error crítico de Runtime en el Puente Principal: {e}")
+        logger.error(f"[{client.id}] Error crítico de Runtime en el Puente Principal: {e}")
     finally:
         if "DISCONNECTED" not in websocket.client_state.name:
             try:
@@ -58,4 +72,4 @@ async def gateway_websocket(websocket: WebSocket):
             except Exception:
                 pass
 
-        logger.info(f"[{client_id}] --- Sesión de entrada WebSocket Concluida ---")
+        logger.info(f"[{client.id}] --- Sesión de entrada WebSocket Concluida ---")

--- a/src/core/config.py
+++ b/src/core/config.py
@@ -1,6 +1,10 @@
 from pydantic_settings import BaseSettings
 
 class Settings(BaseSettings):
+    # jota-db (fuente de verdad de identidad y configuración)
+    JOTA_DB_BASE_URL: str = "http://localhost:8001"
+    JOTA_DB_API_KEY: str = ""
+
     # URL base HTTP del JotaOrchestrator (sin trailing slash)
     ORCHESTRATOR_BASE_URL: str = "http://localhost:8000"
 

--- a/src/main.py
+++ b/src/main.py
@@ -1,7 +1,8 @@
 import logging
+from contextlib import asynccontextmanager
 from fastapi import FastAPI
 from src.api.routes import router as stream_router
-from src.api.transcribe import router as transcribe_router
+from src.services.db_client import db_client
 
 # Configuración Base de Logs para el Gateway
 logging.basicConfig(
@@ -10,10 +11,19 @@ logging.basicConfig(
 )
 logger = logging.getLogger(__name__)
 
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    await db_client.connect()
+    yield
+    await db_client.close()
+
+
 app = FastAPI(
     title="JotaGateway (BFF)",
     description="Backend For Frontend - Enrutador principal de WebSockets. Titiritero del Ecosistema IA.",
-    version="1.0.0"
+    version="1.0.0",
+    lifespan=lifespan,
 )
 
 # Incluir routers

--- a/src/models/schemas.py
+++ b/src/models/schemas.py
@@ -2,6 +2,40 @@ from pydantic import BaseModel, ConfigDict
 from typing import List, Literal, Optional, Any
 
 # =====================================================================
+# jota-db — modelos que el gateway recibe de GET /auth/session
+# =====================================================================
+
+class Client(BaseModel):
+    """Registro de cliente tal como lo devuelve jota-db."""
+    id: str
+    client_key: str
+    is_active: bool
+
+    model_config = ConfigDict(extra="allow")
+
+
+class ClientConfig(BaseModel):
+    """Configuración por cliente tal como la devuelve jota-db."""
+    stt_language: str = "es"
+    stt_model: Optional[str] = None
+    stt_vad_thold: float = 0.0
+    tts_voice: str = "af_heart"
+    tts_speed: float = 1.0
+    preferred_model_id: Optional[str] = None
+    system_prompt_extra: Optional[str] = None
+    barge_in_enabled: bool = True
+    barge_in_min_chars: int = 5
+    conversation_memory_limit: int = 20
+
+    model_config = ConfigDict(extra="allow")
+
+
+class SessionResponse(BaseModel):
+    """Respuesta de GET /auth/session en jota-db."""
+    client: Client
+    config: ClientConfig
+
+# =====================================================================
 # Gateway (Client <-> Gateway)
 # =====================================================================
 

--- a/src/services/bridge.py
+++ b/src/services/bridge.py
@@ -6,7 +6,7 @@ from typing import Optional
 from fastapi import WebSocket, WebSocketDisconnect
 
 from src.core.config import settings
-from src.models.schemas import Handshake
+from src.models.schemas import Client, ClientConfig, Handshake
 from src.services.orchestrator_client import OrchestratorClient
 from src.services.transcriber_client import TranscriberClient
 from src.services.tts_client import TTSClient
@@ -18,8 +18,10 @@ class JotaBridge:
     Titiritero principal. Gestiona la conexión de un cliente físico
     y enruta asincrónicamente los mensajes utilizando los adaptadores de microservicio.
     """
-    def __init__(self, client_id: str, client_ws: WebSocket):
-        self.client_id = client_id
+    def __init__(self, client: Client, config: ClientConfig, client_ws: WebSocket):
+        self.client = client
+        self.config = config
+        self.client_id = client.id  # UUID real — usado en logs y como user_id al orchestrator
         self.client_ws = client_ws
         self.handshake: Optional[Handshake] = None
 
@@ -40,8 +42,8 @@ class JotaBridge:
         # 1. Orchestrator — siempre activo (es el cerebro)
         self.orchestrator = OrchestratorClient(
             base_url=settings.ORCHESTRATOR_BASE_URL,
-            api_key=self.handshake.client_key,
-            client_id=self.client_id,
+            api_key=self.client.client_key,
+            client_id=self.client_id,  # UUID real → user_id correcto en jota-db
         )
         connect_tasks.append(self.orchestrator.connect())
 
@@ -52,8 +54,9 @@ class JotaBridge:
                 client_id=self.client_id
             )
             connect_tasks.append(self.transcriber.connect(
-                language=getattr(self.handshake, "language", "es"),
-                token=self.handshake.client_key,
+                language=self.config.stt_language,
+                token=self.client.client_key,
+                vad_thold=self.config.stt_vad_thold,
             ))
 
         await asyncio.gather(*connect_tasks)

--- a/src/services/db_client.py
+++ b/src/services/db_client.py
@@ -1,0 +1,124 @@
+"""
+db_client.py
+~~~~~~~~~~~~
+Cliente HTTP hacia jota-db. Singleton compartido por todas las sesiones.
+
+Responsabilidades:
+  · Handshake WS: get_session(client_key) → (Client, ClientConfig)
+  · REST API (Fase 2): config, conversaciones, mensajes
+"""
+import logging
+from typing import Optional
+import httpx
+
+from src.models.schemas import Client, ClientConfig, SessionResponse
+
+logger = logging.getLogger(__name__)
+
+
+class DbClient:
+    """
+    Wraps llamadas HTTP a jota-db.
+
+    Se instancia como singleton en este módulo y se reutiliza entre sesiones.
+    Llamar a connect() en el startup de la app y close() en el shutdown.
+    """
+
+    def __init__(self, base_url: str, api_key: str):
+        self.base_url = base_url.rstrip("/")
+        self._api_key = api_key
+        self._http: Optional[httpx.AsyncClient] = None
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    async def connect(self):
+        self._http = httpx.AsyncClient(
+            headers={"Authorization": f"Bearer {self._api_key}"},
+            timeout=httpx.Timeout(10.0),
+        )
+        logger.info(f"DbClient listo → {self.base_url}")
+
+    async def close(self):
+        if self._http:
+            await self._http.aclose()
+            self._http = None
+
+    # ------------------------------------------------------------------
+    # Identidad (usado en el handshake WS)
+    # ------------------------------------------------------------------
+
+    async def get_session(self, client_key: str) -> tuple[Client, ClientConfig]:
+        """
+        Llama a GET /auth/session en jota-db para resolver client_key → Client + ClientConfig.
+
+        Raises:
+            httpx.HTTPStatusError: 401/403 si la key no es válida o el cliente está inactivo.
+            httpx.RequestError:    Si jota-db no está disponible.
+        """
+        assert self._http, "DbClient no está conectado. Llama a connect() primero."
+        response = await self._http.get(
+            f"{self.base_url}/auth/session",
+            headers={"X-API-Key": client_key},
+        )
+        response.raise_for_status()
+        data = SessionResponse.model_validate(response.json())
+        return data.client, data.config
+
+    # ------------------------------------------------------------------
+    # Configuración (usado en la REST API — Fase 2)
+    # ------------------------------------------------------------------
+
+    async def get_config(self, client_id: str) -> ClientConfig:
+        assert self._http
+        r = await self._http.get(f"{self.base_url}/config/me", headers={"X-Client-Id": client_id})
+        r.raise_for_status()
+        return ClientConfig.model_validate(r.json())
+
+    async def update_config(self, client_id: str, patch: dict) -> ClientConfig:
+        assert self._http
+        r = await self._http.put(
+            f"{self.base_url}/config/me",
+            json=patch,
+            headers={"X-Client-Id": client_id},
+        )
+        r.raise_for_status()
+        return ClientConfig.model_validate(r.json())
+
+    async def reset_config(self, client_id: str) -> ClientConfig:
+        assert self._http
+        r = await self._http.post(
+            f"{self.base_url}/config/me/reset",
+            headers={"X-Client-Id": client_id},
+        )
+        r.raise_for_status()
+        return ClientConfig.model_validate(r.json())
+
+    # ------------------------------------------------------------------
+    # Historial (usado en la REST API — Fase 2)
+    # ------------------------------------------------------------------
+
+    async def get_conversations(self, client_id: str) -> list:
+        assert self._http
+        r = await self._http.get(
+            f"{self.base_url}/conversations",
+            headers={"X-Client-Id": client_id},
+        )
+        r.raise_for_status()
+        return r.json()
+
+    async def get_messages(self, conversation_id: str) -> list:
+        assert self._http
+        r = await self._http.get(f"{self.base_url}/conversations/{conversation_id}/messages")
+        r.raise_for_status()
+        return r.json()
+
+
+# Singleton — importar este objeto directamente
+from src.core.config import settings
+
+db_client = DbClient(
+    base_url=settings.JOTA_DB_BASE_URL,
+    api_key=settings.JOTA_DB_API_KEY,
+)

--- a/src/services/transcriber_client.py
+++ b/src/services/transcriber_client.py
@@ -23,7 +23,7 @@ class TranscriberClient:
         self._dropped_unexpectedly: bool = False
         self._last_transcription_at: Optional[float] = None
 
-    async def connect(self, language: str = "es", token: str = ""):
+    async def connect(self, language: str = "es", token: str = "", vad_thold: float = 0.0):
         """Abre el socket y manda el Handshake inicial de config"""
         try:
             logger.info(f"[{self.client_id}] Conectado a Transcriber WS ({self.url})")
@@ -32,7 +32,7 @@ class TranscriberClient:
                 "type": "config",
                 "language": language,
                 "token": token,
-                "vad_thold": 0.0,
+                "vad_thold": vad_thold,
             }
             logger.info(f"[{self.client_id}] Configuracion transcriber: {handshake}")
 


### PR DESCRIPTION
## Resumen

El gateway ya no confía en el string de la `client_key` como identificador interno. Ahora llama a `GET /auth/session` en jota-db durante el handshake WebSocket para resolver la key al UUID real del cliente y su configuración completa.

- `DbClient` singleton que gestiona todas las llamadas a jota-db (también preparado para la REST API de Fase 2)
- `JotaBridge` recibe `Client + ClientConfig` con tipado completo
- El orchestrator recibe `user_id = client.id` (UUID real) → elimina las FK violations en jota-db
- Transcriber recibe `language` y `vad_thold` desde `ClientConfig` en lugar de valores hardcodeados
- Handshake falla rápido: WS `1008` si key inválida, `1011` si jota-db no disponible

## Prerequisito

Este PR requiere que jota-db tenga implementado el endpoint `GET /auth/session` (ver TASKS.md Fase 1 — Paso 1). Los demás cambios son independientes y ya están en marcha en ese repo.

## Archivos clave

- `src/services/db_client.py` — nuevo, singleton HTTP hacia jota-db
- `src/api/routes.py` — handshake llama `get_session()` antes de instanciar `JotaBridge`
- `src/services/bridge.py` — recibe `Client + ClientConfig`, usa UUID real
- `src/models/schemas.py` — modelos `Client`, `ClientConfig`, `SessionResponse`

## Test plan

- [ ] Con jota-db corriendo y `GET /auth/session` implementado: handshake completa y `JotaBridge.client_id` es un UUID
- [ ] Key inválida → WS cierra con código 1008
- [ ] jota-db caído → WS cierra con código 1011
- [ ] Transcriber recibe el idioma del `ClientConfig`, no `"es"` hardcodeado
- [ ] Orchestrator recibe UUID real como `user_id` → conversaciones se crean sin FK error en jota-db

Closes #2
Closes #13
Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)