### PR TITLE
feat: in-memory TTL cache for get_session() and get_models()

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ pydantic>=2.0.0
 pydantic-settings>=2.0.0
 python-multipart>=0.0.6
 httpx>=0.24.0
+cachetools>=5.0.0

--- a/src/core/cache.py
+++ b/src/core/cache.py
@@ -1,0 +1,29 @@
+import asyncio
+from cachetools import TTLCache
+
+
+def make_cache(maxsize: int, ttl: int) -> tuple[TTLCache, asyncio.Lock]:
+    """
+    Crea un par (cache, lock) listo para usar en métodos async.
+
+    Args:
+        maxsize: Número máximo de entradas. Las más antiguas se expulsan (LRU) al superarse.
+        ttl:     Segundos hasta que una entrada expira automáticamente.
+
+    Returns:
+        (TTLCache, asyncio.Lock) — el lock debe envolver SOLO el acceso al dict,
+        nunca el IO, para no bloquear el event loop.
+
+    Example::
+
+        _cache, _lock = make_cache(maxsize=500, ttl=60)
+
+        async with _lock:
+            if key in _cache:
+                return _cache[key]
+        result = await fetch(key)          # IO fuera del lock
+        async with _lock:
+            _cache[key] = result
+        return result
+    """
+    return TTLCache(maxsize=maxsize, ttl=ttl), asyncio.Lock()

--- a/src/services/db_client.py
+++ b/src/services/db_client.py
@@ -138,10 +138,18 @@ class DbClient:
     # ------------------------------------------------------------------
 
     async def get_models(self) -> list:
+        """Lista de modelos disponibles. Resultado cacheado 300s."""
         assert self._http
+        _MODELS_KEY = "models"
+        async with self._models_lock:
+            if _MODELS_KEY in self._models_cache:
+                return self._models_cache[_MODELS_KEY]
         r = await self._http.get(f"{self.base_url}/models")
         r.raise_for_status()
-        return r.json()
+        result = r.json()
+        async with self._models_lock:
+            self._models_cache[_MODELS_KEY] = result
+        return result
 
 
 # Singleton — importar este objeto directamente

--- a/src/services/db_client.py
+++ b/src/services/db_client.py
@@ -16,6 +16,8 @@ from src.models.schemas import Client, ClientConfig, SessionResponse
 
 logger = logging.getLogger(__name__)
 
+_MODELS_KEY = "models"
+
 
 class DbClient:
     """
@@ -140,7 +142,6 @@ class DbClient:
     async def get_models(self) -> list:
         """Lista de modelos disponibles. Resultado cacheado 300s."""
         assert self._http
-        _MODELS_KEY = "models"
         async with self._models_lock:
             if _MODELS_KEY in self._models_cache:
                 return self._models_cache[_MODELS_KEY]

--- a/src/services/db_client.py
+++ b/src/services/db_client.py
@@ -11,6 +11,7 @@ import logging
 from typing import Optional
 import httpx
 
+from src.core.cache import make_cache
 from src.models.schemas import Client, ClientConfig, SessionResponse
 
 logger = logging.getLogger(__name__)
@@ -28,6 +29,8 @@ class DbClient:
         self.base_url = f"http://{base_url.rstrip('/')}"
         self._api_key = api_key
         self._http: Optional[httpx.AsyncClient] = None
+        self._session_cache, self._session_lock = make_cache(maxsize=500, ttl=60)
+        self._models_cache, self._models_lock = make_cache(maxsize=1, ttl=300)
 
     # ------------------------------------------------------------------
     # Lifecycle
@@ -52,19 +55,32 @@ class DbClient:
     async def get_session(self, client_key: str) -> tuple[Client, ClientConfig]:
         """
         Llama a GET /auth/session en jota-db para resolver client_key → Client + ClientConfig.
+        Resultado cacheado 60s. Invalidación explícita en 401/403.
 
         Raises:
             httpx.HTTPStatusError: 401/403 si la key no es válida o el cliente está inactivo.
             httpx.RequestError:    Si jota-db no está disponible.
         """
         assert self._http, "DbClient no está conectado. Llama a connect() primero."
-        response = await self._http.get(
-            f"{self.base_url}/auth/session",
-            headers={"X-API-Key": client_key},
-        )
-        response.raise_for_status()
+        async with self._session_lock:
+            if client_key in self._session_cache:
+                return self._session_cache[client_key]
+        try:
+            response = await self._http.get(
+                f"{self.base_url}/auth/session",
+                headers={"X-API-Key": client_key},
+            )
+            response.raise_for_status()
+        except httpx.HTTPStatusError as e:
+            if e.response.status_code in (401, 403):
+                async with self._session_lock:
+                    self._session_cache.pop(client_key, None)
+            raise
         data = SessionResponse.model_validate(response.json())
-        return data.client, data.config
+        result = (data.client, data.config)
+        async with self._session_lock:
+            self._session_cache[client_key] = result
+        return result
 
     # ------------------------------------------------------------------
     # Configuración (usado en la REST API — Fase 2)


### PR DESCRIPTION
## Summary

- Add `cachetools>=5.0.0` dependency (lightweight, zero transitive deps)
- New `src/core/cache.py` — `make_cache(maxsize, ttl)` utility; reusable by any future service
- `DbClient.get_session()` — cache-aside with 60s TTL, maxsize 500; explicit invalidation on 401/403
- `DbClient.get_models()` — cache-aside with 300s TTL, maxsize 1

## Impact

- Reduces round-trips to jota-db for every REST request and WS handshake
- If jota-db goes down, clients validated in the last 60s can still connect and make requests (partial resilience)
- Docker image rebuild required on next deploy (new `pip install` layer due to `cachetools`)
- Cache lives in process memory — resets on restart/redeploy (correct behavior)

## Limitations

- Resiliency window is fixed at 60s — no stale-while-unavailable beyond that
- Not distributed — each gateway instance has its own cache (acceptable for current single-process deployment)

Closes #23
Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)