### PR TITLE
docs: point to the openclaw skill as source of truth for protocol drift

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -256,6 +256,23 @@ OpenClaw connection details (loopback backend mode, no device signature required
 - Token: `OPENCLAW_TOKEN`
 - Port: `OPENCLAW_PORT` (default 18789)
 
+**Keep the OpenClaw protocol knowledge base in sync.** OpenClaw's wire protocol drifts between
+minor server versions with no changelog (the `agents.list`/`chat.state=="final"` breaks above
+were both discovered live, by accident, not from release notes). The canonical write-up of the
+wire protocol — including every drift found so far — lives in the `openclaw` skill at
+`~/.claude/skills/openclaw/references/protocol.md` (see also `tools.md`, `config-schema.md`,
+`green-house.md` in that same directory), **not** in this file. Whenever you discover a new
+protocol change, inconsistency, or undocumented event shape while working on this codebase
+(via raw-frame capture, a failing assumption, a hanging turn, etc.):
+1. Update `protocol.md` (or the relevant sibling doc) with what you found, dated, including the
+   server version if known — follow the existing "Breaking change — vX.Y.Z" style for anything
+   that silently breaks old client code.
+2. Only mirror the parts of that finding that are specific to *this repo's* implementation here
+   in `CLAUDE.md` (as done above for `agents.list` and turn-completion) — the skill doc is the
+   source of truth for the protocol itself, this file is for how jota-gateway's code responds to it.
+Skipping this is how the same drift gets silently re-discovered (and re-debugged from scratch)
+in a future session.
+
 ---
 
 ## Admin API authentication


### PR DESCRIPTION
## Summary
- Adds a standing instruction to `CLAUDE.md`: whenever a new OpenClaw protocol change/inconsistency is discovered while working on this codebase, update `~/.claude/skills/openclaw/references/protocol.md` (the canonical write-up), not just the jota-gateway-specific consequence in this file.
- Prompted by two silent protocol breaks found by accident this session (agents.list roster fetch — #71, chat.state=="final" turn completion — #70) that cost real debugging time and weren't written down anywhere durable.
- `protocol.md` itself already updated separately (it's outside this repo, in `~/.claude/skills/`, not git-tracked) with both breaks, a new `session.tool` event section, and the multi-turn-per-message nuance discovered while building the E2E suite (#74).

No GitHub issue — documentation housekeeping.

## Test plan
- [x] Doc-only change, no code touched.
- [x] Proofread the added section for accuracy against what's already documented elsewhere in `CLAUDE.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)