### PR TITLE
fix: don't crash on startup if orchestrator is unreachable

### DIFF
--- a/src/services/orchestrators/registry.py
+++ b/src/services/orchestrators/registry.py
@@ -18,8 +18,8 @@ class OrchestratorRegistry:
                 await client.connect()
                 logger.info(f"Orchestrator '{name}' connected.")
             except Exception as e:
-                logger.error(f"Orchestrator '{name}' failed to connect: {e}")
-                raise
+                logger.error(f"Orchestrator '{name}' failed to connect: {e} — starting background retry")
+                await client.trigger_reconnect()
 
     async def close_all(self) -> None:
         for name, client in self._clients.items():


### PR DESCRIPTION
## Summary

- `connect_all()` was re-raising on connect failure, crashing the app if OpenClaw is down at startup
- Now catches the error, logs it, and calls `trigger_reconnect()` — entering RECONNECTING state with exponential backoff
- App starts normally; sessions that hit the orchestrator receive an `orchestrator_unavailable` error event (existing behavior); auto-heals when OpenClaw comes back up
- Same recovery path as a mid-session disconnect — no new logic needed

## Test plan

- [ ] `PYTHONPATH=. pytest` → 149 passed
- [ ] `docker compose up` with OpenClaw unavailable → app starts, logs "starting background retry", no crash
- [ ] When OpenClaw comes up → gateway reconnects automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)