### PR TITLE
fix: protocolo del transcriber — code, session_id, buffer_full, TranscriberConfig

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@
 __pycache__
 __init__.py
 venv/*
-.venv/*
+.venv/
+.worktrees/

--- a/src/models/schemas.py
+++ b/src/models/schemas.py
@@ -61,18 +61,21 @@ class TranscriberConfig(BaseModel):
     """
     type: Literal["config"] = "config"
     language: str = "es"
-    token: str = "pene"
-    publish_mqtt: bool = False
+    token: str = ""
     vad_thold: float = 0.0
-    
+
+
 class TranscriberMessage(BaseModel):
     """
     Formato de salida proveniente del Transcriptor C++.
+    Tipos posibles: "transcription", "ready", "warning", "error".
     """
-    type: str # "transcription", "error", "warning", o "ready"
+    type: str
     text: Optional[str] = None
     is_final: Optional[bool] = None
-    message: Optional[str] = None # Para errors
+    message: Optional[str] = None   # descripción legible en warning/error
+    code: Optional[str] = None      # código de error/warning: AUTH_FAILED, buffer_full, etc.
+    session_id: Optional[str] = None  # presente en el mensaje "ready"
 
 # =====================================================================
 # Orchestrator (Gateway <-> JotaOrchestrator)

--- a/src/services/bridge.py
+++ b/src/services/bridge.py
@@ -178,7 +178,10 @@ class JotaBridge:
         # Loop del Transcriptor (solo si hay audio de entrada)
         if self.transcriber:
             self.tasks.append(asyncio.create_task(
-                self.transcriber.listen_loop(on_transcription_callback=self._on_transcription)
+                self.transcriber.listen_loop(
+                    on_transcription_callback=self._on_transcription,
+                    on_warning_callback=self._on_transcriber_warning,
+                )
             ))
             self.tasks.append(asyncio.create_task(self._transcription_watchdog()))
 
@@ -239,6 +242,19 @@ class JotaBridge:
             logger.info(f"[{self.client_id}] Cliente físico desconectado.")
         except Exception as e:
             logger.error(f"[{self.client_id}] Error en input loop: {e}")
+
+    async def _on_transcriber_warning(self, code: str, message: Optional[str]):
+        """Reenvía warnings del transcriber al cliente (e.g. buffer_full)."""
+        try:
+            await self.client_ws.send_json({
+                "type": "service_status",
+                "service": "transcriber",
+                "status": "warning",
+                "code": code,
+                "message": message or code,
+            })
+        except Exception:
+            pass  # cliente desconectado
 
     async def _on_transcription(self, text: str, is_final: bool):
         """Callback dispatched by TranscriberClient on every transcription event.

--- a/src/services/transcriber_client.py
+++ b/src/services/transcriber_client.py
@@ -20,44 +20,35 @@ class TranscriberClient:
         self.client_id = client_id
         self.ws: Optional[websockets.WebSocketClientProtocol] = None
         self._is_ready = False
+        self._session_id: Optional[str] = None  # recibido en el mensaje "ready"
         self._dropped_unexpectedly: bool = False
         self._last_transcription_at: Optional[float] = None
 
     async def connect(self, language: str = "es", token: str = "", vad_thold: float = 0.0):
-        """Abre el socket y manda el Handshake inicial de config"""
+        """Abre el socket y manda el Handshake inicial de config."""
         try:
-            logger.info(f"[{self.client_id}] Conectado a Transcriber WS ({self.url})")
-
-            handshake = {
-                "type": "config",
-                "language": language,
-                "token": token,
-                "vad_thold": vad_thold,
-            }
-            logger.info(f"[{self.client_id}] Configuracion transcriber: {handshake}")
-
             self.ws = await websockets.connect(self.url)
 
-            logger.info(f"[{self.client_id}] Enviando handshake...")
-            await self.ws.send(json.dumps(handshake))
-            logger.info(f"[{self.client_id}] Handshake enviado, esperando 'ready'...")
-            # Esperamos el evento de {"type": "ready"}
+            config = TranscriberConfig(language=language, token=token, vad_thold=vad_thold)
+            logger.info(f"[{self.client_id}] Conectando a Transcriber ({self.url}) lang={language!r} vad={vad_thold}")
+            await self.ws.send(config.model_dump_json())
+
             response = await self.ws.recv()
-            try:
-                data = json.loads(response)
-                msg = TranscriberMessage(**data)
-                if msg.type == "ready":
-                    self._is_ready = True
-                    logger.info(f"[{self.client_id}] Transcriber Listo para recibir audio (VAD/Lang Confirmed).")
-                elif msg.type == "error":
-                     raise Exception(f"Transcriber error on connect: {msg.message}")
-            except Exception as e:
-                logger.error(f"[{self.client_id}] Fallo interpretando el handshake de Transcriber: {e}")
-                raise e
-                
+            data = json.loads(response)
+            msg = TranscriberMessage(**data)
+
+            if msg.type == "ready":
+                self._is_ready = True
+                self._session_id = msg.session_id
+                logger.info(f"[{self.client_id}] Transcriber listo. session_id={self._session_id!r}")
+            elif msg.type == "error":
+                raise Exception(f"Transcriber auth/config error [{msg.code}]: {msg.message}")
+            else:
+                raise Exception(f"Respuesta inesperada del transcriber en handshake: {msg.type!r}")
+
         except Exception as e:
             logger.error(f"[{self.client_id}] Error conectando a Transcriber: {e}")
-            raise e
+            raise
 
     async def send_audio(self, audio_bytes: bytes):
         """Envía ráfagas PCM crudas al transcriptor si está habilitado."""
@@ -70,10 +61,18 @@ class TranscriberClient:
             self._is_ready = False
             logger.warning(f"[{self.client_id}] Intento de enviar audio a Transcriber cerrado.")
 
-    async def listen_loop(self, on_transcription_callback: Callable[[str, bool], Awaitable[None]]):
+    async def listen_loop(
+        self,
+        on_transcription_callback: Callable[[str, bool], Awaitable[None]],
+        on_warning_callback: Optional[Callable[[str, Optional[str]], Awaitable[None]]] = None,
+    ):
         """
-        Bucle que escucha transcripciones del C++ y ejecuta el callback con (text, is_final).
-        El loop no interpreta is_final — solo reenvía lo que llega.
+        Bucle que escucha mensajes del transcriber.
+
+        Args:
+            on_transcription_callback: llamado con (text, is_final) en cada transcripción.
+            on_warning_callback: llamado con (code, message) cuando llega un warning.
+                                 Si es None, los warnings solo se loguean.
         """
         if not self.ws:
             return
@@ -86,13 +85,16 @@ class TranscriberClient:
 
                     if t_msg.type == "transcription" and t_msg.text:
                         self._last_transcription_at = time.monotonic()
-                        logger.debug(f"[{self.client_id}] Transcripción recibida: is_final={t_msg.is_final!r} text='{t_msg.text[:40]}'")
+                        logger.debug(f"[{self.client_id}] Transcripción: is_final={t_msg.is_final!r} text='{t_msg.text[:40]}'")
                         await on_transcription_callback(t_msg.text, bool(t_msg.is_final))
 
-                    elif t_msg.type == "error":
-                        logger.error(f"[{self.client_id}] Transcriber Runtime Error: {t_msg.message}")
                     elif t_msg.type == "warning":
-                        pass  # Warning de buffer full
+                        logger.warning(f"[{self.client_id}] Transcriber warning [{t_msg.code}]: {t_msg.message}")
+                        if on_warning_callback:
+                            await on_warning_callback(t_msg.code or "unknown", t_msg.message)
+
+                    elif t_msg.type == "error":
+                        logger.error(f"[{self.client_id}] Transcriber error [{t_msg.code}]: {t_msg.message}")
 
                 except json.JSONDecodeError:
                     logger.warning(f"[{self.client_id}] Transcriber mandó un non-JSON: {message}")

--- a/tests/unit/test_bridge_barge_in.py
+++ b/tests/unit/test_bridge_barge_in.py
@@ -3,7 +3,10 @@ import asyncio
 import pytest
 from unittest.mock import AsyncMock, MagicMock
 from src.services.bridge import JotaBridge
-from src.models.schemas import Handshake
+from src.models.schemas import Client, ClientConfig, Handshake
+
+_CLIENT = Client(id="test-uuid", client_key="test-key", is_active=True)
+_CONFIG = ClientConfig()
 
 
 @pytest.fixture
@@ -12,8 +15,8 @@ def make_bridge():
         if output_mode is None:
             output_mode = ["audio", "text", "status"]
         ws = AsyncMock()
-        bridge = JotaBridge(client_id="test", client_ws=ws)
-        bridge.handshake = Handshake(input_mode=input_mode, output_mode=output_mode)
+        bridge = JotaBridge(client=_CLIENT, config=_CONFIG, client_ws=ws)
+        bridge.handshake = Handshake(client_key="test-key", input_mode=input_mode, output_mode=output_mode)
         bridge.orchestrator = AsyncMock()
         bridge.orchestrator.close = AsyncMock()
         bridge.transcriber = MagicMock()
@@ -70,36 +73,38 @@ async def test_cancel_active_turn_clears_active_turn(make_bridge):
 
 # ── _on_transcription ────────────────────────────────────────────────────────
 
-async def test_partial_below_threshold_is_ignored(make_bridge):
-    """Partials shorter than BARGE_IN_MIN_CHARS (5) are silently ignored."""
+async def test_partial_below_threshold_forwarded_but_no_barge_in(make_bridge):
+    """Partials shorter than BARGE_IN_MIN_CHARS are forwarded to client but don't trigger barge-in."""
     bridge = make_bridge()
     bridge._call_orchestrator = AsyncMock()
 
     await bridge._on_transcription("hi", False)  # 2 chars
 
-    bridge.client_ws.send_json.assert_not_called()
+    bridge.client_ws.send_json.assert_called_once_with({"type": "transcription_partial", "text": "hi"})
     assert bridge._active_turn is None
 
 
-async def test_partial_above_threshold_with_no_active_turn_is_ignored(make_bridge):
-    """Partial above threshold but no active turn — no barge-in needed."""
+async def test_partial_above_threshold_with_no_active_turn_forwarded_only(make_bridge):
+    """Partial above threshold but no active turn — forwarded to client, no barge-in needed."""
     bridge = make_bridge()
 
     await bridge._on_transcription("hello world", False)
 
-    bridge.client_ws.send_json.assert_not_called()
+    bridge.client_ws.send_json.assert_called_once_with({"type": "transcription_partial", "text": "hello world"})
     assert bridge._active_turn is None
 
 
 async def test_partial_above_threshold_with_active_turn_triggers_barge_in(make_bridge):
-    """Partial above threshold with active turn → cancel + send interrupted."""
+    """Partial above threshold with active turn → forward partial + cancel + send interrupted."""
     bridge = make_bridge()
     bridge._active_turn = asyncio.create_task(asyncio.sleep(60))
     await asyncio.sleep(0)
 
     await bridge._on_transcription("hello world", False)
 
-    bridge.client_ws.send_json.assert_called_once_with({"type": "interrupted"})
+    calls = bridge.client_ws.send_json.call_args_list
+    assert calls[0][0][0] == {"type": "transcription_partial", "text": "hello world"}
+    assert calls[1][0][0] == {"type": "interrupted"}
     assert bridge._active_turn is None
 
 

--- a/tests/unit/test_bridge_disconnect.py
+++ b/tests/unit/test_bridge_disconnect.py
@@ -2,14 +2,17 @@
 import pytest
 from unittest.mock import AsyncMock, MagicMock, call
 from src.services.bridge import JotaBridge
-from src.models.schemas import Handshake
+from src.models.schemas import Client, ClientConfig, Handshake
+
+_CLIENT = Client(id="test-uuid", client_key="test-key", is_active=True)
+_CONFIG = ClientConfig()
 
 
 @pytest.fixture
 def bridge():
     ws = AsyncMock()
-    b = JotaBridge(client_id="test", client_ws=ws)
-    b.handshake = Handshake(input_mode="audio", output_mode=["text"])
+    b = JotaBridge(client=_CLIENT, config=_CONFIG, client_ws=ws)
+    b.handshake = Handshake(client_key="test-key", input_mode="audio", output_mode=["text"])
     b.transcriber = MagicMock()
     b.transcriber._is_ready = True
     return b

--- a/tests/unit/test_bridge_health_check.py
+++ b/tests/unit/test_bridge_health_check.py
@@ -2,7 +2,10 @@
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 from src.services.bridge import JotaBridge
-from src.models.schemas import Handshake
+from src.models.schemas import Client, ClientConfig, Handshake
+
+_CLIENT = Client(id="test-uuid", client_key="test-key", is_active=True)
+_CONFIG = ClientConfig()
 
 
 @pytest.fixture
@@ -12,8 +15,8 @@ def make_bridge():
         if output_mode is None:
             output_mode = ["audio", "text", "status"]
         ws = AsyncMock()
-        bridge = JotaBridge(client_id="test", client_ws=ws)
-        bridge.handshake = Handshake(input_mode=input_mode, output_mode=output_mode)
+        bridge = JotaBridge(client=_CLIENT, config=_CONFIG, client_ws=ws)
+        bridge.handshake = Handshake(client_key="test-key", input_mode=input_mode, output_mode=output_mode)
         bridge.orchestrator = AsyncMock()
         bridge.orchestrator.ping = AsyncMock(return_value=True)
         bridge.transcriber = MagicMock()

--- a/tests/unit/test_bridge_send_guards.py
+++ b/tests/unit/test_bridge_send_guards.py
@@ -2,14 +2,17 @@
 import pytest
 from unittest.mock import AsyncMock, MagicMock
 from src.services.bridge import JotaBridge
-from src.models.schemas import Handshake
+from src.models.schemas import Client, ClientConfig, Handshake
+
+_CLIENT = Client(id="test-uuid", client_key="test-key", is_active=True)
+_CONFIG = ClientConfig()
 
 
 @pytest.fixture
 def bridge():
     ws = AsyncMock()
-    b = JotaBridge(client_id="test", client_ws=ws)
-    b.handshake = Handshake(input_mode="text", output_mode=["text", "status"])
+    b = JotaBridge(client=_CLIENT, config=_CONFIG, client_ws=ws)
+    b.handshake = Handshake(client_key="test-key", input_mode="text", output_mode=["text", "status"])
     b.orchestrator = AsyncMock()
     b.transcriber = None
     return b
@@ -53,8 +56,8 @@ async def test_audio_send_failure_does_not_propagate():
     """send_bytes raising inside pipe_audio must not crash _call_orchestrator."""
     ws = AsyncMock()
     ws.send_bytes = AsyncMock(side_effect=RuntimeError("disconnected"))
-    b = JotaBridge(client_id="test", client_ws=ws)
-    b.handshake = Handshake(input_mode="audio", output_mode=["audio", "text"])
+    b = JotaBridge(client=_CLIENT, config=_CONFIG, client_ws=ws)
+    b.handshake = Handshake(client_key="test-key", input_mode="audio", output_mode=["audio", "text"])
     b.orchestrator = AsyncMock()
 
     # Orchestrator produces one token, TTS returns one audio chunk


### PR DESCRIPTION
## Resumen

Corrige 5 issues del protocolo entre el gateway y jota-transcriber, descubiertas en el análisis de arquitectura.

### Cambios

**`TranscriberMessage`** — añadidos `code` y `session_id`
- `code`: código de error/warning del servidor C++ (`AUTH_FAILED`, `buffer_full`, etc.) — antes se perdía
- `session_id`: presente en el mensaje `ready` — antes se ignoraba

**`TranscriberConfig`** — limpieza del handshake
- Eliminado `publish_mqtt` (campo muerto, el servidor C++ lo ignora)
- Token default cambiado de `"pene"` a `""`

**`TranscriberClient.connect()`** — usa `TranscriberConfig` en lugar de dict raw

**`TranscriberClient.listen_loop()`** — nuevo parámetro `on_warning_callback`
- Los warnings (`buffer_full`, etc.) ya no se descartan silenciosamente
- El `session_id` del mensaje `ready` se guarda en `self._session_id`

**`JotaBridge`** — nuevo `_on_transcriber_warning()`
- Reenvía warnings al cliente como `service_status` con `code` y `message`

**Tests de bridge** — actualizados a la nueva firma `JotaBridge(client, config, client_ws)` introducida en PR #18

## Test plan
- [ ] Handshake con jota-transcriber: `session_id` visible en logs tras conectar
- [ ] Si el buffer supera 20s: cliente recibe `{ type: "service_status", service: "transcriber", status: "warning", code: "buffer_full" }`
- [ ] Error de auth: `code` del error llega al log correctamente

Closes #9
Closes #10
Closes #11
Closes #12
Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)