### PR TITLE
chore(deps): update sqlmodel requirement from >=0.0.22 to >=0.0.39

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,5 +10,5 @@ pytest>=9.1.1,<9.2.0
 pytest-asyncio>=1.3.0,<1.4.0
 respx>=0.23.1
 ruff>=0.15.20
-sqlmodel>=0.0.22
+sqlmodel>=0.0.39
 alembic>=1.18.5


### PR DESCRIPTION
Resolves conflict with merged PRs #79, #81 by taking newer versions of ruff and alembic from main and applying only the sqlmodel bump.