### PR TITLE
feat: Fase 2 — REST API pública (config, conversations, models, health)

### DIFF
--- a/src/api/config_routes.py
+++ b/src/api/config_routes.py
@@ -1,0 +1,59 @@
+"""
+config_routes.py
+~~~~~~~~~~~~~~~~
+GET /api/config        — leer configuración del cliente
+PUT /api/config        — actualizar campos (patch parcial)
+POST /api/config/reset — restaurar defaults
+"""
+from typing import Any
+
+import httpx
+from fastapi import APIRouter, Body, Depends, HTTPException
+
+from src.api.deps import get_verified_client
+from src.models.schemas import Client, ClientConfig
+from src.services.db_client import db_client
+
+router = APIRouter()
+
+
+def _handle_db_error(e: Exception) -> None:
+    if isinstance(e, httpx.HTTPStatusError):
+        raise HTTPException(status_code=e.response.status_code)
+    if isinstance(e, httpx.RequestError):
+        raise HTTPException(status_code=503, detail="jota-db unavailable")
+    raise HTTPException(status_code=502, detail="Unexpected error")
+
+
+@router.get("/config", response_model=ClientConfig)
+async def get_config(
+    auth: tuple[Client, ClientConfig] = Depends(get_verified_client),
+) -> ClientConfig:
+    client, _ = auth
+    try:
+        return await db_client.get_config(client.id)
+    except Exception as e:
+        _handle_db_error(e)
+
+
+@router.put("/config", response_model=ClientConfig)
+async def update_config(
+    body: dict[str, Any] = Body(...),
+    auth: tuple[Client, ClientConfig] = Depends(get_verified_client),
+) -> ClientConfig:
+    client, _ = auth
+    try:
+        return await db_client.update_config(client.id, body)
+    except Exception as e:
+        _handle_db_error(e)
+
+
+@router.post("/config/reset", response_model=ClientConfig)
+async def reset_config(
+    auth: tuple[Client, ClientConfig] = Depends(get_verified_client),
+) -> ClientConfig:
+    client, _ = auth
+    try:
+        return await db_client.reset_config(client.id)
+    except Exception as e:
+        _handle_db_error(e)

--- a/src/api/conversation_routes.py
+++ b/src/api/conversation_routes.py
@@ -1,0 +1,45 @@
+"""
+conversation_routes.py
+~~~~~~~~~~~~~~~~~~~~~~
+GET /api/conversations                      — listar conversaciones
+GET /api/conversations/{id}/messages        — mensajes de una conversación
+"""
+import httpx
+from fastapi import APIRouter, Depends, HTTPException
+
+from src.api.deps import get_verified_client
+from src.models.schemas import Client, ClientConfig
+from src.services.db_client import db_client
+
+router = APIRouter()
+
+
+def _handle_db_error(e: Exception) -> None:
+    if isinstance(e, httpx.HTTPStatusError):
+        raise HTTPException(status_code=e.response.status_code)
+    if isinstance(e, httpx.RequestError):
+        raise HTTPException(status_code=503, detail="jota-db unavailable")
+    raise HTTPException(status_code=502, detail="Unexpected error")
+
+
+@router.get("/conversations")
+async def get_conversations(
+    auth: tuple[Client, ClientConfig] = Depends(get_verified_client),
+) -> list:
+    client, _ = auth
+    try:
+        return await db_client.get_conversations(client.id)
+    except Exception as e:
+        _handle_db_error(e)
+
+
+@router.get("/conversations/{conversation_id}/messages")
+async def get_messages(
+    conversation_id: str,
+    auth: tuple[Client, ClientConfig] = Depends(get_verified_client),
+) -> list:
+    client, _ = auth
+    try:
+        return await db_client.get_messages(client.id, conversation_id)
+    except Exception as e:
+        _handle_db_error(e)

--- a/src/api/deps.py
+++ b/src/api/deps.py
@@ -1,0 +1,33 @@
+"""
+deps.py
+~~~~~~~
+FastAPI dependencies compartidas por todos los routers de la REST API.
+"""
+import httpx
+from fastapi import Header, HTTPException
+
+from src.models.schemas import Client, ClientConfig
+from src.services.db_client import db_client
+
+
+async def get_verified_client(
+    x_api_key: str = Header(...),
+) -> tuple[Client, ClientConfig]:
+    """
+    Resuelve X-API-Key → (Client, ClientConfig) llamando a jota-db.
+
+    Raises:
+        HTTPException 401: key inválida o cliente inactivo.
+        HTTPException 503: jota-db no está disponible.
+        HTTPException 502: error inesperado.
+    """
+    try:
+        return await db_client.get_session(x_api_key)
+    except httpx.HTTPStatusError as e:
+        if e.response.status_code in (401, 403):
+            raise HTTPException(status_code=401, detail="Invalid or inactive API key")
+        raise HTTPException(status_code=502, detail="Unexpected error from jota-db")
+    except httpx.RequestError:
+        raise HTTPException(status_code=503, detail="jota-db unavailable")
+    except Exception:
+        raise HTTPException(status_code=502, detail="Unexpected error")

--- a/src/api/health_routes.py
+++ b/src/api/health_routes.py
@@ -1,0 +1,61 @@
+"""
+health_routes.py
+~~~~~~~~~~~~~~~~
+GET /api/health — estado de los servicios internos (sin auth, uso de operador)
+
+Siempre devuelve 200. Los valores por servicio son "ok" o "unavailable".
+"""
+import asyncio
+from fastapi import APIRouter
+
+from src.core.config import settings
+from src.services.orchestrator_client import OrchestratorClient
+from src.services.transcriber_client import TranscriberClient
+from src.services.tts_client import TTSClient
+
+router = APIRouter()
+
+
+async def _ping_orchestrator() -> str:
+    client = OrchestratorClient(
+        base_url=settings.ORCHESTRATOR_BASE_URL,
+        api_key=settings.GATEWAY_KEY,
+        client_id="gateway",
+    )
+    await client.connect()
+    try:
+        ok = await client.ping()
+        return "ok" if ok else "unavailable"
+    finally:
+        await client.close()
+
+
+async def _ping_transcriber() -> str:
+    ok = await TranscriberClient.ping(settings.TRANSCRIBER_WS_URL)
+    return "ok" if ok else "unavailable"
+
+
+async def _ping_tts() -> str:
+    ok = await TTSClient.ping(settings.TTS_WS_URL)
+    return "ok" if ok else "unavailable"
+
+
+@router.get("/health")
+async def health() -> dict:
+    results = await asyncio.gather(
+        _ping_orchestrator(),
+        _ping_transcriber(),
+        _ping_tts(),
+        return_exceptions=True,
+    )
+
+    def _resolve(r) -> str:
+        if isinstance(r, Exception):
+            return "unavailable"
+        return r
+
+    return {
+        "orchestrator": _resolve(results[0]),
+        "transcriber": _resolve(results[1]),
+        "tts": _resolve(results[2]),
+    }

--- a/src/api/models_routes.py
+++ b/src/api/models_routes.py
@@ -13,15 +13,19 @@ from src.services.db_client import db_client
 router = APIRouter()
 
 
+def _handle_db_error(e: Exception) -> None:
+    if isinstance(e, httpx.HTTPStatusError):
+        raise HTTPException(status_code=e.response.status_code)
+    if isinstance(e, httpx.RequestError):
+        raise HTTPException(status_code=503, detail="jota-db unavailable")
+    raise HTTPException(status_code=502, detail="Unexpected error")
+
+
 @router.get("/models")
 async def get_models(
     auth: tuple[Client, ClientConfig] = Depends(get_verified_client),
 ) -> list:
     try:
         return await db_client.get_models()
-    except httpx.RequestError:
-        raise HTTPException(status_code=503, detail="jota-db unavailable")
-    except httpx.HTTPStatusError as e:
-        raise HTTPException(status_code=e.response.status_code)
-    except Exception:
-        raise HTTPException(status_code=502, detail="Unexpected error")
+    except Exception as e:
+        _handle_db_error(e)

--- a/src/api/models_routes.py
+++ b/src/api/models_routes.py
@@ -1,0 +1,27 @@
+"""
+models_routes.py
+~~~~~~~~~~~~~~~~
+GET /api/models — lista de modelos disponibles (proxy a jota-db)
+"""
+import httpx
+from fastapi import APIRouter, Depends, HTTPException
+
+from src.api.deps import get_verified_client
+from src.models.schemas import Client, ClientConfig
+from src.services.db_client import db_client
+
+router = APIRouter()
+
+
+@router.get("/models")
+async def get_models(
+    auth: tuple[Client, ClientConfig] = Depends(get_verified_client),
+) -> list:
+    try:
+        return await db_client.get_models()
+    except httpx.RequestError:
+        raise HTTPException(status_code=503, detail="jota-db unavailable")
+    except httpx.HTTPStatusError as e:
+        raise HTTPException(status_code=e.response.status_code)
+    except Exception:
+        raise HTTPException(status_code=502, detail="Unexpected error")

--- a/src/main.py
+++ b/src/main.py
@@ -1,10 +1,14 @@
 import logging
 from contextlib import asynccontextmanager
 from fastapi import FastAPI
+
 from src.api.routes import router as stream_router
+from src.api.config_routes import router as config_router
+from src.api.conversation_routes import router as conversation_router
+from src.api.models_routes import router as models_router
+from src.api.health_routes import router as health_router
 from src.services.db_client import db_client
 
-# Configuración Base de Logs para el Gateway
 logging.basicConfig(
     level=logging.INFO,
     format="%(asctime)s | %(name)s | %(levelname)s | %(message)s"
@@ -22,12 +26,18 @@ async def lifespan(app: FastAPI):
 app = FastAPI(
     title="JotaGateway (BFF)",
     description="Backend For Frontend - Enrutador principal de WebSockets. Titiritero del Ecosistema IA.",
-    version="1.0.0",
+    version="2.0.0",
     lifespan=lifespan,
 )
 
-# Incluir routers
+# WebSocket
 app.include_router(stream_router)
+
+# REST API
+app.include_router(config_router, prefix="/api")
+app.include_router(conversation_router, prefix="/api")
+app.include_router(models_router, prefix="/api")
+app.include_router(health_router, prefix="/api")
 
 
 @app.get("/health")
@@ -40,5 +50,4 @@ def healthcheck():
 
 if __name__ == "__main__":
     import uvicorn
-    # Punto de entrada para tests rápidos, normalmente se levanta por Docker uvicorn directo.
     uvicorn.run(app, host="0.0.0.0", port=8004)


### PR DESCRIPTION
## Summary

Re-abre el trabajo de #26 (que se mergeó en la rama base equivocada). Aplica los mismos commits sobre `main` actualizado.

- Add `src/api/deps.py` — `get_verified_client`: resuelve `X-API-Key` → `(Client, ClientConfig)` via jota-db; mapea errores a 401/503/502
- Add `src/api/config_routes.py` — `GET/PUT /api/config`, `POST /api/config/reset`
- Add `src/api/conversation_routes.py` — `GET /api/conversations`, `GET /api/conversations/{id}/messages`
- Add `src/api/models_routes.py` — `GET /api/models`
- Add `src/api/health_routes.py` — `GET /api/health` (sin auth, pings paralelos a orchestrator/transcriber/TTS)
- Wire 4 routers en `src/main.py` bajo prefijo `/api`

## Depends on

#25 ya mergeado en main.

Closes #1

## Test plan

- [ ] `GET /api/health` → 200 siempre con `{"orchestrator":..., "transcriber":..., "tts":...}`
- [ ] `GET /api/config` con `X-API-Key` válida → ClientConfig
- [ ] `PUT /api/config` con body parcial → ClientConfig actualizado
- [ ] `POST /api/config/reset` → ClientConfig default
- [ ] `GET /api/conversations` → lista de conversaciones
- [ ] `GET /api/conversations/{id}/messages` → lista de mensajes
- [ ] `GET /api/models` → lista de modelos
- [ ] `X-API-Key` inválida → 401; jota-db caído → 503

🤖 Generated with [Claude Code](https://claude.com/claude-code)