### PR TITLE
fix: use gateway-client id in OpenClaw connect handshake

### DIFF
--- a/src/services/orchestrators/openclaw_client.py
+++ b/src/services/orchestrators/openclaw_client.py
@@ -67,7 +67,7 @@ class OpenClawClient:
                 "minProtocol": 3,
                 "maxProtocol": 4,
                 "client": {
-                    "id": "jota-gateway",
+                    "id": "gateway-client",
                     "version": "1.0.0",
                     "platform": "linux",
                     "mode": "backend",


### PR DESCRIPTION
## Summary

- OpenClaw only accepts `"gateway-client"` as a valid `client/id` in the connect handshake
- `"jota-gateway"` was introduced by mistake during the SDD refactor (#53) — reverts the regression

## Test plan

- [ ] `PYTHONPATH=. pytest` → 149 passed
- [ ] `docker compose up` → OpenClaw connects successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)