### PR TITLE
fix: fetch agent roster via agents.list, not hello-ok snapshot

### DIFF
--- a/src/services/openclaw/client.py
+++ b/src/services/openclaw/client.py
@@ -61,6 +61,18 @@ class OpenClawClient:
             raise RuntimeError(f"OpenClaw handshake failed: {hello.get('error')}")
         self.gateway_info = GatewayInfo.from_hello_ok(hello.get("payload", {}))
 
+        # hello-ok's snapshot no longer embeds the full agent roster (OpenClaw
+        # server 2026.6.11+) — fetch it explicitly so has_agent() doesn't
+        # reject every agent. Skip any unrelated event frames (e.g. a periodic
+        # "health" broadcast) that may interleave before the matching res.
+        agents_req_id = str(uuid.uuid4())
+        await self._ws.send(json.dumps(frames.agents_list(agents_req_id)))
+        agents_res = await self._recv_matching(agents_req_id, timeout=10.0)
+        if agents_res.get("ok"):
+            self.gateway_info.update_agents_from_list(agents_res.get("payload", {}))
+        else:
+            logger.warning(f"agents.list failed at connect: {agents_res.get('error')}")
+
         sub_id = str(uuid.uuid4())
         await self._ws.send(json.dumps(frames.sessions_subscribe(sub_id)))
 
@@ -77,6 +89,21 @@ class OpenClawClient:
             f"default_agent={self.gateway_info.default_agent_id})"
         )
         return self.gateway_info
+
+    async def _recv_matching(self, req_id: str, timeout: float) -> dict:
+        """Read frames until the res matching req_id arrives, ignoring any
+        unrelated event frames that may interleave before it (only used
+        during connect(), before _listen() starts routing frames)."""
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + timeout
+        while True:
+            remaining = deadline - loop.time()
+            if remaining <= 0:
+                raise asyncio.TimeoutError(f"No response for req_id={req_id} within {timeout}s")
+            raw = await asyncio.wait_for(self._ws.recv(), timeout=remaining)
+            frame = json.loads(raw)
+            if frame.get("id") == req_id:
+                return frame
 
     async def close(self) -> None:
         for task in (self._keepalive_task, self._listener_task):

--- a/src/services/openclaw/models.py
+++ b/src/services/openclaw/models.py
@@ -21,6 +21,21 @@ class GatewayInfo:
     def has_agent(self, agent_id: str) -> bool:
         return agent_id in self.agents
 
+    def update_agents_from_list(self, payload: dict) -> None:
+        """Populate agents from an agents.list response — OpenClaw server
+        2026.6.11+ no longer embeds the roster in hello-ok's snapshot."""
+        default_id = payload.get("defaultId", self.default_agent_id)
+        agents: dict[str, AgentInfo] = {}
+        for a in payload.get("agents", []):
+            aid = a["id"]
+            agents[aid] = AgentInfo(
+                agent_id=aid,
+                name=a.get("name", aid),
+                is_default=(aid == default_id),
+            )
+        self.agents = agents
+        self.default_agent_id = default_id
+
     @classmethod
     def from_hello_ok(cls, payload: dict) -> "GatewayInfo":
         server = payload.get("server", {})

--- a/tests/integration/test_openclaw_client.py
+++ b/tests/integration/test_openclaw_client.py
@@ -25,6 +25,33 @@ HELLO_OK_PAYLOAD = {
     "auth": {"role": "operator", "scopes": ["operator.read", "operator.write"]},
 }
 
+# Matches OpenClaw server 2026.6.11+: hello-ok's snapshot no longer embeds the
+# agent roster at all — it must be fetched separately via agents.list.
+HELLO_OK_PAYLOAD_NO_SNAPSHOT_AGENTS = {
+    "type": "hello-ok", "protocol": 4,
+    "server": {"version": "2026.6.11", "connId": "test-conn-2"},
+    "policy": {"tickIntervalMs": 30000, "maxPayload": 26214400, "maxBufferedBytes": 0},
+    "snapshot": {
+        "presence": {},
+        "health": {},
+        "stateVersion": 1,
+        "uptimeMs": 1000,
+        "sessionDefaults": {"defaultAgentId": "main"},
+    },
+    "auth": {"role": "operator", "scopes": ["operator.read", "operator.write"]},
+}
+
+AGENTS_LIST_PAYLOAD = {
+    "defaultId": "main",
+    "mainKey": "main",
+    "scope": "per-sender",
+    "agents": [
+        {"id": "main", "name": "Main Agent"},
+        {"id": "assistant", "name": "Jota Voice"},
+        {"id": "ci-tester", "name": "CI Tester"},
+    ],
+}
+
 
 class SmartFakeWS:
     """Queue-backed fake WebSocket that auto-responds to OpenClaw protocol v4.
@@ -32,9 +59,17 @@ class SmartFakeWS:
     chat_responses: {sessionKey → [list of deltaText strings]}
     """
 
-    def __init__(self, chat_responses: Optional[dict] = None, chat_response_delay: float = 0.0):
+    def __init__(
+        self,
+        chat_responses: Optional[dict] = None,
+        chat_response_delay: float = 0.0,
+        hello_ok_payload: Optional[dict] = None,
+        agents_list_payload: Optional[dict] = None,
+    ):
         self.chat_responses: dict[str, list[str]] = chat_responses or {}
         self.chat_response_delay: float = chat_response_delay  # delay between chunks (in seconds)
+        self.hello_ok_payload = hello_ok_payload or HELLO_OK_PAYLOAD
+        self.agents_list_payload = agents_list_payload or AGENTS_LIST_PAYLOAD
         self._to_client: asyncio.Queue = asyncio.Queue()
         self._from_client: asyncio.Queue = asyncio.Queue()
         self.sent_frames: list[dict] = []
@@ -93,7 +128,13 @@ class SmartFakeWS:
             if method == "connect":
                 await self._to_client.put(json.dumps({
                     "type": "res", "id": req_id, "ok": True,
-                    "payload": HELLO_OK_PAYLOAD,
+                    "payload": self.hello_ok_payload,
+                }))
+
+            elif method == "agents.list":
+                await self._to_client.put(json.dumps({
+                    "type": "res", "id": req_id, "ok": True,
+                    "payload": self.agents_list_payload,
                 }))
 
             elif method == "sessions.subscribe":
@@ -165,6 +206,23 @@ async def test_connect_returns_gateway_info(fake_ws):
     assert client.gateway_info is not None
     assert client.gateway_info.default_agent_id == "main"
     assert client.gateway_info.has_agent("assistant")
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_connect_populates_agents_via_agents_list_when_snapshot_lacks_agents():
+    """OpenClaw server 2026.6.11+ no longer embeds the agent roster in
+    hello-ok's snapshot — it must be fetched via a separate agents.list call
+    right after connecting, or has_agent() silently rejects every agent."""
+    fake_ws = SmartFakeWS(
+        {"agent:main:client-a": ["Hola"]},
+        hello_ok_payload=HELLO_OK_PAYLOAD_NO_SNAPSHOT_AGENTS,
+    )
+    client = await connected_client(fake_ws)
+    assert client.gateway_info.has_agent("main")
+    assert client.gateway_info.has_agent("assistant")
+    assert client.gateway_info.has_agent("ci-tester")
+    assert client.gateway_info.default_agent_id == "main"
     await client.close()
 
 

--- a/tests/unit/test_openclaw_models.py
+++ b/tests/unit/test_openclaw_models.py
@@ -49,3 +49,28 @@ def test_from_hello_ok_minimal():
     assert info.default_agent_id == "main"
     assert info.agents == {}
     assert info.tick_interval_ms == 15000
+
+
+def test_update_agents_from_list():
+    """agents.list payload shape differs from snapshot.agents: 'id' not
+    'agentId', no per-agent 'isDefault' — derived from top-level 'defaultId'."""
+    info = GatewayInfo.from_hello_ok({})  # starts with empty agents, default "main"
+    info.update_agents_from_list({
+        "defaultId": "assistant",
+        "agents": [
+            {"id": "main", "name": "Main Agent"},
+            {"id": "assistant", "name": "Jota Voice"},
+        ],
+    })
+    assert info.has_agent("main")
+    assert info.has_agent("assistant")
+    assert info.agents["assistant"].is_default is True
+    assert info.agents["main"].is_default is False
+    assert info.default_agent_id == "assistant"
+
+
+def test_update_agents_from_list_keeps_prior_default_if_missing():
+    info = GatewayInfo.from_hello_ok({})
+    info.update_agents_from_list({"agents": [{"id": "main", "name": "Main Agent"}]})
+    assert info.default_agent_id == "main"
+    assert info.agents["main"].is_default is True


### PR DESCRIPTION
## Summary
- OpenClaw server 2026.6.11+ no longer embeds the agent roster in `hello-ok`'s `snapshot` — `GatewayInfo.has_agent()` silently rejected every agent, closing any WS handshake that specified an explicit `agent` field with 1008 "Agent not available", even for agents that exist and work fine.
- Clients that omit `agent` were unaffected (fallback `default_agent_id` comes from `sessionDefaults`, still present) — that's why this went unnoticed until a client requested a named agent explicitly.
- Fix: fetch the roster via a separate `agents.list` call right after `connect()` and merge it into `GatewayInfo`, tolerating interleaved event frames (observed a periodic `health` broadcast land between the request and its response during manual verification against the live OpenClaw instance).

No GitHub issue exists for this — it was discovered live during this session while trying to validate a dedicated test agent (`ci-tester`) against the running production OpenClaw instance, and confirmed to affect all named agents (`main`, `assistant`), not just the new one.

## Test plan
- [x] New regression test (`test_connect_populates_agents_via_agents_list_when_snapshot_lacks_agents`) reproduces the bug against a fake WS shaped like the new OpenClaw protocol (no `snapshot.agents`) — verified RED before the fix, GREEN after.
- [x] New unit tests for `GatewayInfo.update_agents_from_list` (default-id resolution, id-key mapping).
- [x] Full suite: `PYTHONPATH=. pytest` → 260 passed.
- [x] `ruff check src/ tests/` → clean.
- [x] Manually verified against the real, running production OpenClaw instance (not just fakes): `has_agent("ci-tester")`, `has_agent("main")`, `has_agent("assistant")` all correctly `True`, `has_agent("nonexistent")` correctly `False`.
- [ ] Not yet deployed to the running production jota-gateway process — that process still has the old code in memory until this is merged and the service is restarted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)