### PR TITLE
fix(gateway): orchestrator not reached due to TTS failure and premature session teardown

### DIFF
--- a/.github/TASKS.md
+++ b/.github/TASKS.md
@@ -1,19 +1,34 @@
 # TASKS — jota-gateway
 
-Estado actual del proyecto y trabajo pendiente. Actualizado: 2026-04-04.
+Estado actual del proyecto y trabajo pendiente. Actualizado: 2026-04-07.
 
 ---
 
-## Estado actual: v1.4.0
+## Estado actual: v1.6.0
 
 El gateway está completo en su fase BFF (Backend-For-Frontend). Expone:
 
 - **WebSocket** `/ws/stream` — sesión bidireccional con transcriber + orchestrator + TTS
 - **REST API** `/api/*` — endpoints para config, historial, modelos y health
 
+### Protocolo de voz (desde v1.6.0)
+
+El flujo de audio ahora es **review & send**: la transcripción final no se envía automáticamente al orquestador. El cliente la muestra al usuario, que puede editarla, y la confirma con `{"type":"send","text":"..."}`.
+
+```
+cliente → <PCM audio>               # frames de audio
+gateway → transcription_partial     # parciales en tiempo real (opcional)
+cliente → {"type":"end"}            # fin de grabación
+gateway → {"type":"transcription"}  # transcripción final — cliente la muestra
+cliente → {"type":"send","text":"..."} # usuario confirma (puede editar)
+gateway → token, token, ...         # respuesta del orquestador
+```
+
+Ver [`docs/client-protocol.md`](../docs/client-protocol.md) para la guía completa.
+
 ---
 
-## Arquitectura (v1.4.0)
+## Arquitectura (v1.6.0)
 
 ```
 ESP32 / Web Client
@@ -68,6 +83,9 @@ El lock envuelve solo el acceso al dict, nunca la llamada IO.
 | v1.2.1  | Fix: header `x-client-id` enviado al orchestrator                          |
 | v1.3.0  | Cache TTL en `get_session()` y `get_models()` (cierra #22, #23)            |
 | v1.4.0  | `DELETE /api/conversations/{id}` — archiva conversación (cierra #24)       |
+| v1.5.0  | Fase 3: propagar ClientConfig a TTS, Orchestrator y barge-in               |
+| v1.5.1  | Fix CI: ruff + PYTHONPATH en pytest                                        |
+| v1.6.0  | Fix pipeline de voz: TTS no bloquea, protocolo review & send (cierra #36)  |
 
 ---
 
@@ -81,6 +99,7 @@ El lock envuelve solo el acceso al dict, nunca la llamada IO.
 | #22   | Resiliencia jota-db — caché ante caídas breves               |
 | #23   | Reducir latencia de sesión con caché de `get_session()`       |
 | #24   | `DELETE /api/conversations/{id}` — archivar conversación      |
+| #36   | Fix pipeline de voz + protocolo review & send                 |
 
 ---
 

--- a/docs/client-protocol.md
+++ b/docs/client-protocol.md
@@ -87,13 +87,49 @@ Envía **frames binarios** de audio crudo en formato:
 | Sample rate | 16000 Hz |
 | Canales | 1 (mono) |
 
-Puedes enviar frames de cualquier tamaño. El transcriptor detecta automáticamente los finales de frase (VAD) y cuando obtiene una transcripción final:
+### Flujo de voz — review & send
 
-1. El gateway te envía una confirmación:
-   ```json
-   {"type": "transcription", "text": "lo que dijiste"}
-   ```
-2. El texto se envía automáticamente al orquestador — no necesitas hacer nada más.
+> **Cambio importante desde v1.6.0:** la transcripción final ya **no se envía automáticamente al orquestador**. El cliente debe confirmarla explícitamente con `{"type": "send"}`. Esto permite que el usuario revise y corrija errores antes de procesar.
+
+```
+1. El cliente envía frames de audio PCM:
+   → <PCM Float32 bytes>
+   → <PCM Float32 bytes>
+
+2. Llegan parciales opcionales mientras el transcriptor procesa:
+   ← {"type": "transcription_partial", "text": "hola mun..."}
+
+3. El cliente señaliza fin de audio:
+   → {"type": "end"}
+
+4. El transcriptor entrega la transcripción final — el cliente la muestra al usuario:
+   ← {"type": "transcription", "text": "hola mundo"}
+
+5. El usuario revisa/edita el texto. El cliente confirma enviando:
+   → {"type": "send", "text": "hola mundo"}
+      (puede ser diferente al original si el usuario lo corrigió)
+
+6. El gateway lo envía al orquestador y llegan los tokens:
+   ← {"type": "token", "content": "Hola, ¿en qué puedo ayudarte?"}
+```
+
+### Señal de fin de audio
+
+Enviar `{"type": "end"}` es la forma de indicar al transcriptor que el usuario terminó de hablar y debe emitir la transcripción final. Úsalo cuando:
+
+- El usuario suelta el botón de micrófono
+- Detectas silencio prolongado en el cliente
+- El VAD del cliente decide que la frase ha terminado
+
+### Barge-in (interrumpir respuesta en curso)
+
+Si el usuario empieza a hablar mientras llegan tokens del orquestador, el gateway detecta el nuevo audio y cancela el turno activo. Recibirás:
+
+```json
+{"type": "interrupted"}
+```
+
+Tras esto el flujo reinicia desde el paso 1 — sigue enviando audio normalmente.
 
 ---
 
@@ -129,6 +165,8 @@ async for msg in ws:
         elif data["type"] == "end":
             on_response_complete(buffer)
             buffer = ""
+        elif data["type"] == "transcription":
+            show_editable_transcription(data["text"])  # usuario puede editar
         elif data["type"] == "error":
             show_error(data["content"])
 ```
@@ -140,6 +178,8 @@ async for msg in ws:
 Requiere `"audio"` en `output_mode`.
 
 Cuando el orquestador genera tokens, el gateway los envía en paralelo al TTS. El audio llega como **frames binarios** intercalados con mensajes JSON de control.
+
+> Si el servicio TTS no está disponible, el gateway continúa en modo texto — los tokens llegan igualmente, solo sin audio.
 
 ### Flujo de mensajes por segmento sintetizado
 
@@ -175,29 +215,16 @@ async for msg in ws:
         data = json.loads(msg)
         match data["type"]:
             case "audio_start":
-                # Opcional: preparar buffer para nuevo chunk
-                pass
+                pass  # opcional: preparar buffer para nuevo chunk
             case "audio_end":
-                # Opcional: marcar fin de frase para sincronización
-                pass
+                pass  # opcional: marcar fin de frase para sincronización
             case "end":
-                # Respuesta completa
                 audio_player.flush()
+            case "transcription":
+                show_editable_transcription(data["text"])
             case "error":
                 handle_error(data["content"])
-            case "transcription":
-                show_transcription(data["text"])
 ```
-
-### Interrumpir audio (barge-in)
-
-Si el usuario empieza a hablar mientras el TTS está sonando:
-
-1. Para la reproducción en el cliente.
-2. Cierra la conexión WebSocket con código **1000**.
-3. Abre una nueva conexión con un nuevo handshake.
-
-La reconexión en LAN es típicamente < 100 ms.
 
 ---
 
@@ -211,6 +238,22 @@ El orquestador emite eventos de estado internos durante el procesamiento (p.ej. 
 {"type": "status", "content": "Buscando en base de datos..."}
 ```
 
+### Estado de microservicios (`service_status`)
+
+El gateway notifica degradaciones en los servicios internos:
+
+```json
+{"type": "service_status", "service": "tts", "status": "unavailable", "message": "..."}
+```
+
+| `service` | `status` | Impacto |
+|---|---|---|
+| `orchestrator` | `unavailable` | **Fatal** — la sesión se cierra, no hay respuesta posible |
+| `transcriber` | `unavailable` | Degradado — sin transcripción, el cliente puede seguir en modo texto |
+| `tts` | `unavailable` | Degradado — sin audio, los tokens de texto siguen llegando |
+
+> Ante un `service_status` con `status: "unavailable"`, solo cierra la sesión si el servicio es `orchestrator`. Para `transcriber` y `tts` la sesión continúa en modo degradado.
+
 ### Errores (siempre enviados)
 
 Los errores llegan independientemente de `output_mode`:
@@ -221,7 +264,7 @@ Los errores llegan independientemente de `output_mode`:
 
 | Origen | Cuándo ocurre |
 |---|---|
-| Gateway | JSON inválido, `text` vacío, fallo al conectar a microservicios |
+| Gateway | JSON inválido, fallo al conectar a microservicios |
 | Orquestador | Error HTTP, timeout, fallo interno del modelo |
 | TTS | `session_timeout`, `queue_full` (el audio de esa respuesta se pierde) |
 
@@ -245,7 +288,7 @@ Cliente                         Gateway
    │◄── {"type":"end"} ─────────│
 ```
 
-### Asistente de voz completo
+### Asistente de voz con review & send
 
 ```
 Cliente                         Gateway
@@ -257,8 +300,13 @@ Cliente                         Gateway
    │                            │
    │── <PCM Float32 mic> ──────►│──► Transcriber
    │── <PCM Float32 mic> ──────►│
+   │◄── {"type":"transcription_partial","text":"¿qué tiem..."} │
+   │── {"type":"end"} ──────────►│   (usuario suelta el mic)
    │◄── {"type":"transcription","text":"¿qué tiempo hace?"} │
-   │                            │──► Orchestrator (streaming tokens)
+   │                            │   (usuario revisa, opcionalmente edita)
+   │── {"type":"send",          │
+   │    "text":"¿qué tiempo     │
+   │           hace?"} ────────►│──► Orchestrator (streaming tokens)
    │                            │──► jota-speaker TTS (tokens en paralelo)
    │◄── {"type":"token","content":"Hoy"} ────────│
    │◄── {"type":"audio_start","chunk_id":0} ─────│
@@ -280,18 +328,23 @@ Cliente                         Gateway
 | Mensaje | Formato | Cuándo |
 |---|---|---|
 | Handshake | `{"input_mode":"...", "output_mode":[...]}` | Primer mensaje, obligatorio |
-| Texto | `{"text":"...", "model_id":"..."}` | Enviar prompt, `model_id` opcional |
+| Fin de audio | `{"type":"end"}` | `input_mode="audio"` — usuario termina de hablar |
+| Confirmar y enviar | `{"type":"send","text":"..."}` | Tras recibir `transcription` — lanza la respuesta del orquestador |
+| Texto directo | `{"text":"...", "model_id":"..."}` | `input_mode="text"` — prompt directo, `model_id` opcional |
 | Audio mic | frame binario PCM Float32 16kHz | `input_mode="audio"` |
 
 ### Gateway → Cliente
 
 | Tipo | Formato | Condición |
 |---|---|---|
-| `token` | `{"type":"token","content":"..."}` | `"text"` en `output_mode` |
+| `transcription_partial` | `{"type":"transcription_partial","text":"..."}` | `input_mode="audio"`, parciales en tiempo real |
+| `transcription` | `{"type":"transcription","text":"..."}` | `input_mode="audio"`, transcripción final — esperar `send` |
+| `token` | `{"type":"token","content":"..."}` | `"text"` en `output_mode` — tras recibir `send` |
 | `end` | `{"type":"end"}` | `"text"` en `output_mode`, fin de respuesta |
-| `transcription` | `{"type":"transcription","text":"..."}` | `input_mode="audio"` |
+| `interrupted` | `{"type":"interrupted"}` | Barge-in confirmado — turno anterior cancelado |
 | `audio_start` | `{"type":"audio_start","chunk_id":N}` | `"audio"` en `output_mode` |
 | audio frame | frame binario PCM16 24kHz | `"audio"` en `output_mode` |
 | `audio_end` | `{"type":"audio_end","chunk_id":N}` | `"audio"` en `output_mode` |
 | `status` | `{"type":"status","content":"..."}` | `"status"` en `output_mode` |
+| `service_status` | `{"type":"service_status","service":"...","status":"...","message":"..."}` | Siempre — degradación de microservicio |
 | `error` | `{"type":"error","content":"..."}` | Siempre |

--- a/src/services/bridge.py
+++ b/src/services/bridge.py
@@ -62,14 +62,17 @@ class JotaBridge:
         await asyncio.gather(*connect_tasks)
 
     async def close_all(self):
-        # Cancel and await the active turn first so TTS finally-blocks run before
-        # orchestrator/transcriber clients are closed.
+        # Await (don't cancel) the active turn so the orchestrator response is
+        # delivered before we tear down microservice clients.  Explicit cancellation
+        # only happens via _cancel_active_turn() (barge-in) or task cancellation
+        # from outside; close_all() itself should let the turn finish naturally.
         if self._active_turn and not self._active_turn.done():
-            self._active_turn.cancel()
             try:
                 await self._active_turn
-            except (asyncio.CancelledError, Exception):
+            except asyncio.CancelledError:
                 pass
+            except Exception as e:
+                logger.error(f"[{self.client_id}] _active_turn falló: {e}")
 
         for task in self.tasks:
             if not task.done():
@@ -187,18 +190,19 @@ class JotaBridge:
             ))
             self.tasks.append(asyncio.create_task(self._transcription_watchdog()))
 
+        # El ciclo de vida de la sesión lo marca _client_input_loop.
+        # listen_loop y watchdog corren en background y terminan solos sin cerrar la sesión.
+        client_task = self.tasks[0]  # siempre el primero (ver arriba)
         try:
-            done, pending = await asyncio.wait(self.tasks, return_when=asyncio.FIRST_COMPLETED)
-            for task in done:
-                try:
-                    task.result()
-                except asyncio.CancelledError:
-                    pass
-                except Exception as e:
-                    logger.error(f"[{self.client_id}] Loop crasheó: {e}")
-
+            await client_task
+        except asyncio.CancelledError:
+            pass
+        except Exception as e:
+            logger.error(f"[{self.client_id}] client_input_loop crasheó: {e}")
+        finally:
             # Notificar al cliente si el transcriptor cayó inesperadamente
-            if self.transcriber and self.transcriber._dropped_unexpectedly:
+            # (no notificar si ya recibimos una transcripción final — el cierre es esperado)
+            if self.transcriber and self.transcriber._dropped_unexpectedly and not self._last_final_text:
                 try:
                     await self.client_ws.send_json({
                         "type": "service_status",
@@ -208,7 +212,6 @@ class JotaBridge:
                     })
                 except Exception:
                     pass
-        finally:
             await self.close_all()
 
     async def _client_input_loop(self):
@@ -240,7 +243,16 @@ class JotaBridge:
                         # Cliente terminó de hablar → señalizar fin al transcriber
                         if self.handshake.input_mode == "audio" and self.transcriber:
                             await self.transcriber.send_end()
-                    elif self.orchestrator:
+
+                    elif json_msg and json_msg.get("type") == "send":
+                        # Cliente confirma/edita la transcripción y la envía al orquestador
+                        text = json_msg.get("text", "").strip()
+                        if text and self.orchestrator:
+                            logger.info(f"[{self.client_id}] send recibido: '{text[:60]}'")
+                            self._active_turn = asyncio.create_task(self._call_orchestrator(text))
+
+                    elif json_msg is None and self.handshake.input_mode == "text":
+                        # Texto plano en modo texto — compatibilidad con clientes de texto puro
                         await self._call_orchestrator(text_data)
 
         except WebSocketDisconnect:
@@ -291,14 +303,14 @@ class JotaBridge:
             return
         self._last_final_text = text
 
-        # Final: cancel any running turn, notify client, start new turn
+        # Final: cancel any running turn, notify client.
+        # El orquestador se llama cuando el cliente envíe {"type": "send", "text": "..."}.
         await self._cancel_active_turn()
         logger.info(f"[{self.client_id}] Transcripción final: '{text}'")
         try:
             await self.client_ws.send_json({"type": "transcription", "text": text})
-        except Exception:
-            return  # client disconnected — no point starting a new turn
-        self._active_turn = asyncio.create_task(self._call_orchestrator(text))
+        except Exception as e:
+            logger.warning(f"[{self.client_id}] send_json(transcription) falló: {e}")
 
     async def _call_orchestrator(self, text: str):
         """
@@ -316,10 +328,14 @@ class JotaBridge:
                 token=settings.TTS_TOKEN,
                 client_id=self.client_id,
             )
-            await tts.connect(
-                voice=self.config.tts_voice,
-                speed=self.config.tts_speed,
-            )
+            try:
+                await tts.connect(
+                    voice=self.config.tts_voice,
+                    speed=self.config.tts_speed,
+                )
+            except Exception as e:
+                logger.warning(f"[{self.client_id}] TTS no disponible, continuando en modo texto: {e}")
+                tts = None
 
         async def _on_token(token_text: str):
             try:

--- a/src/services/transcriber_client.py
+++ b/src/services/transcriber_client.py
@@ -98,11 +98,12 @@ class TranscriberClient:
 
                 except json.JSONDecodeError:
                     logger.warning(f"[{self.client_id}] Transcriber mandó un non-JSON: {message}")
-        except ConnectionClosed:
-            if self._is_ready:
+        except ConnectionClosed as e:
+            clean_close = e.rcvd is not None and e.rcvd.code == 1000
+            if self._is_ready and not clean_close:
                 self._dropped_unexpectedly = True
             self._is_ready = False
-            logger.info(f"[{self.client_id}] Loop de escucha del Transcriber finalizado.")
+            logger.info(f"[{self.client_id}] Loop de escucha del Transcriber finalizado (code={e.rcvd.code if e.rcvd else 'none'}).")
 
     async def send_end(self):
         """Señaliza al transcriber que el audio terminó, disparando la transcripción final."""

--- a/tests/integration/test_bridge_audio_flow.py
+++ b/tests/integration/test_bridge_audio_flow.py
@@ -90,7 +90,8 @@ def start_fake_transcriber():
 
 
 def test_audio_chunk_transcribed_and_forwarded_to_orchestrator(mock_services):
-    """PCM → transcriber fake emite is_final → orchestrator llamado con el texto."""
+    """PCM → transcriber fake emite is_final → cliente recibe transcripción
+    → cliente envía {"type":"send"} → orchestrator llamado con el texto."""
     called_with_text = {}
 
     def capture(req):
@@ -107,7 +108,16 @@ def test_audio_chunk_transcribed_and_forwarded_to_orchestrator(mock_services):
         with client.websocket_connect("/ws/stream") as ws:
             ws.send_json(HANDSHAKE_AUDIO)
             ws.send_bytes(b"\x00" * 512)  # PCM fake
-            # Esperar token (pueden llegar mensajes intermedios)
+            # Esperar transcripción final (nuevo protocolo: gateway no auto-despacha)
+            for _ in range(10):
+                msg = ws.receive_json()
+                if msg.get("type") == "transcription":
+                    break
+            assert msg["type"] == "transcription"
+            assert msg["text"] == "hola desde audio"
+            # Cliente confirma y envía al orquestador
+            ws.send_json({"type": "send", "text": msg["text"]})
+            # Esperar token del orquestador
             for _ in range(10):
                 msg = ws.receive_json()
                 if msg.get("type") == "token":

--- a/tests/unit/test_bridge_barge_in.py
+++ b/tests/unit/test_bridge_barge_in.py
@@ -133,25 +133,20 @@ async def test_final_sends_transcription_to_client(make_bridge):
     )
 
 
-async def test_final_starts_new_active_turn(make_bridge):
-    """Final transcription starts a new _active_turn task."""
+async def test_final_does_not_start_active_turn(make_bridge):
+    """Final transcription no longer auto-dispatches to orchestrator.
+    _active_turn stays None — client must send {"type":"send"} explicitly."""
     bridge = make_bridge()
     bridge._call_orchestrator = AsyncMock()
 
     await bridge._on_transcription("hola", True)
     await asyncio.sleep(0)
 
-    assert bridge._active_turn is not None
-    # cleanup
-    bridge._active_turn.cancel()
-    try:
-        await bridge._active_turn
-    except (asyncio.CancelledError, Exception):
-        pass
+    assert bridge._active_turn is None
 
 
 async def test_final_cancels_previous_active_turn(make_bridge):
-    """Final transcription cancels any in-progress turn before starting a new one."""
+    """Final transcription cancels any in-progress turn but does NOT start a new one."""
     bridge = make_bridge()
     bridge._call_orchestrator = AsyncMock()
     old_turn = asyncio.create_task(asyncio.sleep(60))
@@ -162,13 +157,7 @@ async def test_final_cancels_previous_active_turn(make_bridge):
     await asyncio.sleep(0)
 
     assert old_turn.cancelled()
-    assert bridge._active_turn is not None
-    assert bridge._active_turn is not old_turn
-    bridge._active_turn.cancel()
-    try:
-        await bridge._active_turn
-    except (asyncio.CancelledError, Exception):
-        pass
+    assert bridge._active_turn is None
 
 
 async def test_final_with_disconnected_client_does_not_start_turn(make_bridge):
@@ -195,26 +184,22 @@ async def test_barge_in_interrupted_send_failure_is_silent(make_bridge):
 
 # ── close_all ────────────────────────────────────────────────────────────────
 
-async def test_close_all_cancels_and_awaits_active_turn(make_bridge):
-    """close_all() cancels _active_turn and waits for cleanup (e.g. tts.close())
-    to complete before closing other clients."""
+async def test_close_all_awaits_active_turn(make_bridge):
+    """close_all() awaits _active_turn to completion (does not cancel it),
+    so the orchestrator response is delivered before tearing down clients."""
     bridge = make_bridge()
 
-    cleanup_ran = asyncio.Event()
+    turn_ran = asyncio.Event()
 
     async def mock_turn():
-        try:
-            await asyncio.sleep(60)
-        except asyncio.CancelledError:
-            cleanup_ran.set()
-            raise
+        turn_ran.set()
 
     bridge._active_turn = asyncio.create_task(mock_turn())
     await asyncio.sleep(0)
 
     await bridge.close_all()
 
-    assert cleanup_ran.is_set()
+    assert turn_ran.is_set()
 
 
 async def test_barge_in_uses_config_threshold_not_global(make_bridge):


### PR DESCRIPTION
## ⚠️ Breaking change — protocolo WebSocket de voz

Desde esta PR, la transcripción final **no se envía automáticamente al orquestador**. El cliente debe confirmarla explícitamente con \`{"type":"send","text":"..."}\`.

Ver \`docs/client-protocol.md\` para la guía completa actualizada.

---

## Contexto

Durante el debugging del pipeline de voz se identificaron dos problemas distintos:

1. **Bug crítico:** el orquestador nunca recibía las peticiones (TTS caído bloqueaba silenciosamente toda la cadena)
2. **Rediseño de protocolo:** se aprovechó el fix para desacoplar transcripción de respuesta, permitiendo al usuario revisar/editar antes de enviar

---

## Nuevo protocolo de voz

\`\`\`
Antes (automático):
  PCM audio → transcripción final → orquestador (inmediato)

Ahora (review & send):
  PCM audio → {"type":"end"} → transcripción final
            → usuario revisa/edita
            → {"type":"send","text":"..."} → orquestador
\`\`\`

| Mensaje nuevo | Dirección | Cuándo |
|---|---|---|
| \`{"type":"end"}\` | cliente→gateway | usuario termina de grabar |
| \`{"type":"send","text":"..."}\` | cliente→gateway | usuario confirma la transcripción |
| \`{"type":"transcription_partial","text":"..."}\` | gateway→cliente | parciales en tiempo real |

---

## Fixes incluidos

**\`src/services/bridge.py\`**
- \`_call_orchestrator\`: TTS no disponible → fallback texto-solo con WARNING, nunca excepción
- \`close_all()\`: awaita \`_active_turn\` en lugar de cancelarlo — entrega la respuesta antes del teardown; loguea errores
- \`run()\`: ciclo de vida de sesión marcado por \`_client_input_loop\` (desconexión del cliente), no por \`listen_loop\` del transcriber
- \`_on_transcription\`: final notifica al cliente pero no despacha al orquestador
- \`_client_input_loop\`: nuevo handler para \`{"type":"send"}\`

**\`src/services/transcriber_client.py\`**
- Cierre limpio (código 1000) post-transcripción ya no marca \`_dropped_unexpectedly\`

**\`tests/unit/test_bridge_barge_in.py\`**
- Tests actualizados para reflejar el nuevo protocolo

**\`docs/client-protocol.md\`**
- Protocolo reescrito: flujo review & send, diagramas actualizados, referencia completa

**\`.github/TASKS.md\`**
- Arquitectura y historial de releases actualizados a v1.6.0

---

## Cliente

Implementación del lado cliente trackeada en SitoSt/jota-float#3.