### PR TITLE
test: add manually-triggered E2E smoke test suite against real OpenClaw

### DIFF
--- a/.github/workflows/e2e-real-smoke.yml
+++ b/.github/workflows/e2e-real-smoke.yml
@@ -17,6 +17,13 @@ jobs:
       - name: Install dependencies
         run: pip install -r requirements.txt
 
+      - name: Verify required tokens are present in runner environment
+        run: |
+          if [ -z "$ADMIN_TOKEN" ] || [ -z "$OPENCLAW_TOKEN" ]; then
+            echo "::error::ADMIN_TOKEN y/o OPENCLAW_TOKEN no están definidos en el entorno del runner. Estos tests NUNCA deben pasar en silencio por falta de tokens — configúralos en el servicio del runner self-hosted (no en este workflow, no en GitHub Secrets)."
+            exit 1
+          fi
+
       - name: Run E2E real smoke tests
         run: PYTHONPATH=. pytest tests/e2e -m e2e_real -v
         env:

--- a/.github/workflows/e2e-real-smoke.yml
+++ b/.github/workflows/e2e-real-smoke.yml
@@ -1,0 +1,27 @@
+name: E2E Real Smoke Test
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: e2e-real-smoke
+  cancel-in-progress: false
+
+jobs:
+  e2e-real:
+    runs-on: [self-hosted, jota-e2e]
+    environment: e2e-real-production
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      - name: Run E2E real smoke tests
+        run: PYTHONPATH=. pytest tests/e2e -m e2e_real -v
+        env:
+          E2E_TEST_AGENT: ${{ vars.E2E_TEST_AGENT }}
+
+      - name: Write summary
+        if: always()
+        run: echo "Ver resultados detallados en el log del job anterior." >> "$GITHUB_STEP_SUMMARY"

--- a/README.md
+++ b/README.md
@@ -178,6 +178,16 @@ PYTHONPATH=. E2E_TEST_AGENT=<agente-de-test> pytest tests/e2e -m e2e_real -v
 `OPENCLAW_TOKEN` y `ADMIN_TOKEN` nunca se guardan en GitHub — el proceso de test
 los lee del `.env` local del servidor, igual que la propia app.
 
+**Nota para el workflow de GitHub Actions:** el checkout que hace `actions/checkout`
+en el runner es limpio y **no incluye `.env`** (está en `.gitignore`). Por eso, para
+la ruta de CI, `ADMIN_TOKEN` y `OPENCLAW_TOKEN` deben estar exportados como
+variables de entorno reales en el propio proceso del runner self-hosted (p. ej.
+vía `Environment=` en su unidad systemd) — no en un `.env` dentro del checkout ni
+en GitHub Secrets. El job incluye un paso de verificación previo al de tests que
+falla explícitamente (`exit 1`) si alguna de las dos falta, para que un runner mal
+configurado rompa de forma visible en lugar de pasar en silencio sin cobertura
+real.
+
 ---
 
 ## Arquitectura interna

--- a/README.md
+++ b/README.md
@@ -144,6 +144,42 @@ ruff check src/ tests/
 
 ---
 
+## Smoke-test E2E real (contra OpenClaw de producción)
+
+`tests/e2e/` valida el pipeline completo contra el OpenClaw **real** de este mismo
+servidor: turno de texto, cancelación, sesiones concurrentes y uso de tools. Nunca
+corre automáticamente — ni en la CI normal, ni con un `pytest` a secas (marker
+`e2e_real`, deseleccionado por defecto en `pytest.ini`).
+
+Solo se dispara manualmente vía el workflow `E2E Real Smoke Test`
+(`workflow_dispatch`), gated por un GitHub Environment con aprobación requerida.
+Antes de poder usarlo hace falta configurar, una sola vez, lo siguiente
+(fuera de este repo):
+
+1. **Agente de test dedicado en OpenClaw** — con personalidad/memoria aislada de
+   los agentes de producción, y alguna tool/skill simple y determinista habilitada
+   (para `test_tool_use.py`). Nunca se testea contra un agente real.
+2. **Runner self-hosted dedicado**, separado del runner `green-house` existente
+   (que sirve a otro repo). Registrar una segunda instancia de
+   [`actions-runner`](https://github.com/actions/runner) en este servidor, con
+   label `jota-e2e`, contra este repo.
+3. **GitHub Environment `e2e-real-production`** (Settings → Environments):
+   - *Required reviewers*: el usuario propietario del repo, explícitamente.
+   - *Deployment branches*: restringido a `main`.
+   - *Environment variable* `E2E_TEST_AGENT`: nombre del agente de test del punto 1.
+
+Ejecución manual local (sin pasar por GitHub Actions), útil para validar cambios
+en la suite antes de fiarse del workflow:
+
+```bash
+PYTHONPATH=. E2E_TEST_AGENT=<agente-de-test> pytest tests/e2e -m e2e_real -v
+```
+
+`OPENCLAW_TOKEN` y `ADMIN_TOKEN` nunca se guardan en GitHub — el proceso de test
+los lee del `.env` local del servidor, igual que la propia app.
+
+---
+
 ## Arquitectura interna
 
 El gateway instancia un `JotaBridge` por cada sesión WebSocket. `OpenClawClient` es un singleton persistente envuelto en `ReconnectingOpenClawClient` (reconexión automática con backoff exponencial; estados CONNECTED / RECONNECTING / DEGRADED).

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,7 @@
 [pytest]
 asyncio_mode = auto
 testpaths = tests
+addopts = -m "not e2e_real"
 markers =
     integration: marks tests as integration tests
+    e2e_real: hits the real production OpenClaw/gateway — never runs by default, requires -m e2e_real

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -95,7 +95,7 @@ DEFAULT_TOOL_PROBE_TEMPLATE = (
 )
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture
 def tool_probe_prompt():
     """Builds a prompt + expected verbatim token for the tool-use smoke test.
 

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -87,3 +87,21 @@ def test_client_records_x3(admin_headers):
     finally:
         for r in records:
             _delete_test_client(admin_headers, r["id"])
+
+
+DEFAULT_TOOL_PROBE_TEMPLATE = (
+    "Usa tu herramienta de eco y repite exactamente el siguiente texto, "
+    "sin traducirlo ni modificarlo: {token}"
+)
+
+
+@pytest.fixture(scope="session")
+def tool_probe_prompt():
+    """Builds a prompt + expected verbatim token for the tool-use smoke test.
+
+    Override the phrasing with E2E_TOOL_PROBE_PROMPT_TEMPLATE if the test
+    agent's tool needs a different trigger phrase (must contain '{token}').
+    """
+    template = os.environ.get("E2E_TOOL_PROBE_PROMPT_TEMPLATE", DEFAULT_TOOL_PROBE_TEMPLATE)
+    token = f"E2E-PROBE-{secrets.token_hex(4).upper()}"
+    return template.format(token=token), token

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -45,13 +45,14 @@ def admin_headers() -> dict:
     return {"X-Admin-Token": settings.ADMIN_TOKEN}
 
 
-def _create_test_client(admin_headers: dict, suffix: str) -> dict:
+def _create_test_client(admin_headers: dict, suffix: str, tool_calls_enabled: bool = False) -> dict:
     resp = httpx.post(
         f"{GATEWAY_HTTP_URL}/admin/clients",
         json={
             "name": f"e2e-smoke-{suffix}",
             "client_type": "e2e-test",
             "output_mode": ["text"],
+            "tool_calls_enabled": tool_calls_enabled,
         },
         headers=admin_headers,
         timeout=10.0,
@@ -89,19 +90,11 @@ def test_client_records_x3(admin_headers):
             _delete_test_client(admin_headers, r["id"])
 
 
-DEFAULT_TOOL_PROBE_TEMPLATE = (
-    "Usa tu herramienta de eco y repite exactamente el siguiente texto, "
-    "sin traducirlo ni modificarlo: {token}"
-)
-
-
 @pytest.fixture
-def tool_probe_prompt():
-    """Builds a prompt + expected verbatim token for the tool-use smoke test.
-
-    Override the phrasing with E2E_TOOL_PROBE_PROMPT_TEMPLATE if the test
-    agent's tool needs a different trigger phrase (must contain '{token}').
-    """
-    template = os.environ.get("E2E_TOOL_PROBE_PROMPT_TEMPLATE", DEFAULT_TOOL_PROBE_TEMPLATE)
-    token = f"E2E-PROBE-{secrets.token_hex(4).upper()}"
-    return template.format(token=token), token
+def test_client_record_with_tools(admin_headers):
+    """An ephemeral test client with tool_calls_enabled=True, for the tool-use scenario."""
+    record = _create_test_client(admin_headers, secrets.token_hex(4), tool_calls_enabled=True)
+    try:
+        yield record
+    finally:
+        _delete_test_client(admin_headers, record["id"])

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -1,0 +1,43 @@
+"""Fixtures for tests/e2e — hits the real, already-running production
+jota-gateway + real OpenClaw. Every test here is marked e2e_real and is
+excluded by default (see pytest.ini addopts). Run explicitly with:
+
+    PYTHONPATH=. pytest tests/e2e -m e2e_real -v
+"""
+import os
+
+import pytest
+
+from src.core.config import settings
+
+GATEWAY_HTTP_URL = os.environ.get("E2E_GATEWAY_HTTP_URL", "http://127.0.0.1:8004")
+GATEWAY_WS_URL = os.environ.get("E2E_GATEWAY_WS_URL", "ws://127.0.0.1:8004/ws/stream")
+
+
+def pytest_collection_modifyitems(items):
+    """Force-applies e2e_real to every test collected under tests/e2e/, so a new
+    test file can never accidentally skip the default-exclusion safety net by
+    forgetting its own marker. (pytestmark in a conftest.py would NOT do this —
+    it only marks tests within the conftest's own module, which has none.)"""
+    for item in items:
+        if "tests/e2e/" in item.nodeid:
+            item.add_marker(pytest.mark.e2e_real)
+
+
+@pytest.fixture(scope="session")
+def e2e_agent() -> str:
+    """The dedicated OpenClaw test agent — never a production agent."""
+    agent = os.environ.get("E2E_TEST_AGENT")
+    if not agent:
+        pytest.skip(
+            "E2E_TEST_AGENT no está definida — obligatoria para tests/e2e "
+            "(debe apuntar a un agente de test dedicado en OpenClaw)."
+        )
+    return agent
+
+
+@pytest.fixture(scope="session")
+def admin_headers() -> dict:
+    if not settings.ADMIN_TOKEN:
+        pytest.skip("ADMIN_TOKEN no configurado en el entorno — obligatorio para tests/e2e.")
+    return {"X-Admin-Token": settings.ADMIN_TOKEN}

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -5,7 +5,9 @@ excluded by default (see pytest.ini addopts). Run explicitly with:
     PYTHONPATH=. pytest tests/e2e -m e2e_real -v
 """
 import os
+import secrets
 
+import httpx
 import pytest
 
 from src.core.config import settings
@@ -41,3 +43,47 @@ def admin_headers() -> dict:
     if not settings.ADMIN_TOKEN:
         pytest.skip("ADMIN_TOKEN no configurado en el entorno — obligatorio para tests/e2e.")
     return {"X-Admin-Token": settings.ADMIN_TOKEN}
+
+
+def _create_test_client(admin_headers: dict, suffix: str) -> dict:
+    resp = httpx.post(
+        f"{GATEWAY_HTTP_URL}/admin/clients",
+        json={
+            "name": f"e2e-smoke-{suffix}",
+            "client_type": "e2e-test",
+            "output_mode": ["text"],
+        },
+        headers=admin_headers,
+        timeout=10.0,
+    )
+    resp.raise_for_status()
+    return resp.json()
+
+
+def _delete_test_client(admin_headers: dict, client_id: str) -> None:
+    httpx.delete(
+        f"{GATEWAY_HTTP_URL}/admin/clients/{client_id}",
+        headers=admin_headers,
+        timeout=10.0,
+    )
+
+
+@pytest.fixture
+def test_client_record(admin_headers):
+    """A single ephemeral test client — created before the test, deleted after."""
+    record = _create_test_client(admin_headers, secrets.token_hex(4))
+    try:
+        yield record
+    finally:
+        _delete_test_client(admin_headers, record["id"])
+
+
+@pytest.fixture
+def test_client_records_x3(admin_headers):
+    """Three ephemeral test clients, for the concurrent-sessions scenario."""
+    records = [_create_test_client(admin_headers, secrets.token_hex(4)) for _ in range(3)]
+    try:
+        yield records
+    finally:
+        for r in records:
+            _delete_test_client(admin_headers, r["id"])

--- a/tests/e2e/test_admin_client_lifecycle.py
+++ b/tests/e2e/test_admin_client_lifecycle.py
@@ -1,0 +1,33 @@
+"""Proves the ephemeral test-client fixtures actually create and clean up
+ClientRecords against the real, running Admin API."""
+import httpx
+
+from tests.e2e.conftest import GATEWAY_HTTP_URL
+
+
+def test_single_ephemeral_client_created_and_cleaned_up(test_client_record, admin_headers):
+    client_id = test_client_record["id"]
+    assert test_client_record["client_type"] == "e2e-test"
+
+    resp = httpx.get(f"{GATEWAY_HTTP_URL}/admin/clients/{client_id}", headers=admin_headers)
+    assert resp.status_code == 200, "el cliente efímero debería existir mientras el test corre"
+
+
+def test_three_ephemeral_clients_created_and_cleaned_up(test_client_records_x3, admin_headers):
+    assert len(test_client_records_x3) == 3
+    for record in test_client_records_x3:
+        resp = httpx.get(
+            f"{GATEWAY_HTTP_URL}/admin/clients/{record['id']}", headers=admin_headers
+        )
+        assert resp.status_code == 200
+
+
+def test_cleanup_actually_deletes(admin_headers):
+    """Runs a client through the fixture manually to confirm the finally-block DELETE lands."""
+    from tests.e2e.conftest import _create_test_client, _delete_test_client
+
+    record = _create_test_client(admin_headers, "cleanup-check")
+    _delete_test_client(admin_headers, record["id"])
+
+    resp = httpx.get(f"{GATEWAY_HTTP_URL}/admin/clients/{record['id']}", headers=admin_headers)
+    assert resp.status_code == 404, "el cliente debería haber sido borrado"

--- a/tests/e2e/test_basic_turn.py
+++ b/tests/e2e/test_basic_turn.py
@@ -1,0 +1,16 @@
+"""Validates a full text turn against the real OpenClaw test agent."""
+import pytest
+
+from tests.e2e.ws_helpers import send_turn, ws_handshake
+
+
+async def test_basic_text_turn_gets_a_real_response(test_client_record, e2e_agent):
+    ws, ready = await ws_handshake(test_client_record["client_key"], e2e_agent)
+    try:
+        assert ready["agent"] == e2e_agent
+        result = await send_turn(ws, "Responde solo con la palabra: PONG")
+        assert result["turn_id"] is not None
+        assert len(result["text"].strip()) > 0, "el agente real debería devolver texto no vacío"
+        assert not any(f["type"] == "error" for f in result["frames"]), result["frames"]
+    finally:
+        await ws.close()

--- a/tests/e2e/test_basic_turn.py
+++ b/tests/e2e/test_basic_turn.py
@@ -1,5 +1,4 @@
 """Validates a full text turn against the real OpenClaw test agent."""
-import pytest
 
 from tests.e2e.ws_helpers import send_turn, ws_handshake
 

--- a/tests/e2e/test_cancel.py
+++ b/tests/e2e/test_cancel.py
@@ -1,0 +1,45 @@
+"""Validates that {"type": "cancel"} really reaches chat.abort on the real
+OpenClaw orchestrator, and that a subsequent turn still works normally."""
+import asyncio
+import json
+
+from tests.e2e.ws_helpers import cancel_active_turn, send_turn, ws_handshake
+
+
+async def test_cancel_stops_the_active_turn_on_real_openclaw(test_client_record, e2e_agent):
+    ws, _ready = await ws_handshake(test_client_record["client_key"], e2e_agent)
+    try:
+        await ws.send(json.dumps({
+            "type": "send",
+            "text": "Cuenta lentamente en voz alta del 1 al 100, un número por frase.",
+        }))
+        # Wait for turn_start to confirm the turn is actually running before cancelling.
+        first = json.loads(await asyncio.wait_for(ws.recv(), timeout=10))
+        assert first["type"] == "turn_start"
+        cancelled_turn_id = first["turn_id"]
+
+        await cancel_active_turn(ws)
+
+        # No turn_end (nor interrupted) should ever arrive for the cancelled turn —
+        # drain briefly and assert nothing matches.
+        leftover_frames = []
+        try:
+            while True:
+                raw = await asyncio.wait_for(ws.recv(), timeout=5)
+                leftover_frames.append(json.loads(raw))
+        except asyncio.TimeoutError:
+            pass
+
+        assert not any(
+            f.get("turn_id") == cancelled_turn_id and f["type"] == "turn_end"
+            for f in leftover_frames
+        ), f"turn_end no debería llegar para un turno cancelado: {leftover_frames}"
+
+        # A fresh turn afterwards must complete normally — proves the session
+        # wasn't left in a broken state by the cancellation.
+        result = await send_turn(ws, "Responde solo con la palabra: PONG")
+        assert result["turn_id"] is not None
+        assert result["turn_id"] != cancelled_turn_id
+        assert len(result["text"].strip()) > 0
+    finally:
+        await ws.close()

--- a/tests/e2e/test_concurrent_sessions.py
+++ b/tests/e2e/test_concurrent_sessions.py
@@ -1,0 +1,29 @@
+"""Validates that OpenClawClient's multiplexing keeps concurrent sessions
+isolated: N different clients, same test agent, turns in parallel, each
+gets back its own distinct response without cross-talk."""
+import asyncio
+
+from tests.e2e.ws_helpers import send_turn, ws_handshake
+
+
+async def _run_one_session(client_key: str, agent: str, probe_word: str) -> str:
+    ws, _ready = await ws_handshake(client_key, agent)
+    try:
+        result = await send_turn(ws, f"Responde solo con la palabra: {probe_word}")
+        return result["text"]
+    finally:
+        await ws.close()
+
+
+async def test_three_concurrent_sessions_stay_isolated(test_client_records_x3, e2e_agent):
+    probe_words = ["ALPHA", "BRAVO", "CHARLIE"]
+    tasks = [
+        _run_one_session(record["client_key"], e2e_agent, word)
+        for record, word in zip(test_client_records_x3, probe_words)
+    ]
+    responses = await asyncio.gather(*tasks)
+
+    for word, response in zip(probe_words, responses):
+        assert word in response.upper(), (
+            f"la sesión que pidió '{word}' no la recibió de vuelta: {response!r}"
+        )

--- a/tests/e2e/test_concurrent_sessions.py
+++ b/tests/e2e/test_concurrent_sessions.py
@@ -24,6 +24,13 @@ async def test_three_concurrent_sessions_stay_isolated(test_client_records_x3, e
     responses = await asyncio.gather(*tasks)
 
     for word, response in zip(probe_words, responses):
-        assert word in response.upper(), (
+        response_upper = response.upper()
+        assert word in response_upper, (
             f"la sesión que pidió '{word}' no la recibió de vuelta: {response!r}"
+        )
+        other_words = [w for w in probe_words if w != word]
+        leaked = [w for w in other_words if w in response_upper]
+        assert not leaked, (
+            f"la sesión que pidió '{word}' recibió palabras de otra sesión "
+            f"({leaked}), posible cross-talk: {response!r}"
         )

--- a/tests/e2e/test_marker_safety.py
+++ b/tests/e2e/test_marker_safety.py
@@ -1,0 +1,3 @@
+def test_this_file_is_deselected_by_default():
+    """If this test ever runs under a bare `pytest`, the marker safety net is broken."""
+    assert False, "tests/e2e ran without -m e2e_real — addopts safety net is broken"

--- a/tests/e2e/test_marker_safety.py
+++ b/tests/e2e/test_marker_safety.py
@@ -1,3 +1,0 @@
-def test_this_file_is_deselected_by_default():
-    """If this test ever runs under a bare `pytest`, the marker safety net is broken."""
-    assert False, "tests/e2e ran without -m e2e_real — addopts safety net is broken"

--- a/tests/e2e/test_tool_use.py
+++ b/tests/e2e/test_tool_use.py
@@ -1,0 +1,15 @@
+"""Validates that the real test agent actually invokes its configured tool
+and the tool's result reaches the client — not just plain LLM text."""
+from tests.e2e.ws_helpers import send_turn, ws_handshake
+
+
+async def test_agent_tool_use_reaches_the_client(test_client_record, e2e_agent, tool_probe_prompt):
+    prompt, expected_token = tool_probe_prompt
+    ws, _ready = await ws_handshake(test_client_record["client_key"], e2e_agent)
+    try:
+        result = await send_turn(ws, prompt)
+        assert expected_token in result["text"], (
+            f"el token de prueba de la tool no apareció en la respuesta: {result['text']!r}"
+        )
+    finally:
+        await ws.close()

--- a/tests/e2e/test_tool_use.py
+++ b/tests/e2e/test_tool_use.py
@@ -1,22 +1,34 @@
-"""Validates that the real test agent actually invokes its configured tool
-and the tool's result reaches the client — not just plain LLM text."""
-# LIMITACIÓN CONOCIDA: el prompt incluye el token literal, así que un LLM
-# normal puede pasar este test simplemente repitiéndolo, sin invocar
-# ninguna tool real. Este test valida el pipeline de texto end-to-end,
-# pero NO aísla específicamente el uso de una tool. Pendiente de rediseño
-# cuando se defina la tool determinista real del agente ci-tester (ver
-# memoria del proyecto: oportunidades OpenClaw, idea de surfacing de
-# tool-call events, 2026-07-02).
-from tests.e2e.ws_helpers import send_turn, ws_handshake
+"""Validates that the real test agent actually invokes a real tool (read) and
+that the tool's start/result reach the client as tool_call WS messages — not
+just plain LLM text.
+
+Uses IDENTITY.md, a static bootstrap file that ships in every fresh OpenClaw
+agent workspace (see docs.openclaw.ai — agent-workspace concept). Its content
+is fixed boilerplate the model could not reproduce from memory, so a correct
+'result' payload proves the file was actually read via the tool, not
+hallucinated. Requires the test client to have tool_calls_enabled=True (see
+test_client_record_with_tools fixture) — otherwise the gateway never forwards
+tool_call messages at all (opt-in, see CLAUDE.md).
+"""
+from tests.e2e.ws_helpers import send_turn_until_tool_call, ws_handshake
+
+EXPECTED_IDENTITY_SNIPPET = "This isn't just metadata. It's the start of figuring out who you are."
 
 
-async def test_agent_tool_use_reaches_the_client(test_client_record, e2e_agent, tool_probe_prompt):
-    prompt, expected_token = tool_probe_prompt
-    ws, _ready = await ws_handshake(test_client_record["client_key"], e2e_agent)
+async def test_agent_tool_use_reaches_the_client(test_client_record_with_tools, e2e_agent):
+    ws, _ready = await ws_handshake(test_client_record_with_tools["client_key"], e2e_agent)
     try:
-        result = await send_turn(ws, prompt)
-        assert expected_token in result["text"], (
-            f"el token de prueba de la tool no apareció en la respuesta: {result['text']!r}"
+        result = await send_turn_until_tool_call(
+            ws,
+            "Lee el archivo IDENTITY.md de tu workspace y dime qué pone.",
+        )
+        starts = [tc for tc in result["tool_calls"] if tc["phase"] == "start"]
+        results = [tc for tc in result["tool_calls"] if tc["phase"] == "result"]
+        assert starts, f"no llegó ningún tool_call de fase 'start': {result['frames']}"
+        assert results, f"no llegó ningún tool_call de fase 'result': {result['frames']}"
+        assert results[0]["name"] == "read", f"se esperaba la tool 'read': {results[0]}"
+        assert EXPECTED_IDENTITY_SNIPPET in (results[0]["result"] or ""), (
+            f"el resultado de la tool no contiene el contenido esperado de IDENTITY.md: {results[0]}"
         )
     finally:
         await ws.close()

--- a/tests/e2e/test_tool_use.py
+++ b/tests/e2e/test_tool_use.py
@@ -1,5 +1,12 @@
 """Validates that the real test agent actually invokes its configured tool
 and the tool's result reaches the client — not just plain LLM text."""
+# LIMITACIÓN CONOCIDA: el prompt incluye el token literal, así que un LLM
+# normal puede pasar este test simplemente repitiéndolo, sin invocar
+# ninguna tool real. Este test valida el pipeline de texto end-to-end,
+# pero NO aísla específicamente el uso de una tool. Pendiente de rediseño
+# cuando se defina la tool determinista real del agente ci-tester (ver
+# memoria del proyecto: oportunidades OpenClaw, idea de surfacing de
+# tool-call events, 2026-07-02).
 from tests.e2e.ws_helpers import send_turn, ws_handshake
 
 

--- a/tests/e2e/ws_helpers.py
+++ b/tests/e2e/ws_helpers.py
@@ -26,20 +26,38 @@ async def ws_handshake(client_key: str, agent: str, ws_url: str = GATEWAY_WS_URL
 
 
 async def send_turn(ws, text: str, timeout: float = 60.0) -> dict:
-    """Sends a text turn and collects frames until turn_end or error."""
+    """Sends a text turn and collects frames belonging to that turn until its
+    own turn_end (or a matching/fatal error) arrives.
+
+    Agents that invoke tools (or otherwise produce multi-part replies)
+    routinely emit additional turn_start/turn_end pairs unrelated to this
+    specific message — confirmed live against ci-tester, see
+    docs/client-protocol.md §5. Only the first turn_id observed (the turn
+    triggered by this send) is tracked for `text`/stop purposes; frames
+    belonging to other turn_ids are still recorded in `frames` but ignored
+    otherwise, so a stray turn_end from an unrelated turn can't truncate
+    collection early.
+    """
     await ws.send(json.dumps({"type": "send", "text": text}))
+    loop = asyncio.get_event_loop()
+    deadline = loop.time() + timeout
     tokens = []
     frames = []
     turn_id = None
     while True:
-        raw = await asyncio.wait_for(ws.recv(), timeout=timeout)
+        remaining = deadline - loop.time()
+        if remaining <= 0:
+            raise AssertionError(f"turn_end no llegó en {timeout}s para turn_id={turn_id}: {frames}")
+        raw = await asyncio.wait_for(ws.recv(), timeout=remaining)
         frame = json.loads(raw)
         frames.append(frame)
-        if frame["type"] == "turn_start":
+        if frame["type"] == "turn_start" and turn_id is None:
             turn_id = frame["turn_id"]
-        elif frame["type"] == "token":
+        elif frame["type"] == "token" and frame.get("turn_id") == turn_id:
             tokens.append(frame["text"])
-        elif frame["type"] in ("turn_end", "error"):
+        elif frame["type"] == "turn_end" and frame.get("turn_id") == turn_id:
+            break
+        elif frame["type"] == "error" and (frame.get("turn_id") == turn_id or frame.get("fatal")):
             break
     return {"turn_id": turn_id, "text": "".join(tokens), "frames": frames}
 

--- a/tests/e2e/ws_helpers.py
+++ b/tests/e2e/ws_helpers.py
@@ -46,3 +46,34 @@ async def send_turn(ws, text: str, timeout: float = 60.0) -> dict:
 
 async def cancel_active_turn(ws) -> None:
     await ws.send(json.dumps({"type": "cancel"}))
+
+
+async def send_turn_until_tool_call(ws, text: str, timeout: float = 100.0) -> dict:
+    """Sends a text turn and collects frames until a tool_call event with
+    phase == "result" arrives, or error, or the timeout elapses.
+
+    Unlike send_turn(), this does NOT assume one turn per message: agents that
+    invoke tools routinely chain several turn_start/turn_end pairs for a
+    single user message (tool invocation, intermediate replies, final text),
+    per docs/client-protocol.md §5. Requires the client to have
+    tool_calls_enabled=True (see test_client_record_with_tools fixture).
+    """
+    await ws.send(json.dumps({"type": "send", "text": text}))
+    loop = asyncio.get_event_loop()
+    deadline = loop.time() + timeout
+    frames = []
+    tool_calls = []
+    while True:
+        remaining = deadline - loop.time()
+        if remaining <= 0:
+            raise AssertionError(f"No llegó ningún tool_call 'result' en {timeout}s: {frames}")
+        raw = await asyncio.wait_for(ws.recv(), timeout=remaining)
+        frame = json.loads(raw)
+        frames.append(frame)
+        if frame["type"] == "tool_call":
+            tool_calls.append(frame)
+            if frame["phase"] == "result":
+                break
+        elif frame["type"] == "error":
+            break
+    return {"tool_calls": tool_calls, "frames": frames}

--- a/tests/e2e/ws_helpers.py
+++ b/tests/e2e/ws_helpers.py
@@ -42,3 +42,7 @@ async def send_turn(ws, text: str, timeout: float = 60.0) -> dict:
         elif frame["type"] in ("turn_end", "error"):
             break
     return {"turn_id": turn_id, "text": "".join(tokens), "frames": frames}
+
+
+async def cancel_active_turn(ws) -> None:
+    await ws.send(json.dumps({"type": "cancel"}))

--- a/tests/e2e/ws_helpers.py
+++ b/tests/e2e/ws_helpers.py
@@ -1,0 +1,44 @@
+"""Real WebSocket client helpers for tests/e2e — talk to the actual
+/ws/stream endpoint of the running production gateway, same wire protocol
+documented in docs/client-protocol.md."""
+import asyncio
+import json
+
+import websockets
+
+from tests.e2e.conftest import GATEWAY_WS_URL
+
+
+async def ws_handshake(client_key: str, agent: str, ws_url: str = GATEWAY_WS_URL, input_mode: str = "text"):
+    ws = await websockets.connect(ws_url, open_timeout=10)
+    await ws.send(json.dumps({
+        "client_key": client_key,
+        "input_mode": input_mode,
+        "output_mode": ["text"],
+        "agent": agent,
+    }))
+    raw = await asyncio.wait_for(ws.recv(), timeout=10)
+    ready = json.loads(raw)
+    if ready.get("type") != "ready":
+        await ws.close()
+        raise AssertionError(f"Handshake falló, esperaba 'ready': {ready}")
+    return ws, ready
+
+
+async def send_turn(ws, text: str, timeout: float = 60.0) -> dict:
+    """Sends a text turn and collects frames until turn_end or error."""
+    await ws.send(json.dumps({"type": "send", "text": text}))
+    tokens = []
+    frames = []
+    turn_id = None
+    while True:
+        raw = await asyncio.wait_for(ws.recv(), timeout=timeout)
+        frame = json.loads(raw)
+        frames.append(frame)
+        if frame["type"] == "turn_start":
+            turn_id = frame["turn_id"]
+        elif frame["type"] == "token":
+            tokens.append(frame["text"])
+        elif frame["type"] in ("turn_end", "error"):
+            break
+    return {"turn_id": turn_id, "text": "".join(tokens), "frames": frames}


### PR DESCRIPTION
## Summary
- Adds `tests/e2e/` — a manually-triggered, tightly-gated E2E suite that exercises the real jota-gateway + real OpenClaw orchestrator (same production instance), never mocks. Never runs automatically: excluded by default via the `e2e_real` pytest marker (`addopts = -m "not e2e_real"`), and isolated from the normal CI (`test.yml` unaffected).
- Scenarios: ephemeral test-client lifecycle (Admin API), basic text turn, cancellation, 3 concurrent sessions, and real tool-use (validates the `tool_call` WS message from #70 actually reaches the client for a real `read` tool invocation).
- Gated `workflow_dispatch`-only GitHub Actions workflow (`.github/workflows/e2e-real-smoke.yml`) for future manual runs against a dedicated self-hosted runner + GitHub Environment with required-reviewer approval — infra setup (runner, environment, `E2E_TEST_AGENT` variable) is a manual, out-of-repo prerequisite documented in the README.
- README section documenting prerequisites and local usage.

No GitHub issue — implemented from `docs/superpowers/plans/2026-07-01-e2e-real-smoke-test.md` (local plan, not committed).

## Live verification (this is the important part)

Every scenario was run repeatedly against the actual running production gateway + real OpenClaw + the dedicated `ci-tester` test agent, not just collected/linted:

- `PYTHONPATH=. E2E_TEST_AGENT=ci-tester pytest tests/e2e -m e2e_real -v` → **3 consecutive clean runs, 21/21 passed**.
- Along the way, live verification surfaced and led to fixing two real bugs unrelated to this branch's original scope, already merged separately: PR #70 (turn-completion + tool_call surfacing) and PR #71 (agents.list roster fetch) — this suite is what proved both were actually needed and confirmed the fixes work end-to-end.
- The tool-use scenario was redesigned mid-session: the original probe asked the agent to use a nonexistent "echo" tool, so it never proved real tool invocation. Replaced with asking `ci-tester` to read `IDENTITY.md` (a real file it can actually access via its `read` tool) and asserting on the `tool_call` WS messages directly (`phase="start"` → `phase="result"` with the file's real content).
- Also found and fixed a real bug in the test suite's own WS helper (`send_turn()`): it broke on the *first* `turn_end` frame regardless of `turn_id`, but agents that invoke tools routinely chain multiple `turn_start`/`turn_end` pairs per user message (confirmed live). A stray turn ending early truncated collection of the real turn's tokens mid-word (reproduced twice: an empty response in the tool-use test, `"CHARL"` instead of `"CHARLIE"` in the concurrent-sessions test). Fixed by tracking only the first `turn_id` observed and ignoring frames from unrelated turns.

## Test plan
- [x] `PYTHONPATH=. pytest` (bare, no args) → tests/e2e never runs (marker safety net holds), 282 passed.
- [x] `ruff check src/ tests/` → clean.
- [x] `PYTHONPATH=. E2E_TEST_AGENT=ci-tester pytest tests/e2e -m e2e_real -v` → 3x consecutive clean runs, 21/21 passed, against real production infra.
- [ ] Runner/Environment/variable setup (Task 8 operator steps) — manual, out-of-repo, not part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)