### PR TITLE
fix: remove spurious session_key from OpenClawClient constructor in registry

### DIFF
--- a/src/services/orchestrators/registry.py
+++ b/src/services/orchestrators/registry.py
@@ -61,7 +61,7 @@ def build_registry() -> OrchestratorRegistry:
             host="127.0.0.1",
             port=settings.OPENCLAW_PORT,
             token=settings.OPENCLAW_TOKEN,
-            session_key=settings.OPENCLAW_SESSION_KEY,
+            default_agent=settings.OPENCLAW_DEFAULT_AGENT,
         )
         clients["openclaw"] = ReconnectingOrchestrator(inner, name="openclaw")
         logger.info("OpenClawClient registered (wrapped in ReconnectingOrchestrator).")


### PR DESCRIPTION
## Summary

- `build_registry()` was passing `session_key=settings.OPENCLAW_SESSION_KEY` to `OpenClawClient.__init__`
- `OPENCLAW_SESSION_KEY` doesn't exist in `Settings` → `AttributeError` on app startup
- `session_key` is not a constructor parameter — it's per-turn, passed via `stream_response()`
- Replaced with the correct `default_agent=settings.OPENCLAW_DEFAULT_AGENT`

## Root cause

Bug introduced during the WS/HTTP coherence refactor (#53). The `session_key` concept was added as a per-turn parameter but was mistakenly also wired into the constructor call in `build_registry`.

## Test plan

- [ ] `PYTHONPATH=. pytest` → 149 passed
- [ ] `docker compose up` starts without `AttributeError`

🤖 Generated with [Claude Code](https://claude.com/claude-code)