### PR TITLE
refactor: isolate OpenClaw wire-format frames into frames.py + fix silent error logging

### DIFF
--- a/src/services/bridge.py
+++ b/src/services/bridge.py
@@ -417,6 +417,7 @@ class JotaBridge:
                     on_token=_on_token,
                 )
             except RuntimeError as e:
+                logger.error(f"[{self.client_id}] Orchestrator error: {e}")
                 try:
                     await self.client_ws.send_json({
                         "type": "error",

--- a/src/services/openclaw/client.py
+++ b/src/services/openclaw/client.py
@@ -7,6 +7,7 @@ from typing import AsyncIterator, Callable, Optional
 import websockets
 from websockets.asyncio.client import ClientConnection
 
+from src.services.openclaw import frames
 from src.services.openclaw.dispatcher import FrameDispatcher
 from src.services.openclaw.models import GatewayInfo
 from src.services.openclaw.registry import TurnRegistry
@@ -52,19 +53,7 @@ class OpenClawClient:
             raise RuntimeError(f"Expected connect.challenge, got: {frame}")
 
         req_id = str(uuid.uuid4())
-        await self._ws.send(json.dumps({
-            "type": "req", "id": req_id, "method": "connect",
-            "params": {
-                "minProtocol": 3, "maxProtocol": 4,
-                "client": {
-                    "id": "gateway-client", "version": "1.0.0",
-                    "platform": "linux", "mode": "backend",
-                },
-                "role": "operator",
-                "scopes": ["operator.read", "operator.write"],
-                "auth": {"token": self._token},
-            },
-        }))
+        await self._ws.send(json.dumps(frames.connect_backend(req_id, self._token)))
 
         raw = await asyncio.wait_for(self._ws.recv(), timeout=30.0)
         hello = json.loads(raw)
@@ -73,9 +62,7 @@ class OpenClawClient:
         self.gateway_info = GatewayInfo.from_hello_ok(hello.get("payload", {}))
 
         sub_id = str(uuid.uuid4())
-        await self._ws.send(json.dumps({
-            "type": "req", "id": sub_id, "method": "sessions.subscribe", "params": {},
-        }))
+        await self._ws.send(json.dumps(frames.sessions_subscribe(sub_id)))
 
         # Consume the subscribe ack synchronously before starting _listen.
         # If we skipped this, the ack would flow into _listen → dispatcher, which
@@ -113,9 +100,7 @@ class OpenClawClient:
             loop = asyncio.get_running_loop()
             fut: asyncio.Future = loop.create_future()
             self._health_futures[req_id] = fut
-            await self._ws.send(json.dumps({
-                "type": "req", "id": req_id, "method": "health", "params": {},
-            }))
+            await self._ws.send(json.dumps(frames.health(req_id)))
             res = await asyncio.wait_for(fut, timeout=5.0)
             return res.get("ok", False)
         except Exception as e:
@@ -144,14 +129,9 @@ class OpenClawClient:
 
         try:
             try:
-                await self._ws.send(json.dumps({
-                    "type": "req", "id": req_id, "method": "chat.send",
-                    "params": {
-                        "sessionKey": session_key,
-                        "message": text,
-                        "idempotencyKey": str(uuid.uuid4()),
-                    },
-                }))
+                await self._ws.send(json.dumps(
+                    frames.chat_send(req_id, session_key, text, str(uuid.uuid4()))
+                ))
                 _sent = True
             except Exception as e:
                 yield OrchestratorEvent(type="error", content=f"send failed: {e}")
@@ -179,11 +159,9 @@ class OpenClawClient:
             self._turn_registry.unregister(session_key, req_id)
             if _sent and not _finished and self._ws:
                 try:
-                    await asyncio.shield(self._ws.send(json.dumps({
-                        "type": "req", "id": str(uuid.uuid4()),
-                        "method": "chat.abort",
-                        "params": {"sessionKey": session_key},
-                    })))
+                    await asyncio.shield(self._ws.send(json.dumps(
+                        frames.chat_abort(str(uuid.uuid4()), session_key)
+                    )))
                 except Exception:
                     pass
 

--- a/src/services/openclaw/client.py
+++ b/src/services/openclaw/client.py
@@ -157,7 +157,7 @@ class OpenClawClient:
                     break
         finally:
             self._turn_registry.unregister(session_key, req_id)
-            if _sent and not _finished and self._ws:
+            if _sent and self._ws:
                 try:
                     await asyncio.shield(self._ws.send(json.dumps(
                         frames.chat_abort(str(uuid.uuid4()), session_key)

--- a/src/services/openclaw/client.py
+++ b/src/services/openclaw/client.py
@@ -157,7 +157,7 @@ class OpenClawClient:
                     break
         finally:
             self._turn_registry.unregister(session_key, req_id)
-            if _sent and self._ws:
+            if _sent and not _finished and self._ws:
                 try:
                     await asyncio.shield(self._ws.send(json.dumps(
                         frames.chat_abort(str(uuid.uuid4()), session_key)

--- a/src/services/openclaw/frames.py
+++ b/src/services/openclaw/frames.py
@@ -1,0 +1,88 @@
+def _req(method: str, req_id: str, params: dict) -> dict:
+    return {"type": "req", "id": req_id, "method": method, "params": params}
+
+
+# ── Conexión ──────────────────────────────────────────────────────
+
+def connect_backend(req_id: str, token: str, client_id: str = "gateway-client") -> dict:
+    return _req("connect", req_id, {
+        "minProtocol": 3,
+        "maxProtocol": 4,
+        "client": {
+            "id": client_id,
+            "version": "1.0.0",
+            "platform": "linux",
+            "mode": "backend",
+        },
+        "role": "operator",
+        "scopes": ["operator.read", "operator.write"],
+        "auth": {"token": token},
+    })
+
+
+def sessions_subscribe(req_id: str) -> dict:
+    return _req("sessions.subscribe", req_id, {})
+
+
+def health(req_id: str) -> dict:
+    return _req("health", req_id, {})
+
+
+# ── Chat ──────────────────────────────────────────────────────────
+
+def chat_send(req_id: str, session_key: str, message: str, idempotency_key: str) -> dict:
+    return _req("chat.send", req_id, {
+        "sessionKey": session_key,
+        "message": message,
+        "idempotencyKey": idempotency_key,
+    })
+
+
+def chat_abort(req_id: str, session_key: str) -> dict:
+    return _req("chat.abort", req_id, {"sessionKey": session_key})
+
+
+def chat_history(req_id: str, session_key: str, limit: int = 50, offset: int = 0) -> dict:
+    return _req("chat.history", req_id, {
+        "sessionKey": session_key,
+        "limit": limit,
+        "offset": offset,
+    })
+
+
+def chat_inject(req_id: str, session_key: str, content: str) -> dict:
+    return _req("chat.inject", req_id, {
+        "sessionKey": session_key,
+        "content": content,
+    })
+
+
+# ── Sessions ──────────────────────────────────────────────────────
+
+def sessions_steer(req_id: str, session_key: str, steer_text: str) -> dict:
+    return _req("sessions.steer", req_id, {
+        "key": session_key,
+        "steerText": steer_text,
+    })
+
+
+def sessions_list(req_id: str) -> dict:
+    return _req("sessions.list", req_id, {})
+
+
+# ── Agentes y modelos ─────────────────────────────────────────────
+
+def agents_list(req_id: str) -> dict:
+    return _req("agents.list", req_id, {})
+
+
+def agent_identity_get(req_id: str, agent_id: str) -> dict:
+    return _req("agent.identity.get", req_id, {"agentId": agent_id})
+
+
+def models_list(req_id: str, view: str = "configured") -> dict:
+    return _req("models.list", req_id, {"view": view})
+
+
+def models_auth_status(req_id: str) -> dict:
+    return _req("models.authStatus", req_id, {})

--- a/tests/integration/test_openclaw_client.py
+++ b/tests/integration/test_openclaw_client.py
@@ -271,7 +271,7 @@ async def test_chat_abort_frame_schema(fake_ws):
     # Create a fake WS with delays so cancellation races an in-flight response (not a completed one).
     slow_fake_ws = SmartFakeWS(
         {"agent:main:client-a": ["Hola ", "mundo"]},
-        chat_response_delay=0.03  # 30ms delay between responses
+        chat_response_delay=0.15  # 150ms delay between responses
     )
     client = await connected_client(slow_fake_ws)
 
@@ -282,7 +282,7 @@ async def test_chat_abort_frame_schema(fake_ws):
             pass
 
     task = asyncio.create_task(consume())
-    await asyncio.sleep(0.02)  # let first chunk queue before cancel
+    await asyncio.sleep(0.01)  # let first chunk queue before cancel
     task.cancel()
     try:
         await task

--- a/tests/integration/test_openclaw_client.py
+++ b/tests/integration/test_openclaw_client.py
@@ -243,3 +243,45 @@ async def test_on_disconnect_called_on_ws_drop(fake_ws):
     await fake_ws.close()
     await asyncio.sleep(0.05)
     assert disconnected == [True]
+
+
+@pytest.mark.asyncio
+async def test_connect_frame_schema(fake_ws):
+    """connect frame must carry protocol range, auth token, and operator role."""
+    client = await connected_client(fake_ws)
+    connect_frames = [f for f in fake_ws.sent_frames if f.get("method") == "connect"]
+    assert len(connect_frames) == 1
+    p = connect_frames[0]["params"]
+    assert p["minProtocol"] == 3
+    assert p["maxProtocol"] == 4
+    assert p["role"] == "operator"
+    assert "token" in p["auth"]
+    assert p["client"]["mode"] == "backend"
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_chat_abort_frame_schema(fake_ws):
+    """chat.abort sent on task cancellation must use flat sessionKey, not nested session.key."""
+    client = await connected_client(fake_ws)
+
+    async def consume():
+        async for _ in client.stream_response(
+            "hola", "client-a", session_key="agent:main:client-a"
+        ):
+            pass
+
+    task = asyncio.create_task(consume())
+    await asyncio.sleep(0.01)
+    task.cancel()
+    try:
+        await task
+    except asyncio.CancelledError:
+        pass
+    await asyncio.sleep(0.05)  # let shield-wrapped abort send complete
+
+    aborts = [f for f in fake_ws.sent_frames if f.get("method") == "chat.abort"]
+    assert len(aborts) >= 1
+    assert "sessionKey" in aborts[0]["params"]
+    assert "session" not in aborts[0]["params"]
+    await client.close()

--- a/tests/integration/test_openclaw_client.py
+++ b/tests/integration/test_openclaw_client.py
@@ -32,8 +32,9 @@ class SmartFakeWS:
     chat_responses: {sessionKey → [list of deltaText strings]}
     """
 
-    def __init__(self, chat_responses: Optional[dict] = None):
+    def __init__(self, chat_responses: Optional[dict] = None, chat_response_delay: float = 0.0):
         self.chat_responses: dict[str, list[str]] = chat_responses or {}
+        self.chat_response_delay: float = chat_response_delay  # delay between chunks (in seconds)
         self._to_client: asyncio.Queue = asyncio.Queue()
         self._from_client: asyncio.Queue = asyncio.Queue()
         self.sent_frames: list[dict] = []
@@ -110,6 +111,8 @@ class SmartFakeWS:
                     "type": "res", "id": req_id, "ok": True,
                     "payload": {"runId": run_id, "status": "started"},
                 }))
+                if self.chat_response_delay > 0:
+                    await asyncio.sleep(self.chat_response_delay)
                 for i, chunk in enumerate(chunks):
                     await self._to_client.put(json.dumps({
                         "type": "event", "event": "chat",
@@ -118,6 +121,8 @@ class SmartFakeWS:
                             "seq": i + 1, "state": "delta", "deltaText": chunk,
                         },
                     }))
+                    if self.chat_response_delay > 0:
+                        await asyncio.sleep(self.chat_response_delay)
                 await self._to_client.put(json.dumps({
                     "type": "res", "id": req_id, "ok": True,
                     "payload": {"status": "done", "runId": run_id},
@@ -263,7 +268,12 @@ async def test_connect_frame_schema(fake_ws):
 @pytest.mark.asyncio
 async def test_chat_abort_frame_schema(fake_ws):
     """chat.abort sent on task cancellation must use flat sessionKey, not nested session.key."""
-    client = await connected_client(fake_ws)
+    # Create a fake WS with delays so cancellation races an in-flight response (not a completed one).
+    slow_fake_ws = SmartFakeWS(
+        {"agent:main:client-a": ["Hola ", "mundo"]},
+        chat_response_delay=0.03  # 30ms delay between responses
+    )
+    client = await connected_client(slow_fake_ws)
 
     async def consume():
         async for _ in client.stream_response(
@@ -272,7 +282,7 @@ async def test_chat_abort_frame_schema(fake_ws):
             pass
 
     task = asyncio.create_task(consume())
-    await asyncio.sleep(0.01)
+    await asyncio.sleep(0.02)  # let first chunk queue before cancel
     task.cancel()
     try:
         await task
@@ -280,7 +290,7 @@ async def test_chat_abort_frame_schema(fake_ws):
         pass
     await asyncio.sleep(0.05)  # let shield-wrapped abort send complete
 
-    aborts = [f for f in fake_ws.sent_frames if f.get("method") == "chat.abort"]
+    aborts = [f for f in slow_fake_ws.sent_frames if f.get("method") == "chat.abort"]
     assert len(aborts) >= 1
     assert "sessionKey" in aborts[0]["params"]
     assert "session" not in aborts[0]["params"]

--- a/tests/unit/test_openclaw_frames.py
+++ b/tests/unit/test_openclaw_frames.py
@@ -1,0 +1,204 @@
+from src.services.openclaw import frames
+
+
+# ── Shape ─────────────────────────────────────────────────────────
+
+def test_every_frame_is_req_type():
+    for fn, args in [
+        (frames.connect_backend, ("r", "tok")),
+        (frames.sessions_subscribe, ("r",)),
+        (frames.health, ("r",)),
+        (frames.chat_send, ("r", "sk", "msg", "idem")),
+        (frames.chat_abort, ("r", "sk")),
+        (frames.chat_history, ("r", "sk")),
+        (frames.chat_inject, ("r", "sk", "ctx")),
+        (frames.sessions_steer, ("r", "sk", "txt")),
+        (frames.sessions_list, ("r",)),
+        (frames.agents_list, ("r",)),
+        (frames.agent_identity_get, ("r", "aid")),
+        (frames.models_list, ("r",)),
+        (frames.models_auth_status, ("r",)),
+    ]:
+        f = fn(*args)
+        assert f["type"] == "req", f"{fn.__name__} must have type=req"
+        assert f["id"] == "r", f"{fn.__name__} must echo req_id"
+        assert isinstance(f["params"], dict), f"{fn.__name__} params must be dict"
+
+
+# ── connect_backend ───────────────────────────────────────────────
+
+def test_connect_backend_method():
+    frame = frames.connect_backend("r1", "secret")
+    assert frame["method"] == "connect"
+
+
+def test_connect_backend_protocol_range():
+    p = frames.connect_backend("r1", "secret")["params"]
+    assert p["minProtocol"] == 3
+    assert p["maxProtocol"] == 4
+
+
+def test_connect_backend_token_in_auth():
+    p = frames.connect_backend("r1", "my-token")["params"]
+    assert p["auth"]["token"] == "my-token"
+
+
+def test_connect_backend_default_client_id():
+    p = frames.connect_backend("r1", "tok")["params"]
+    assert p["client"]["id"] == "gateway-client"
+
+
+def test_connect_backend_custom_client_id():
+    p = frames.connect_backend("r1", "tok", client_id="custom")["params"]
+    assert p["client"]["id"] == "custom"
+
+
+def test_connect_backend_operator_role():
+    p = frames.connect_backend("r1", "tok")["params"]
+    assert p["role"] == "operator"
+    assert "operator.read" in p["scopes"]
+    assert "operator.write" in p["scopes"]
+
+
+# ── sessions_subscribe ────────────────────────────────────────────
+
+def test_sessions_subscribe_method():
+    assert frames.sessions_subscribe("r1")["method"] == "sessions.subscribe"
+
+
+def test_sessions_subscribe_empty_params():
+    assert frames.sessions_subscribe("r1")["params"] == {}
+
+
+# ── health ────────────────────────────────────────────────────────
+
+def test_health_method():
+    assert frames.health("r1")["method"] == "health"
+
+
+def test_health_empty_params():
+    assert frames.health("r1")["params"] == {}
+
+
+# ── chat_send ─────────────────────────────────────────────────────
+
+def test_chat_send_method():
+    assert frames.chat_send("r", "sk", "msg", "idem")["method"] == "chat.send"
+
+
+def test_chat_send_uses_sessionkey_not_session():
+    """Regression: OpenClaw v2026.6.10 renamed session.key → sessionKey (flat)."""
+    p = frames.chat_send("r", "agent:main:hab_sito", "hola", "idem")["params"]
+    assert p["sessionKey"] == "agent:main:hab_sito"
+    assert "session" not in p
+
+
+def test_chat_send_message_and_idempotency_key():
+    p = frames.chat_send("r", "sk", "hello world", "unique-idem")["params"]
+    assert p["message"] == "hello world"
+    assert p["idempotencyKey"] == "unique-idem"
+
+
+# ── chat_abort ────────────────────────────────────────────────────
+
+def test_chat_abort_method():
+    assert frames.chat_abort("r", "sk")["method"] == "chat.abort"
+
+
+def test_chat_abort_uses_sessionkey_not_session():
+    """Regression: same rename as chat.send — both were broken in the 2026-07-01 incident."""
+    p = frames.chat_abort("r", "agent:main:hab_sito")["params"]
+    assert p["sessionKey"] == "agent:main:hab_sito"
+    assert "session" not in p
+
+
+# ── chat_history ──────────────────────────────────────────────────
+
+def test_chat_history_method():
+    assert frames.chat_history("r", "sk")["method"] == "chat.history"
+
+
+def test_chat_history_defaults():
+    p = frames.chat_history("r", "sk")["params"]
+    assert p["limit"] == 50
+    assert p["offset"] == 0
+
+
+def test_chat_history_custom_pagination():
+    p = frames.chat_history("r", "sk", limit=10, offset=20)["params"]
+    assert p["limit"] == 10
+    assert p["offset"] == 20
+
+
+# ── chat_inject ───────────────────────────────────────────────────
+
+def test_chat_inject_method():
+    assert frames.chat_inject("r", "sk", "ctx")["method"] == "chat.inject"
+
+
+def test_chat_inject_content():
+    p = frames.chat_inject("r", "agent:main:hab_sito", "estado del hogar")["params"]
+    assert p["sessionKey"] == "agent:main:hab_sito"
+    assert p["content"] == "estado del hogar"
+
+
+# ── sessions_steer ────────────────────────────────────────────────
+
+def test_sessions_steer_method():
+    assert frames.sessions_steer("r", "sk", "txt")["method"] == "sessions.steer"
+
+
+def test_sessions_steer_params():
+    p = frames.sessions_steer("r", "agent:main:hab_sito", "nueva dirección")["params"]
+    assert p["key"] == "agent:main:hab_sito"
+    assert p["steerText"] == "nueva dirección"
+
+
+# ── sessions_list ─────────────────────────────────────────────────
+
+def test_sessions_list_method():
+    assert frames.sessions_list("r")["method"] == "sessions.list"
+
+
+# ── agents_list ───────────────────────────────────────────────────
+
+def test_agents_list_method():
+    assert frames.agents_list("r")["method"] == "agents.list"
+
+
+def test_agents_list_empty_params():
+    assert frames.agents_list("r")["params"] == {}
+
+
+# ── agent_identity_get ────────────────────────────────────────────
+
+def test_agent_identity_get_method():
+    assert frames.agent_identity_get("r", "main")["method"] == "agent.identity.get"
+
+
+def test_agent_identity_get_param():
+    assert frames.agent_identity_get("r", "assistant")["params"]["agentId"] == "assistant"
+
+
+# ── models_list ───────────────────────────────────────────────────
+
+def test_models_list_method():
+    assert frames.models_list("r")["method"] == "models.list"
+
+
+def test_models_list_default_view():
+    assert frames.models_list("r")["params"]["view"] == "configured"
+
+
+def test_models_list_custom_view():
+    assert frames.models_list("r", view="all")["params"]["view"] == "all"
+
+
+# ── models_auth_status ────────────────────────────────────────────
+
+def test_models_auth_status_method():
+    assert frames.models_auth_status("r")["method"] == "models.authStatus"
+
+
+def test_models_auth_status_empty_params():
+    assert frames.models_auth_status("r")["params"] == {}


### PR DESCRIPTION
## Summary
- Isolate all OpenClaw wire-format JSON construction into a new `src/services/openclaw/frames.py` module (pure functions, no state, no `src.*` imports) with a full regression-test suite pinning exact field names — protects against silent breakage on future protocol renames (e.g. the `session.key` → `sessionKey` rename from the 2026-07-01 incident).
- Migrate `src/services/openclaw/client.py`'s 5 inline JSON-dict call sites to use `frames.*` — pure refactor, no behavior change.
- Fix a missing `logger.error()` in `bridge.py`'s `pipe_tokens()` that made OpenClaw protocol errors invisible in production logs during the 2026-07-01 incident.
- Add 2 integration tests pinning the exact schema of frames `client.py` sends over the wire (connect frame, chat.abort frame).

No related GitHub issue — this work originates from an internal incident/design doc, not a filed issue.

## Test plan
- [x] `PYTHONPATH=. pytest` — 257 passed, 0 failed (222 baseline + 33 new unit tests + 2 new integration tests)
- [x] Each task individually reviewed by a fresh subagent (spec compliance + code quality) — all approved
- [x] Final whole-branch review — Ready to merge: Yes (only cosmetic Minor notes, no fixes needed)
- [x] `client.py`'s `chat.abort` guard verified behavior-identical to baseline after a mid-implementation detour was caught and reverted (see commit history)

🤖 Generated with [Claude Code](https://claude.com/claude-code)