### PR TITLE
docs: document agents.list fetch and chat.state='final' turn-completion

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -242,12 +242,15 @@ The HA REST endpoint (`/v1/chat/completions`) uses a fixed key: `agent:{default_
 
 Built once in `main.py` lifespan; stored in `app.state`.
 
-- `OpenClawClient` (`client.py`) — WebSocket v4 handshake (challenge → connect → hello-ok → sessions.subscribe), persistent `_listen` task, `_keepalive_loop` (pings at 80% of `tickIntervalMs`). All events carry `sessionKey`; `stream_response()` registers a `Queue` in `TurnRegistry` per turn, sends `{"sessionKey": key}` and reads the queue until `done`/`error`.
+- `OpenClawClient` (`client.py`) — WebSocket v4 handshake (challenge → connect → hello-ok → **agents.list → sessions.subscribe**), persistent `_listen` task, `_keepalive_loop` (pings at 80% of `tickIntervalMs`). All events carry `sessionKey`; `stream_response()` registers a `Queue` in `TurnRegistry` per turn, sends `{"sessionKey": key}` and reads the queue until turn completion or `error` (see turn-completion note below).
 - `ReconnectingOpenClawClient` (`reconnecting.py`) — wraps `OpenClawClient`; on unexpected disconnect calls `on_disconnect` hook, retries with exponential backoff up to `ORCHESTRATOR_RECONNECT_MAX_DURATION` seconds; after that enters DEGRADED state. `stream_response()` returns an `error` event immediately when not CONNECTED.
 - `TurnRegistry` (`registry.py`) — dual-index dict (`session_key → Queue`, `req_id → session_key`); `FrameDispatcher` uses it to route response frames to the correct waiting `stream_response()` call.
 - `ClientRegistry` (`registry.py`) — maps `client_id → JotaBridge`; used by `FrameDispatcher` to deliver agent-initiated push events to the right session.
-- `FrameDispatcher` (`dispatcher.py`) — called by `_listen` for every incoming frame; routes `res` frames to `TurnRegistry`, `chat` events to active turn queue or bridge push hooks, `agent` phase events to `on_push_turn_start`/`on_push_turn_end`.
-- `GatewayInfo` / `AgentInfo` (`models.py`) — parsed from the `hello-ok` payload; `gateway_info.default_agent_id` is used as the fallback agent when the client doesn't specify one.
+- `FrameDispatcher` (`dispatcher.py`) — called by `_listen` for every incoming frame; routes `res` frames to `TurnRegistry`, `chat` events to active turn queue or bridge push hooks, `agent` phase events to `on_push_turn_start`/`on_push_turn_end`, `session.tool` events (`phase: "start"`/`"result"`, `"update"` dropped) to the active turn queue or `bridge.deliver_push_tool_call`.
+- `GatewayInfo` / `AgentInfo` (`models.py`) — `default_agent_id`/`tick_interval_ms`/etc. come from the `hello-ok` payload; the **agent roster itself no longer does** (OpenClaw server 2026.6.11+ stopped embedding it in `hello-ok`'s `snapshot`). `OpenClawClient.connect()` fetches it explicitly via `agents.list` right after `hello-ok` and merges it in via `GatewayInfo.update_agents_from_list()`. Without this, `has_agent()` silently rejects every named agent — clients that omit `agent` in the Handshake are unaffected, since the fallback `default_agent_id` still comes from `sessionDefaults`.
+- `ToolCallEvent` (`models.py`) — parsed from a `session.tool` event's `data` sub-object; only `start`/`result` phases are surfaced (`update` streaming-partials are dropped). Forwarded to clients as a `{"type": "tool_call", ...}` WS message only when `ClientConfig.tool_calls_enabled` is `True` (default `False`).
+
+**Turn-completion signal:** OpenClaw server 2026.6.11+ never sends a second `res` for `chat.send` — the real completion signal is a `chat` event with `payload.state == "final"`. `stream_response()` treats that as `status: "done"` and ends the turn; the old `res`-based `done`/`status` handling is kept only as a fallback for older server versions, but production no longer relies on it. Assume this if a turn ever appears to hang after a token is received but before `turn_end` reaches the client — check `state` on the `chat` events, not for a stray `res`.
 
 OpenClaw connection details (loopback backend mode, no device signature required):
 - Token: `OPENCLAW_TOKEN`
@@ -301,6 +304,6 @@ The `StaticPool` is required for SQLite `:memory:` so all connections share one 
 
 ### OpenClaw tests
 
-`OpenClawClient` tests (`test_openclaw_client.py`) use `SmartFakeWS` — a queue-backed fake WebSocket that auto-responds to the v4 handshake (challenge → connect → hello-ok → subscribe ack) and per-test `chat.send` sequences.
+`OpenClawClient` tests (`test_openclaw_client.py`) use `SmartFakeWS` — a queue-backed fake WebSocket that auto-responds to the v4 handshake (challenge → connect → hello-ok → agents.list → subscribe ack) and per-test `chat.send` sequences. Constructor accepts `hello_ok_payload`/`agents_list_payload` overrides (for exercising the agents-roster-fetch path) and `chat_responses`/`tool_calls` (for turn content and `session.tool` events).
 
 `ReconnectingOpenClawClient` tests (`test_reconnecting_openclaw.py`) stub `OpenClawClient` to test backoff, DEGRADED state, and the `on_disconnect` hook contract.

--- a/docs/client-protocol.md
+++ b/docs/client-protocol.md
@@ -190,6 +190,27 @@ Los tokens llegan en orden; concaténalos para reconstruir la respuesta completa
 
 Señala que el orquestador terminó de generar la respuesta. El audio TTS puede seguir llegando brevemente después (ya está en tránsito).
 
+### `tool_call` — uso de herramientas del agente (opt-in)
+
+Solo se envía si el cliente tiene el flag `tool_calls_enabled` activado (por defecto `False`, gestionable vía Admin API — ver `CLAUDE.md`). Cuando el agente invoca una herramienta durante el turno, llegan dos mensajes intercalados con los `token`:
+
+```json
+{ "type": "tool_call", "turn_id": "t-1", "phase": "start", "name": "exec", "tool_call_id": "call-1", "args": {"command": "ls"}, "result": null, "is_error": null }
+{ "type": "tool_call", "turn_id": "t-1", "phase": "result", "name": "exec", "tool_call_id": "call-1", "args": null, "result": "file.txt", "is_error": false }
+```
+
+| Campo | Descripción |
+|-------|-------------|
+| `turn_id` | Turno al que pertenece (mismo `turn_id` que su `turn_start`) |
+| `phase` | `"start"` (la herramienta empieza a ejecutarse) o `"result"` (resultado disponible) |
+| `name` | Nombre de la herramienta |
+| `tool_call_id` | Identificador único de esta invocación — correlaciona `start` con su `result` |
+| `args` | Argumentos pasados a la herramienta (solo en `phase="start"`) |
+| `result` | Resultado en texto plano (solo en `phase="result"`) |
+| `is_error` | Si la herramienta falló (solo en `phase="result"`) |
+
+No hay un `phase="update"` — OpenClaw emite resultados parciales de streaming que el gateway descarta deliberadamente; solo se reenvían inicio y resultado final. También llegan durante turnos iniciados por el agente (push, ver §10).
+
 ### Pseudocódigo de recepción
 
 ```python
@@ -216,6 +237,10 @@ async for msg in ws:
             case "turn_end":
                 turn_id = data["turn_id"]
                 on_turn_complete(current_buffer.pop(turn_id, ""))
+
+            case "tool_call":
+                # Solo llega si tool_calls_enabled=True para este cliente
+                handle_tool_call(data["turn_id"], data["phase"], data["name"], data.get("args"), data.get("result"))
 
             case "transcription_partial":
                 show_live_transcription(data["text"])
@@ -399,7 +424,7 @@ OpenClaw puede iniciar turnos proactivamente sin que el usuario haya enviado nad
 { "type": "turn_end", "turn_id": "t-3" }
 ```
 
-El cliente no necesita distinguirlos de los turnos normales — el `turn_id` y `turn_seq` siguen la misma secuencia.
+El cliente no necesita distinguirlos de los turnos normales — el `turn_id` y `turn_seq` siguen la misma secuencia. Si `tool_calls_enabled` está activo, también pueden llegar mensajes `tool_call` (§5) intercalados.
 
 ---
 
@@ -472,6 +497,7 @@ El cliente escribe; el gateway sintetiza audio con el texto de la respuesta.
 | `turn_start` | `{"type":"turn_start","turn_id":"t-N","turn_seq":N}` | Inicio de cada turno |
 | `token` | `{"type":"token","turn_id":"t-N","text":"..."}` | `"text"` en `output_mode` — tokens en streaming |
 | `turn_end` | `{"type":"turn_end","turn_id":"t-N"}` | Fin de cada turno |
+| `tool_call` | `{"type":"tool_call","turn_id":"t-N","phase":"start"\|"result","name":"...","tool_call_id":"...","args":{...}\|null,"result":"..."\|null,"is_error":bool\|null}` | Solo si `tool_calls_enabled=True` para el cliente — uso de herramientas del agente |
 | `transcription_partial` | `{"type":"transcription_partial","text":"..."}` | `input_mode="audio"` — parciales en tiempo real |
 | `transcription` | `{"type":"transcription","text":"..."}` | `input_mode="audio"` — transcripción final, espera `send` |
 | `interrupted` | `{"type":"interrupted"}` | Barge-in confirmado, turno anterior cancelado |


### PR DESCRIPTION
## Summary
- `CLAUDE.md`'s OpenClaw package section still described the pre-drift protocol after PR #70 and #71 changed it: agent roster now comes from `agents.list` (not `hello-ok`'s snapshot), turn completion now comes from `chat.state=="final"` (not a second `res`), and `session.tool`/`ToolCallEvent` routing wasn't mentioned in the package bullet list.
- Documentation-only change, no code touched.

No GitHub issue — follow-up documentation pass after merging #70 and #71.

## Test plan
- [x] `ruff check src/ tests/` — n/a, doc-only, but re-ran to confirm no accidental code changes: clean.
- [x] Proofread rendered markdown for the changed sections.

🤖 Generated with [Claude Code](https://claude.com/claude-code)