### PR TITLE
fix: turn-completion detection + surface OpenClaw tool calls (opt-in)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,6 +95,7 @@ SQLModel table (`__tablename__ = "clients"`) with the following columns:
 | `silence_timeout_s` | `float` | `2.0` | Seconds of no transcription before a silence event |
 | `max_silence_turns` | `int` | `3` | Consecutive silence events before session is closed |
 | `push_enabled` | `bool` | `True` | Whether agent-initiated push turns are accepted |
+| `tool_calls_enabled` | `bool` | `False` | Whether `tool_call` WS messages are sent for this client (opt-in) |
 | `system_prompt_extra` | `str?` | `None` | Appended to the system prompt for all turns |
 
 ### `src/db/database.py`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -198,6 +198,12 @@ The singleton `db_client = DbClient()` is imported from this module everywhere. 
 - **`{"type":"send","text":"..."}`** → `_call_orchestrator(text)` — creates a fresh `TTSClient` per turn, runs `pipe_tokens` + `pipe_audio` concurrently via `asyncio.gather`
 - **Barge-in**: partial transcriptions with `len >= config.barge_in_min_chars` cancel the active orchestrator turn via `_cancel_active_turn()`, which cancels the Python task and causes `OpenClawClient` to send `chat.abort` to OpenClaw. Controlled per-client by `barge_in_enabled` and `barge_in_min_chars`.
 - **Agent-initiated push**: OpenClaw sends `agent` events with `phase: "start"/"end"` and interleaved `chat` events. `FrameDispatcher` routes these to the bridge via `ClientRegistry`. `on_push_turn_start` checks `config.push_enabled` — if `False`, the push is silently dropped. Otherwise creates a TTS client, pipes audio, and sends `turn_start`/`turn_end` to the client.
+- **Tool calls**: when the agent invokes a tool during a turn, OpenClaw emits a `session.tool`
+  event (`phase: "start"` with `args`, then `phase: "result"` with `result`/`isError` — the
+  intermediate `phase: "update"` streaming partials are dropped). If the client's
+  `tool_calls_enabled` config flag is `True` (default `False`), the gateway forwards each as
+  `{"type": "tool_call", "turn_id", "phase", "name", "tool_call_id", "args", "result",
+  "is_error"}` over the WS — for both regular turns and agent-initiated push turns.
 
 ### Silence watchdog
 

--- a/src/api/admin_routes.py
+++ b/src/api/admin_routes.py
@@ -77,6 +77,7 @@ def create_client(
         silence_timeout_s=body.silence_timeout_s,
         max_silence_turns=body.max_silence_turns,
         push_enabled=body.push_enabled,
+        tool_calls_enabled=body.tool_calls_enabled,
         system_prompt_extra=body.system_prompt_extra,
     )
     session.add(record)

--- a/src/db/models.py
+++ b/src/db/models.py
@@ -32,6 +32,7 @@ class ClientRecord(SQLModel, table=True):
     silence_timeout_s: float = Field(default=2.0)
     max_silence_turns: int = Field(default=3)
     push_enabled: bool = Field(default=True)
+    tool_calls_enabled: bool = Field(default=False)
 
     # Personalización
     system_prompt_extra: Optional[str] = Field(default=None)

--- a/src/models/admin_schemas.py
+++ b/src/models/admin_schemas.py
@@ -32,6 +32,7 @@ class ClientCreate(BaseModel):
     silence_timeout_s: float = 2.0
     max_silence_turns: int = 3
     push_enabled: bool = True
+    tool_calls_enabled: bool = False
     # Personalización
     system_prompt_extra: Optional[str] = None
 
@@ -53,6 +54,7 @@ class ClientUpdate(BaseModel):
     silence_timeout_s: Optional[float] = None
     max_silence_turns: Optional[int] = None
     push_enabled: Optional[bool] = None
+    tool_calls_enabled: Optional[bool] = None
     system_prompt_extra: Optional[str] = None
 
 
@@ -76,6 +78,7 @@ class ClientResponse(BaseModel):
     silence_timeout_s: float
     max_silence_turns: int
     push_enabled: bool
+    tool_calls_enabled: bool
     # Personalización
     system_prompt_extra: Optional[str]
 
@@ -100,5 +103,6 @@ class ClientResponse(BaseModel):
             silence_timeout_s=r.silence_timeout_s,
             max_silence_turns=r.max_silence_turns,
             push_enabled=r.push_enabled,
+            tool_calls_enabled=r.tool_calls_enabled,
             system_prompt_extra=r.system_prompt_extra,
         )

--- a/src/models/schemas.py
+++ b/src/models/schemas.py
@@ -27,6 +27,7 @@ class ClientConfig(BaseModel):
     silence_timeout_s: float = 2.0
     max_silence_turns: int = 3
     push_enabled: bool = True
+    tool_calls_enabled: bool = False
 
     model_config = ConfigDict(extra="allow")
 

--- a/src/services/bridge.py
+++ b/src/services/bridge.py
@@ -8,12 +8,26 @@ from fastapi import WebSocket, WebSocketDisconnect
 from src.core.config import settings
 from src.models.schemas import Client, ClientConfig, Handshake
 from src.services.protocol import OrchestratorProtocol
+from src.services.openclaw.models import ToolCallEvent
 from src.services.pipeline_tracker import PipelineTracker
 from src.services.transcriber_client import TranscriberClient
 from src.services.tts_client import TTSClient
 from src.services.openclaw.registry import ClientRegistry
 
 logger = logging.getLogger(__name__)
+
+
+def _tool_call_message(turn_id: Optional[str], tool_call: ToolCallEvent) -> dict:
+    return {
+        "type": "tool_call",
+        "turn_id": turn_id,
+        "phase": tool_call.phase,
+        "name": tool_call.name,
+        "tool_call_id": tool_call.tool_call_id,
+        "args": tool_call.args,
+        "result": tool_call.result,
+        "is_error": tool_call.is_error,
+    }
 
 class JotaBridge:
     """
@@ -408,6 +422,14 @@ class JotaBridge:
             if tts:
                 await tts.send_text_chunk(token_text)
 
+        async def _on_tool_call(tool_call: ToolCallEvent):
+            if not self.config.tool_calls_enabled:
+                return
+            try:
+                await self.client_ws.send_json(_tool_call_message(turn_id, tool_call))
+            except Exception:
+                pass
+
         async def pipe_tokens():
             try:
                 await call_orchestrator(
@@ -415,6 +437,7 @@ class JotaBridge:
                     system_prompt_extra=self.config.system_prompt_extra,
                     tracker=self.tracker,
                     on_token=_on_token,
+                    on_tool_call=_on_tool_call,
                 )
             except RuntimeError as e:
                 logger.error(f"[{self.client_id}] Orchestrator error: {e}")
@@ -511,6 +534,17 @@ class JotaBridge:
                 pass
         if self._push_tts:
             await self._push_tts.send_text_chunk(delta)
+
+    async def deliver_push_tool_call(self, data: dict) -> None:
+        if not self.config.tool_calls_enabled:
+            return
+        tool_call = ToolCallEvent.from_session_tool_payload(data)
+        if tool_call is None:
+            return
+        try:
+            await self.client_ws.send_json(_tool_call_message(self._push_turn_id, tool_call))
+        except Exception:
+            pass
 
     async def on_push_turn_end(self, session_key: str) -> None:
         if self._push_tts:

--- a/src/services/db_client.py
+++ b/src/services/db_client.py
@@ -75,6 +75,7 @@ class DbClient:
             silence_timeout_s=record.silence_timeout_s,
             max_silence_turns=record.max_silence_turns,
             push_enabled=record.push_enabled,
+            tool_calls_enabled=record.tool_calls_enabled,
         )
         result = (client, config)
         async with self._session_lock:

--- a/src/services/openclaw/client.py
+++ b/src/services/openclaw/client.py
@@ -9,7 +9,7 @@ from websockets.asyncio.client import ClientConnection
 
 from src.services.openclaw import frames
 from src.services.openclaw.dispatcher import FrameDispatcher
-from src.services.openclaw.models import GatewayInfo
+from src.services.openclaw.models import GatewayInfo, ToolCallEvent
 from src.services.openclaw.registry import TurnRegistry
 from src.services.protocol import OrchestratorEvent
 
@@ -148,6 +148,10 @@ class OpenClawClient:
                         yield OrchestratorEvent(type="status", content="done")
                         _finished = True
                         break
+                elif kind == "tool":
+                    tool_call = ToolCallEvent.from_session_tool_payload(data)
+                    if tool_call is not None:
+                        yield OrchestratorEvent(type="tool_call", tool_call=tool_call)
                 elif kind == "done":
                     if not data.get("ok"):
                         yield OrchestratorEvent(type="error", content=str(data.get("error", {})))

--- a/src/services/openclaw/client.py
+++ b/src/services/openclaw/client.py
@@ -144,6 +144,10 @@ class OpenClawClient:
                     delta = data.get("deltaText", "")
                     if delta:
                         yield OrchestratorEvent(type="token", content=delta)
+                    if data.get("state") == "final":
+                        yield OrchestratorEvent(type="status", content="done")
+                        _finished = True
+                        break
                 elif kind == "done":
                     if not data.get("ok"):
                         yield OrchestratorEvent(type="error", content=str(data.get("error", {})))

--- a/src/services/openclaw/dispatcher.py
+++ b/src/services/openclaw/dispatcher.py
@@ -36,6 +36,8 @@ class FrameDispatcher:
             await self._handle_chat(payload)
         elif event == "agent":
             await self._handle_agent_lifecycle(payload)
+        elif event == "session.tool":
+            await self._handle_session_tool(payload)
 
     async def _handle_chat(self, payload: dict) -> None:
         sk = payload.get("sessionKey")
@@ -63,3 +65,19 @@ class FrameDispatcher:
             await bridge.on_push_turn_start(sk)
         elif phase == "end":
             await bridge.on_push_turn_end(sk)
+
+    async def _handle_session_tool(self, payload: dict) -> None:
+        sk = payload.get("sessionKey")
+        if sk is None:
+            return
+        data = payload.get("data", {})
+        if data.get("phase") not in ("start", "result"):
+            return
+        q = self._turns.get_queue_by_session(sk)
+        if q is not None:
+            await q.put(("tool", data))
+            return
+        client_id = client_id_from_session_key(sk)
+        bridge = self._clients.get(client_id)
+        if bridge is not None:
+            await bridge.deliver_push_tool_call(data)

--- a/src/services/openclaw/models.py
+++ b/src/services/openclaw/models.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from typing import Literal, Optional
 
 
 @dataclass
@@ -50,4 +51,62 @@ class GatewayInfo:
             agents=agents,
             tick_interval_ms=policy.get("tickIntervalMs", 15000),
             max_payload=policy.get("maxPayload", 26214400),
+        )
+
+
+def _flatten_tool_result_content(content: Optional[list]) -> Optional[str]:
+    """Join result.content[].text blocks from a session.tool 'result' payload.
+
+    OpenClaw tool results carry a list of typed content blocks; jota-gateway
+    only cares about the text ones. Returns None if there's nothing to show.
+    """
+    if not content:
+        return None
+    texts = [
+        block.get("text", "")
+        for block in content
+        if isinstance(block, dict) and block.get("type") == "text"
+    ]
+    joined = "\n".join(t for t in texts if t)
+    return joined or None
+
+
+@dataclass
+class ToolCallEvent:
+    phase: Literal["start", "result"]
+    name: str
+    tool_call_id: str
+    args: Optional[dict] = None
+    result: Optional[str] = None
+    is_error: Optional[bool] = None
+
+    @classmethod
+    def from_session_tool_payload(cls, data: dict) -> Optional["ToolCallEvent"]:
+        """Parse the `data` sub-object of an OpenClaw `session.tool` event.
+
+        Only `start` and `result` phases are recognized — `update` (streaming
+        partial result) and anything else return None. Returns None on
+        missing required fields (name, toolCallId) instead of raising.
+        """
+        phase = data.get("phase")
+        name = data.get("name")
+        tool_call_id = data.get("toolCallId")
+        if phase not in ("start", "result") or not name or not tool_call_id:
+            return None
+
+        if phase == "result":
+            result_payload = data.get("result") or {}
+            return cls(
+                phase="result",
+                name=name,
+                tool_call_id=tool_call_id,
+                result=_flatten_tool_result_content(result_payload.get("content")),
+                is_error=data.get("isError"),
+            )
+
+        return cls(
+            phase="start",
+            name=name,
+            tool_call_id=tool_call_id,
+            args=data.get("args"),
         )

--- a/src/services/orchestration.py
+++ b/src/services/orchestration.py
@@ -2,6 +2,7 @@ import logging
 from typing import Awaitable, Callable, Optional
 
 from src.services.protocol import OrchestratorProtocol
+from src.services.openclaw.models import ToolCallEvent
 from src.services.pipeline_tracker import PipelineTracker
 
 logger = logging.getLogger(__name__)
@@ -16,8 +17,10 @@ async def call_orchestrator(
     system_prompt_extra: Optional[str] = None,
     tracker: Optional[PipelineTracker] = None,
     on_token: Optional[Callable[[str], Awaitable[None]]] = None,
+    on_tool_call: Optional[Callable[[ToolCallEvent], Awaitable[None]]] = None,
 ) -> None:
-    """Iterate orchestrator.stream_response(), record pipeline events, call on_token per token.
+    """Iterate orchestrator.stream_response(), record pipeline events, call on_token per token
+    and on_tool_call per tool-call event.
 
     Raises RuntimeError if the orchestrator emits an error event.
     """
@@ -42,6 +45,10 @@ async def call_orchestrator(
             _token_count += 1
             if on_token:
                 await on_token(event.content)
+
+        elif event.type == "tool_call":
+            if on_tool_call and event.tool_call is not None:
+                await on_tool_call(event.tool_call)
 
         elif event.type == "error":
             raise RuntimeError(event.content)

--- a/src/services/protocol.py
+++ b/src/services/protocol.py
@@ -1,11 +1,14 @@
 from dataclasses import dataclass
 from typing import Literal, AsyncIterator, Optional, Protocol, runtime_checkable
 
+from src.services.openclaw.models import ToolCallEvent
+
 
 @dataclass
 class OrchestratorEvent:
-    type: Literal["token", "status", "error"]
+    type: Literal["token", "status", "error", "tool_call"]
     content: str = ""
+    tool_call: Optional[ToolCallEvent] = None
 
 
 @runtime_checkable

--- a/tests/integration/test_admin_clients.py
+++ b/tests/integration/test_admin_clients.py
@@ -155,3 +155,28 @@ def test_missing_token_returns_422(http):
 def test_wrong_token_returns_401(http):
     r = http.get("/admin/clients", headers={"x-admin-token": "bad"})
     assert r.status_code == 401
+
+
+# --- tool_calls_enabled ---
+
+def test_create_client_tool_calls_enabled_defaults_false(http):
+    r = http.post("/admin/clients", json={"name": "T"}, headers=HEADERS)
+    assert r.status_code == 201
+    assert r.json()["tool_calls_enabled"] is False
+
+
+def test_create_client_tool_calls_enabled_explicit_true(http):
+    r = http.post("/admin/clients", json={"name": "T", "tool_calls_enabled": True}, headers=HEADERS)
+    assert r.status_code == 201
+    assert r.json()["tool_calls_enabled"] is True
+
+
+def test_patch_client_tool_calls_enabled(http):
+    created = http.post("/admin/clients", json={"name": "C"}, headers=HEADERS).json()
+    r = http.patch(
+        f"/admin/clients/{created['id']}",
+        json={"tool_calls_enabled": True},
+        headers=HEADERS,
+    )
+    assert r.status_code == 200
+    assert r.json()["tool_calls_enabled"] is True

--- a/tests/integration/test_openclaw_client.py
+++ b/tests/integration/test_openclaw_client.py
@@ -114,19 +114,18 @@ class SmartFakeWS:
                 if self.chat_response_delay > 0:
                     await asyncio.sleep(self.chat_response_delay)
                 for i, chunk in enumerate(chunks):
+                    is_last = i == len(chunks) - 1
                     await self._to_client.put(json.dumps({
                         "type": "event", "event": "chat",
                         "payload": {
                             "runId": run_id, "sessionKey": sk,
-                            "seq": i + 1, "state": "delta", "deltaText": chunk,
+                            "seq": i + 1,
+                            "state": "final" if is_last else "delta",
+                            "deltaText": chunk,
                         },
                     }))
                     if self.chat_response_delay > 0:
                         await asyncio.sleep(self.chat_response_delay)
-                await self._to_client.put(json.dumps({
-                    "type": "res", "id": req_id, "ok": True,
-                    "payload": {"status": "done", "runId": run_id},
-                }))
 
             elif method == "health":
                 await self._to_client.put(json.dumps({
@@ -294,4 +293,24 @@ async def test_chat_abort_frame_schema(fake_ws):
     assert len(aborts) >= 1
     assert "sessionKey" in aborts[0]["params"]
     assert "session" not in aborts[0]["params"]
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_stream_response_completes_without_second_res(fake_ws):
+    """Turn completion must come from chat.state=='final', not a second res frame —
+    the real OpenClaw server (2026.6.11+) never sends one."""
+    client = await connected_client(fake_ws)
+    events = []
+    async for event in client.stream_response(
+        "hola", "client-a", session_key="agent:main:client-a"
+    ):
+        events.append(event)
+    res_frames_after_started = [
+        f for f in fake_ws.sent_frames
+        if f.get("method") == "chat.send"
+    ]
+    assert len(res_frames_after_started) == 1  # only the request itself was sent by us
+    assert events[-1].type == "status"
+    assert events[-1].content == "done"
     await client.close()

--- a/tests/integration/test_openclaw_client.py
+++ b/tests/integration/test_openclaw_client.py
@@ -32,9 +32,11 @@ class SmartFakeWS:
     chat_responses: {sessionKey → [list of deltaText strings]}
     """
 
-    def __init__(self, chat_responses: Optional[dict] = None, chat_response_delay: float = 0.0):
+    def __init__(self, chat_responses: Optional[dict] = None, chat_response_delay: float = 0.0,
+                 tool_calls: Optional[dict] = None):
         self.chat_responses: dict[str, list[str]] = chat_responses or {}
         self.chat_response_delay: float = chat_response_delay  # delay between chunks (in seconds)
+        self.tool_calls: dict[str, list[dict]] = tool_calls or {}
         self._to_client: asyncio.Queue = asyncio.Queue()
         self._from_client: asyncio.Queue = asyncio.Queue()
         self.sent_frames: list[dict] = []
@@ -113,6 +115,11 @@ class SmartFakeWS:
                 }))
                 if self.chat_response_delay > 0:
                     await asyncio.sleep(self.chat_response_delay)
+                for tool_data in self.tool_calls.get(sk, []):
+                    await self._to_client.put(json.dumps({
+                        "type": "event", "event": "session.tool",
+                        "payload": {"sessionKey": sk, "runId": run_id, "data": tool_data},
+                    }))
                 for i, chunk in enumerate(chunks):
                     is_last = i == len(chunks) - 1
                     await self._to_client.put(json.dumps({
@@ -313,4 +320,31 @@ async def test_stream_response_completes_without_second_res(fake_ws):
     assert len(res_frames_after_started) == 1  # only the request itself was sent by us
     assert events[-1].type == "status"
     assert events[-1].content == "done"
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_stream_response_yields_tool_call_events():
+    fake_ws = SmartFakeWS(
+        chat_responses={"agent:main:client-a": ["Listo."]},
+        tool_calls={"agent:main:client-a": [
+            {"phase": "start", "name": "exec", "toolCallId": "call-1", "args": {"command": "ls"}},
+            {"phase": "result", "name": "exec", "toolCallId": "call-1", "isError": False,
+             "result": {"content": [{"type": "text", "text": "file.txt"}]}},
+        ]},
+    )
+    client = await connected_client(fake_ws)
+    tool_events = []
+    async for event in client.stream_response(
+        "hola", "client-a", session_key="agent:main:client-a"
+    ):
+        if event.type == "tool_call":
+            tool_events.append(event.tool_call)
+    assert len(tool_events) == 2
+    assert tool_events[0].phase == "start"
+    assert tool_events[0].name == "exec"
+    assert tool_events[0].args == {"command": "ls"}
+    assert tool_events[1].phase == "result"
+    assert tool_events[1].result == "file.txt"
+    assert tool_events[1].is_error is False
     await client.close()

--- a/tests/unit/test_bridge_push.py
+++ b/tests/unit/test_bridge_push.py
@@ -180,3 +180,57 @@ async def test_push_disabled_ignores_push_turn_start():
     await bridge.on_push_turn_start("agent:main:ha")
     ws.send_json.assert_not_awaited()
     assert bridge._push_turn_id is None
+
+
+@pytest.mark.asyncio
+async def test_deliver_push_tool_call_forwarded_when_enabled():
+    client = Client(id="hab_sito", client_key="key-123", is_active=True)
+    config = ClientConfig(tool_calls_enabled=True)
+    ws = AsyncMock()
+    handshake = Handshake(client_key="key-123", input_mode="text", output_mode=["text"], agent="main")
+    bridge = JotaBridge(
+        client=client, config=config, client_ws=ws,
+        orchestrator=AsyncMock(), tracker=AsyncMock(), handshake=handshake,
+        client_registry=ClientRegistry(), default_agent="main",
+    )
+    bridge._push_turn_id = "t-1"
+    data = {"phase": "start", "name": "exec", "toolCallId": "call-1", "args": {"command": "ls"}}
+    await bridge.deliver_push_tool_call(data)
+    ws.send_json.assert_awaited_once_with({
+        "type": "tool_call", "turn_id": "t-1", "phase": "start",
+        "name": "exec", "tool_call_id": "call-1",
+        "args": {"command": "ls"}, "result": None, "is_error": None,
+    })
+
+
+@pytest.mark.asyncio
+async def test_deliver_push_tool_call_not_forwarded_when_disabled():
+    client = Client(id="hab_sito", client_key="key-123", is_active=True)
+    config = ClientConfig(tool_calls_enabled=False)
+    ws = AsyncMock()
+    handshake = Handshake(client_key="key-123", input_mode="text", output_mode=["text"], agent="main")
+    bridge = JotaBridge(
+        client=client, config=config, client_ws=ws,
+        orchestrator=AsyncMock(), tracker=AsyncMock(), handshake=handshake,
+        client_registry=ClientRegistry(), default_agent="main",
+    )
+    bridge._push_turn_id = "t-1"
+    data = {"phase": "start", "name": "exec", "toolCallId": "call-1", "args": {}}
+    await bridge.deliver_push_tool_call(data)
+    ws.send_json.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_deliver_push_tool_call_malformed_payload_ignored():
+    client = Client(id="hab_sito", client_key="key-123", is_active=True)
+    config = ClientConfig(tool_calls_enabled=True)
+    ws = AsyncMock()
+    handshake = Handshake(client_key="key-123", input_mode="text", output_mode=["text"], agent="main")
+    bridge = JotaBridge(
+        client=client, config=config, client_ws=ws,
+        orchestrator=AsyncMock(), tracker=AsyncMock(), handshake=handshake,
+        client_registry=ClientRegistry(), default_agent="main",
+    )
+    bridge._push_turn_id = "t-1"
+    await bridge.deliver_push_tool_call({"phase": "update"})  # must not raise
+    ws.send_json.assert_not_awaited()

--- a/tests/unit/test_bridge_send_guards.py
+++ b/tests/unit/test_bridge_send_guards.py
@@ -5,6 +5,7 @@ from src.services.bridge import JotaBridge
 from src.services.openclaw.registry import ClientRegistry
 from src.services.protocol import OrchestratorEvent
 from src.models.schemas import Client, ClientConfig, Handshake
+from src.services.openclaw.models import ToolCallEvent
 
 import src.services.bridge as bridge_module
 
@@ -34,6 +35,53 @@ def make_stream_with_event(event_type: str, content: str):
     async def _stream(*args, **kwargs):
         yield OrchestratorEvent(type=event_type, content=content)
     return _stream
+
+
+def make_stream_with_tool_call(tool_call: ToolCallEvent):
+    async def _stream(*args, **kwargs):
+        yield OrchestratorEvent(type="tool_call", tool_call=tool_call)
+    return _stream
+
+
+async def test_tool_call_forwarded_when_enabled(mock_tracker):
+    ws = AsyncMock()
+    config = ClientConfig(tool_calls_enabled=True)
+    b = JotaBridge(client=_CLIENT, config=config, client_ws=ws, orchestrator=AsyncMock(), tracker=mock_tracker,
+                   handshake=Handshake(client_key="test-key", input_mode="text", output_mode=["text"]),
+                   client_registry=ClientRegistry(), default_agent="main")
+    tc = ToolCallEvent(phase="start", name="exec", tool_call_id="call-1", args={"command": "ls"})
+    b.orchestrator.stream_response = make_stream_with_tool_call(tc)
+
+    await b._call_orchestrator("test")
+
+    tool_call_msgs = [
+        c.args[0] for c in ws.send_json.await_args_list
+        if c.args[0].get("type") == "tool_call"
+    ]
+    assert len(tool_call_msgs) == 1
+    assert tool_call_msgs[0]["phase"] == "start"
+    assert tool_call_msgs[0]["name"] == "exec"
+    assert tool_call_msgs[0]["tool_call_id"] == "call-1"
+    assert tool_call_msgs[0]["args"] == {"command": "ls"}
+    assert tool_call_msgs[0]["turn_id"] == "t-1"
+
+
+async def test_tool_call_not_forwarded_when_disabled(mock_tracker):
+    ws = AsyncMock()
+    config = ClientConfig(tool_calls_enabled=False)
+    b = JotaBridge(client=_CLIENT, config=config, client_ws=ws, orchestrator=AsyncMock(), tracker=mock_tracker,
+                   handshake=Handshake(client_key="test-key", input_mode="text", output_mode=["text"]),
+                   client_registry=ClientRegistry(), default_agent="main")
+    tc = ToolCallEvent(phase="start", name="exec", tool_call_id="call-1", args={"command": "ls"})
+    b.orchestrator.stream_response = make_stream_with_tool_call(tc)
+
+    await b._call_orchestrator("test")
+
+    tool_call_msgs = [
+        c.args[0] for c in ws.send_json.await_args_list
+        if c.args[0].get("type") == "tool_call"
+    ]
+    assert tool_call_msgs == []
 
 
 async def test_token_send_failure_does_not_propagate(bridge):

--- a/tests/unit/test_openclaw_dispatcher.py
+++ b/tests/unit/test_openclaw_dispatcher.py
@@ -111,3 +111,75 @@ async def test_health_and_tick_ignored():
     for event_name in ("health", "tick", "presence", "sessions.changed"):
         frame = {"type": "event", "event": event_name, "payload": {}}
         await dispatcher.dispatch(frame)  # must not raise
+
+
+@pytest.mark.asyncio
+async def test_session_tool_start_routes_to_turn_queue():
+    dispatcher, turn_reg, _ = make_dispatcher()
+    q = turn_reg.register("req-1", "agent:main:client-a")
+    payload = {
+        "sessionKey": "agent:main:client-a",
+        "runId": "r1",
+        "data": {"phase": "start", "name": "exec", "toolCallId": "call-1", "args": {"command": "ls"}},
+    }
+    frame = {"type": "event", "event": "session.tool", "payload": payload}
+    await dispatcher.dispatch(frame)
+    kind, data = q.get_nowait()
+    assert kind == "tool"
+    assert data["phase"] == "start"
+    assert data["name"] == "exec"
+
+
+@pytest.mark.asyncio
+async def test_session_tool_result_routes_to_turn_queue():
+    dispatcher, turn_reg, _ = make_dispatcher()
+    q = turn_reg.register("req-1", "agent:main:client-a")
+    payload = {
+        "sessionKey": "agent:main:client-a",
+        "data": {
+            "phase": "result", "name": "exec", "toolCallId": "call-1",
+            "isError": False, "result": {"content": [{"type": "text", "text": "ok"}]},
+        },
+    }
+    frame = {"type": "event", "event": "session.tool", "payload": payload}
+    await dispatcher.dispatch(frame)
+    kind, data = q.get_nowait()
+    assert kind == "tool"
+    assert data["phase"] == "result"
+
+
+@pytest.mark.asyncio
+async def test_session_tool_update_phase_is_dropped():
+    dispatcher, turn_reg, _ = make_dispatcher()
+    q = turn_reg.register("req-1", "agent:main:client-a")
+    payload = {
+        "sessionKey": "agent:main:client-a",
+        "data": {"phase": "update", "name": "exec", "toolCallId": "call-1", "partialResult": {}},
+    }
+    frame = {"type": "event", "event": "session.tool", "payload": payload}
+    await dispatcher.dispatch(frame)
+    assert q.empty()
+
+
+@pytest.mark.asyncio
+async def test_session_tool_no_active_turn_routes_to_client_registry():
+    dispatcher, turn_reg, client_reg = make_dispatcher()
+    bridge = AsyncMock()
+    client_reg.register("client-a", bridge)
+    payload = {
+        "sessionKey": "agent:main:client-a",
+        "data": {"phase": "start", "name": "exec", "toolCallId": "call-1", "args": {}},
+    }
+    frame = {"type": "event", "event": "session.tool", "payload": payload}
+    await dispatcher.dispatch(frame)
+    bridge.deliver_push_tool_call.assert_awaited_once_with(payload["data"])
+
+
+@pytest.mark.asyncio
+async def test_session_tool_no_session_key_ignored():
+    dispatcher, _, _ = make_dispatcher()
+    frame = {
+        "type": "event", "event": "session.tool",
+        "payload": {"data": {"phase": "start", "name": "exec", "toolCallId": "call-1"}},
+    }
+    await dispatcher.dispatch(frame)  # must not raise

--- a/tests/unit/test_openclaw_models.py
+++ b/tests/unit/test_openclaw_models.py
@@ -1,4 +1,4 @@
-from src.services.openclaw.models import GatewayInfo
+from src.services.openclaw.models import GatewayInfo, ToolCallEvent
 
 HELLO_OK_PAYLOAD = {
     "type": "hello-ok",
@@ -49,3 +49,47 @@ def test_from_hello_ok_minimal():
     assert info.default_agent_id == "main"
     assert info.agents == {}
     assert info.tick_interval_ms == 15000
+
+
+def test_tool_call_start_parses_name_and_args():
+    data = {
+        "phase": "start", "name": "exec", "toolCallId": "call-1",
+        "args": {"command": "pwd && ls", "workdir": "/tmp"},
+    }
+    tc = ToolCallEvent.from_session_tool_payload(data)
+    assert tc.phase == "start"
+    assert tc.name == "exec"
+    assert tc.tool_call_id == "call-1"
+    assert tc.args == {"command": "pwd && ls", "workdir": "/tmp"}
+    assert tc.result is None
+    assert tc.is_error is None
+
+
+def test_tool_call_result_flattens_text_content():
+    data = {
+        "phase": "result", "name": "exec", "toolCallId": "call-1",
+        "isError": False,
+        "result": {"content": [{"type": "text", "text": "line1\nline2"}]},
+    }
+    tc = ToolCallEvent.from_session_tool_payload(data)
+    assert tc.phase == "result"
+    assert tc.result == "line1\nline2"
+    assert tc.is_error is False
+    assert tc.args is None
+
+
+def test_tool_call_result_with_no_content_has_none_result():
+    data = {"phase": "result", "name": "exec", "toolCallId": "call-1", "isError": True, "result": {}}
+    tc = ToolCallEvent.from_session_tool_payload(data)
+    assert tc.result is None
+    assert tc.is_error is True
+
+
+def test_tool_call_update_phase_returns_none():
+    data = {"phase": "update", "name": "exec", "toolCallId": "call-1", "partialResult": {}}
+    assert ToolCallEvent.from_session_tool_payload(data) is None
+
+
+def test_tool_call_missing_required_fields_returns_none():
+    assert ToolCallEvent.from_session_tool_payload({"phase": "start"}) is None
+    assert ToolCallEvent.from_session_tool_payload({"phase": "start", "name": "exec"}) is None

--- a/tests/unit/test_orchestration.py
+++ b/tests/unit/test_orchestration.py
@@ -2,6 +2,7 @@ import pytest
 from unittest.mock import MagicMock
 from src.services.orchestration import call_orchestrator
 from src.services.protocol import OrchestratorEvent
+from src.services.openclaw.models import ToolCallEvent
 
 
 def _make_orchestrator(events):
@@ -66,6 +67,32 @@ async def test_error_event_raises():
     orch = _make_orchestrator([OrchestratorEvent(type="error", content="orchestrator_unavailable")])
     with pytest.raises(RuntimeError, match="orchestrator_unavailable"):
         await call_orchestrator(orch, "hi", "agent:main:ha", "ha")
+
+
+async def test_tool_call_reaches_callback():
+    tc_start = ToolCallEvent(phase="start", name="exec", tool_call_id="call-1", args={"command": "ls"})
+    tc_result = ToolCallEvent(phase="result", name="exec", tool_call_id="call-1", result="ok", is_error=False)
+    orch = _make_orchestrator([
+        OrchestratorEvent(type="tool_call", tool_call=tc_start),
+        OrchestratorEvent(type="tool_call", tool_call=tc_result),
+        OrchestratorEvent(type="status", content="done"),
+    ])
+    received = []
+
+    async def on_tool_call(tc):
+        received.append(tc)
+
+    await call_orchestrator(orch, "hi", "agent:main:ha", "ha", on_tool_call=on_tool_call)
+    assert received == [tc_start, tc_result]
+
+
+async def test_no_on_tool_call_does_not_raise():
+    tc = ToolCallEvent(phase="start", name="exec", tool_call_id="call-1")
+    orch = _make_orchestrator([
+        OrchestratorEvent(type="tool_call", tool_call=tc),
+        OrchestratorEvent(type="status", content="done"),
+    ])
+    await call_orchestrator(orch, "hi", "agent:main:ha", "ha", on_tool_call=None)
 
 
 async def test_llm_done_meta_has_token_count():


### PR DESCRIPTION
## Summary
- Fixes turn-completion detection: the real OpenClaw server (2026.6.11+) never sends a second `res` frame for `chat.send` — only a `chat` event with `state: "final"`. `stream_response()` previously hung forever waiting for a `res` that never arrives.
- Surfaces OpenClaw `session.tool` events (`start`/`result` phases; `update` is dropped) as a new `tool_call` WebSocket message, routed through `dispatcher.py` → `client.py` → `orchestration.py` → `bridge.py`, for both normal and agent-initiated push turns.
- Opt-in per client via a new `tool_calls_enabled` DB config flag (default `False`) — no behavior change for existing clients unless explicitly enabled via `PATCH /admin/clients/{id}`.

No related GitHub issue — this closes no issue, implemented from `docs/superpowers/plans/2026-07-02-openclaw-tool-calls.md`.

## Test plan
- [x] `PYTHONPATH=. pytest` — 279 passed (up from 257 baseline)
- [x] Regression test confirms turn completion no longer depends on a second `res` frame
- [x] Unit + integration tests cover `ToolCallEvent` parsing, dispatcher routing, `stream_response` tool_call events, `call_orchestrator` callback wiring, and bridge forwarding (enabled/disabled, normal + push turns)

🤖 Generated with [Claude Code](https://claude.com/claude-code)