### PR TITLE
fix: add session_key to OrchestratorProtocol and propagate through stack

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,12 @@
 fastapi>=0.136.1
-uvicorn>=0.23.0
+uvicorn>=0.46.0
 websockets>=11.0.3
-pydantic>=2.0.0
+pydantic>=2.13.3
 pydantic-settings>=2.0.0
 python-multipart>=0.0.6
 httpx>=0.24.0
 cachetools>=5.0.0
 pytest>=8.0.0,<9.1.0
 pytest-asyncio>=1.3.0,<1.4.0
-respx>=0.21.0
+respx>=0.23.1
 ruff>=0.4.0

--- a/src/services/orchestrators/protocol.py
+++ b/src/services/orchestrators/protocol.py
@@ -20,4 +20,5 @@ class OrchestratorProtocol(Protocol):
         user_id: str,
         model_id: Optional[str] = None,
         system_prompt_extra: Optional[str] = None,
+        session_key: Optional[str] = None,
     ) -> AsyncIterator[OrchestratorEvent]: ...

--- a/src/services/orchestrators/reconnecting.py
+++ b/src/services/orchestrators/reconnecting.py
@@ -75,6 +75,7 @@ class ReconnectingOrchestrator:
         user_id: str,
         model_id: Optional[str] = None,
         system_prompt_extra: Optional[str] = None,
+        session_key: Optional[str] = None,
     ) -> AsyncIterator[OrchestratorEvent]:
         if self._state != OrchestratorState.CONNECTED:
             if self._state == OrchestratorState.DEGRADED:
@@ -87,6 +88,7 @@ class ReconnectingOrchestrator:
             user_id=user_id,
             model_id=model_id,
             system_prompt_extra=system_prompt_extra,
+            session_key=session_key,
         ):
             yield event
 

--- a/tests/integration/test_bridge_audio_flow.py
+++ b/tests/integration/test_bridge_audio_flow.py
@@ -100,7 +100,7 @@ def test_audio_chunk_transcribed_and_forwarded_to_orchestrator(mock_services, mo
     called_with_text = {}
     mock_orch = make_mock_orchestrator()
 
-    async def _stream(text, user_id, model_id=None, system_prompt_extra=None):
+    async def _stream(text, user_id, model_id=None, system_prompt_extra=None, session_key=None):
         called_with_text["text"] = text
         yield OrchestratorEvent(type="token", content="ok")
         yield OrchestratorEvent(type="status", content="done")


### PR DESCRIPTION
## Summary

- `OrchestratorProtocol.stream_response` was missing the `session_key` parameter that `OpenClawClient.stream_response` already accepted
- `ReconnectingOrchestrator.stream_response` likewise didn't accept or forward `session_key`
- `test_bridge_audio_flow.py` inline mock didn't accept `session_key`, causing `TypeError` → silent deadlock (bridge waits for client, client waits for bridge)
- Bumps `uvicorn>=0.46.0`, `pydantic>=2.13.3`, `respx>=0.23.1` lower bounds (closes dependabot PRs #40, #41, #42)

## Root Cause

`call_orchestrator()` (added in #53) passes `session_key=` as a keyword argument, but the protocol and the reconnecting wrapper didn't declare it. Any mock matching the protocol signature would raise `TypeError`, which `pipe_tokens()` only catches as `RuntimeError` — leaving the test hung in a deadlock waiting for a token that was never sent.

## Test plan

- [ ] `PYTHONPATH=. pytest` → 149 passed
- [ ] Docker build with `python:3.14-slim` succeeds (all packages install, image builds)
- [ ] PRs #40, #41, #42, #43 closed with explanation
- [ ] PRs #44, #45 merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)