### PR TITLE
feat: require auth for /v1/* from untrusted origins (issue #52)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,7 +37,7 @@ jota-gateway is a **BFF (Backend For Frontend)** — the single entry point for 
 
 - **WebSocket** `/ws/stream` — full voice+text session managed by `JotaBridge`
 - **Admin REST** `/admin/*` — client CRUD + observability (sessions, orchestrators); requires `X-Admin-Token`
-- **OpenAI-compatible REST** `/v1/*` — `GET /v1/models` and `POST /v1/chat/completions` for Home Assistant integration; delegates to the singleton `OpenClawClient`
+- **OpenAI-compatible REST** `/v1/*` — `GET /v1/models` and `POST /v1/chat/completions` for Home Assistant integration; delegates to the singleton `OpenClawClient`. Requests from a trusted origin (loopback and/or `TRUSTED_NETWORKS`) need no auth; anyone else must send `Authorization: Bearer <client_key>`, validated against the same `ClientRecord` table the WS handshake uses (`src/core/network.py`, `resolve_ha_caller` in `src/api/openai_routes.py`) — see issue #52.
 - **Health** `/healthz`, `/ready` — liveness and readiness probes
 
 There is no longer any dependency on `jota-db`. Client identity and configuration live in the local SQLite database (`data/gateway.db`).
@@ -47,6 +47,10 @@ There is no longer any dependency on `jota-db`. Client identity and configuratio
 ```
 DATABASE_URL=sqlite:///data/gateway.db   # path to SQLite file
 ADMIN_TOKEN=<secret>                     # required for /admin/* routes
+
+TRUST_LOOPBACK=true                      # 127.0.0.1/::1 exempt from /v1/* auth
+TRUSTED_NETWORKS=                        # CSV of CIDRs exempt from /v1/* auth, e.g. 192.168.1.0/24. Empty = fail-closed.
+TRUSTED_PROXIES=127.0.0.1,::1            # CSV of IPs/CIDRs allowed to set X-Real-IP for /v1/*
 
 TRANSCRIBER_WS_URL=localhost:9000
 TTS_WS_URL=localhost:8005
@@ -281,7 +285,7 @@ in a future session.
 
 All `/admin/*` routes use `Depends(get_admin_auth)` (`src/api/deps.py`), which reads the `X-Admin-Token` header and compares it against `settings.ADMIN_TOKEN`. Returns 422 if the header is missing, 401 if wrong, 503 if `ADMIN_TOKEN` is not configured.
 
-The `/v1/*` routes have **no auth** — they are exposed only on LAN via nginx.
+The `/v1/*` routes use `Depends(resolve_ha_caller)` (`src/api/openai_routes.py`) instead — see `src/core/network.py` and the trusted-origin bullet under Architecture above (issue #52).
 
 ---
 

--- a/src/api/openai_routes.py
+++ b/src/api/openai_routes.py
@@ -2,11 +2,17 @@ import asyncio
 import json
 import uuid
 import logging
-from fastapi import APIRouter, Request
+from dataclasses import dataclass
+
+from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import StreamingResponse, JSONResponse
 from pydantic import BaseModel
 
+from src.core.exceptions import ClientInactive, ClientNotFound
+from src.core.network import is_trusted_origin, resolve_client_ip
 from src.core.session_key import make_session_key
+from src.models.schemas import Client, ClientConfig
+from src.services.db_client import db_client
 from src.services.orchestration import call_orchestrator
 from src.services.pipeline_tracker import PipelineTracker, _NullWS
 
@@ -26,8 +32,45 @@ class _ChatCompletionRequest(BaseModel):
     model: str = ""
 
 
+@dataclass
+class HACaller:
+    """Identidad resuelta para un caller de /v1/*.
+
+    client/config son None en el path legacy (origen de red confiable,
+    sin Authorization) — preserva el comportamiento histórico fijo "ha".
+    """
+    client: Client | None
+    config: ClientConfig | None
+
+
+async def resolve_ha_caller(request: Request) -> HACaller:
+    """Dependency de auth para /v1/*.
+
+    - Authorization: Bearer <client_key> presente -> valida contra la BD
+      (igual que el handshake WS). Aplica siempre, sin importar el origen.
+    - Sin Authorization -> exige que el origen (ver resolve_client_ip) sea
+      confiable (loopback y/o TRUSTED_NETWORKS); si no, 401.
+    """
+    auth = request.headers.get("authorization")
+    if auth:
+        if not auth.startswith("Bearer "):
+            raise HTTPException(status_code=401, detail="authentication required")
+        client_key = auth[len("Bearer "):]
+        try:
+            client, config = await db_client.get_session(client_key)
+        except (ClientNotFound, ClientInactive):
+            raise HTTPException(status_code=401, detail="authentication required")
+        return HACaller(client=client, config=config)
+
+    ip = resolve_client_ip(request)
+    if is_trusted_origin(ip):
+        return HACaller(client=None, config=None)
+
+    raise HTTPException(status_code=401, detail="authentication required")
+
+
 @router.get("/models")
-async def list_models(request: Request):
+async def list_models(request: Request, caller: HACaller = Depends(resolve_ha_caller)):
     return JSONResponse({
         "object": "list",
         "data": [{"id": "jota-gateway", "object": "model", "created": 0, "owned_by": "jota-gateway"}],
@@ -41,10 +84,10 @@ def _extract_last_user_message(messages: list[_ChatMessage]) -> str:
     return ""
 
 
-def _make_http_tracker(session_id: str, registry) -> PipelineTracker:
+def _make_http_tracker(session_id: str, registry, client_id: str) -> PipelineTracker:
     return PipelineTracker(
         session_id=session_id,
-        client_id="ha",
+        client_id=client_id,
         input_mode="text",
         output_mode=[],
         client_ws=_NullWS(),
@@ -53,16 +96,28 @@ def _make_http_tracker(session_id: str, registry) -> PipelineTracker:
 
 
 @router.post("/chat/completions")
-async def chat_completions(request: Request, body: _ChatCompletionRequest):
+async def chat_completions(
+    request: Request,
+    body: _ChatCompletionRequest,
+    caller: HACaller = Depends(resolve_ha_caller),
+):
     text = _extract_last_user_message(body.messages)
     stream = body.stream
     orchestrator = request.app.state.openclaw
     session_registry = request.app.state.session_registry
     completion_id = f"chatcmpl-{uuid.uuid4().hex[:12]}"
     default_agent = orchestrator.gateway_info.default_agent_id if orchestrator.gateway_info else "main"
-    session_key = make_session_key(default_agent, "ha")
 
-    tracker = _make_http_tracker(f"http:{completion_id}", session_registry)
+    if caller.client is not None:
+        client_id = caller.client.id
+        system_prompt_extra = caller.config.system_prompt_extra
+    else:
+        client_id = "ha"
+        system_prompt_extra = None
+
+    session_key = make_session_key(default_agent, client_id)
+
+    tracker = _make_http_tracker(f"http:{completion_id}", session_registry, client_id)
     session_registry.register(tracker)
 
     if stream:
@@ -80,7 +135,8 @@ async def chat_completions(request: Request, body: _ChatCompletionRequest):
             async def _run():
                 try:
                     await call_orchestrator(
-                        orchestrator, text, session_key, "ha",
+                        orchestrator, text, session_key, client_id,
+                        system_prompt_extra=system_prompt_extra,
                         tracker=tracker, on_token=_on_token,
                     )
                 except RuntimeError as e:
@@ -124,7 +180,8 @@ async def chat_completions(request: Request, body: _ChatCompletionRequest):
     orchestrator_error: Exception | None = None
     try:
         await call_orchestrator(
-            orchestrator, text, session_key, "ha",
+            orchestrator, text, session_key, client_id,
+            system_prompt_extra=system_prompt_extra,
             tracker=tracker, on_token=_on_token,
         )
     except RuntimeError as e:

--- a/src/core/config.py
+++ b/src/core/config.py
@@ -10,6 +10,11 @@ class Settings(BaseSettings):
     # Admin API
     ADMIN_TOKEN: str = ""
 
+    # /v1/* trusted-origin auth (issue #52)
+    TRUST_LOOPBACK: bool = True
+    TRUSTED_NETWORKS: str = ""              # CSV of CIDRs, e.g. "192.168.1.0/24". Empty = only loopback trusted.
+    TRUSTED_PROXIES: str = "127.0.0.1,::1"  # CSV of IPs/CIDRs allowed to set X-Real-IP
+
     # Servicios externos
     TRANSCRIBER_WS_URL: str = "localhost:9000"
     TTS_WS_URL: str = "localhost:8005"

--- a/src/core/network.py
+++ b/src/core/network.py
@@ -1,0 +1,78 @@
+"""
+network.py
+~~~~~~~~~~
+Resolución de origen de red confiable para /v1/*.
+
+is_trusted_origin(ip)   -> bool  — ip exenta de auth (loopback y/o TRUSTED_NETWORKS)
+resolve_client_ip(req)  -> str   — IP real a evaluar, respetando X-Real-IP
+                                    solo cuando el peer TCP es un proxy confiable
+"""
+import ipaddress
+import logging
+
+from fastapi import Request
+
+from src.core.config import settings
+
+logger = logging.getLogger(__name__)
+
+_IpNetwork = ipaddress.IPv4Network | ipaddress.IPv6Network
+
+
+def _parse_networks(csv: str) -> list[_IpNetwork]:
+    networks: list[_IpNetwork] = []
+    for raw in csv.split(","):
+        raw = raw.strip()
+        if not raw:
+            continue
+        try:
+            networks.append(ipaddress.ip_network(raw, strict=False))
+        except ValueError:
+            logger.warning(f"Ignoring invalid CIDR/IP in network config: {raw!r}")
+    return networks
+
+
+def _ip_in_networks(ip_str: str, networks: list[_IpNetwork]) -> bool:
+    try:
+        ip = ipaddress.ip_address(ip_str)
+    except ValueError:
+        return False
+    return any(ip in net for net in networks)
+
+
+def is_trusted_proxy(ip_str: str) -> bool:
+    """True if ip_str is allowed to set X-Real-IP (settings.TRUSTED_PROXIES)."""
+    return _ip_in_networks(ip_str, _parse_networks(settings.TRUSTED_PROXIES))
+
+
+def is_trusted_origin(ip_str: str) -> bool:
+    """True if ip_str is exempt from /v1/* auth (loopback and/or TRUSTED_NETWORKS)."""
+    try:
+        ip = ipaddress.ip_address(ip_str)
+    except ValueError:
+        return False
+    if settings.TRUST_LOOPBACK and ip.is_loopback:
+        return True
+    return _ip_in_networks(ip_str, _parse_networks(settings.TRUSTED_NETWORKS))
+
+
+def resolve_client_ip(request: Request) -> str:
+    """
+    Returns the IP to evaluate with is_trusted_origin().
+
+    If the immediate TCP peer is a trusted proxy (settings.TRUSTED_PROXIES),
+    trust X-Real-IP if present. Otherwise the peer connected directly — use
+    its address as-is and ignore any X-Real-IP it sends.
+    """
+    peer = request.client.host if request.client else ""
+
+    if is_trusted_proxy(peer):
+        real_ip = request.headers.get("x-real-ip")
+        return real_ip if real_ip else peer
+
+    if request.headers.get("x-real-ip"):
+        logger.warning(
+            f"Ignoring X-Real-IP header from untrusted peer {peer!r} "
+            "(possible spoofing attempt)"
+        )
+    return peer

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -161,9 +161,7 @@ def mock_registry(mock_orchestrator):
     return make_mock_registry(mock_orchestrator)
 
 
-@pytest.fixture
-def client(mock_services, mock_registry, seed_client, monkeypatch):
-    """TestClient con SQLite en memoria y orchestrator mock inyectado."""
+def _configure_app_mocks(mock_registry, monkeypatch):
     monkeypatch.setattr("src.main.ReconnectingOpenClawClient", lambda *a, **kw: mock_registry)
     monkeypatch.setattr("src.main.OpenClawClient", lambda *a, **kw: MagicMock())
     monkeypatch.setattr("src.main.FrameDispatcher", lambda *a, **kw: MagicMock())
@@ -171,10 +169,35 @@ def client(mock_services, mock_registry, seed_client, monkeypatch):
     monkeypatch.setattr("src.main.ClientRegistry", lambda: ClientRegistry())
     mock_registry.connect = AsyncMock()
     mock_registry.close = AsyncMock()
-    with TestClient(app) as c:
+
+
+@pytest.fixture
+def client(mock_services, mock_registry, seed_client, monkeypatch):
+    """TestClient con SQLite en memoria y orchestrator mock inyectado.
+
+    client=("127.0.0.1", 50000): peer loopback, para que /v1/* (ver
+    src/core/network.py) se comporte igual que en el despliegue doméstico
+    real sin exigir Authorization en cada test existente.
+    """
+    _configure_app_mocks(mock_registry, monkeypatch)
+    with TestClient(app, client=("127.0.0.1", 50000)) as c:
+        yield c
+
+
+@pytest.fixture
+def client_untrusted(mock_services, mock_registry, seed_client, monkeypatch):
+    """TestClient cuyo peer TCP no es loopback ni está en TRUSTED_NETWORKS
+    (203.0.113.5 es TEST-NET-3, RFC 5737 — rango reservado para documentación)."""
+    _configure_app_mocks(mock_registry, monkeypatch)
+    with TestClient(app, client=("203.0.113.5", 54321)) as c:
         yield c
 
 
 @pytest.fixture
 def auth_headers():
     return {"x-api-key": VALID_KEY}
+
+
+@pytest.fixture
+def ha_bearer_headers():
+    return {"authorization": f"Bearer {VALID_KEY}"}

--- a/tests/integration/test_rest_openai.py
+++ b/tests/integration/test_rest_openai.py
@@ -1,6 +1,8 @@
 # tests/integration/test_rest_openai.py
 from src.services.protocol import OrchestratorEvent
 from src.main import app
+from src.core.config import settings
+from tests.integration.conftest import CLIENT_ID
 
 
 def test_get_models_returns_list(client):
@@ -237,3 +239,118 @@ def test_http_session_appears_in_registry(client):
     http_sessions = [s for s in sessions if s.session_id.startswith("http:")]
     assert len(http_sessions) >= 1
     assert http_sessions[0].client_id == "ha"
+
+
+def test_get_models_from_trusted_loopback_passes(client):
+    r = client.get("/v1/models")
+    assert r.status_code == 200
+
+
+def test_get_models_from_untrusted_origin_without_auth_returns_401(client_untrusted):
+    r = client_untrusted.get("/v1/models")
+    assert r.status_code == 401
+
+
+def test_chat_completions_from_untrusted_origin_without_auth_returns_401(client_untrusted):
+    r = client_untrusted.post("/v1/chat/completions", json={
+        "model": "openclaw",
+        "messages": [{"role": "user", "content": "Hola"}],
+        "stream": False,
+    })
+    assert r.status_code == 401
+
+
+def test_chat_completions_from_untrusted_origin_with_valid_key_passes(client_untrusted, ha_bearer_headers):
+    r = client_untrusted.post(
+        "/v1/chat/completions",
+        json={"model": "openclaw", "messages": [{"role": "user", "content": "Hola"}], "stream": False},
+        headers=ha_bearer_headers,
+    )
+    assert r.status_code == 200
+    assert r.json()["choices"][0]["message"]["content"] == "Hola"
+
+
+def test_chat_completions_with_valid_key_uses_real_client_session_key(client_untrusted, ha_bearer_headers, mock_registry):
+    from src.core.session_key import make_session_key
+    captured = {}
+
+    async def _stream(text, user_id, model_id=None, system_prompt_extra=None, session_key=None):
+        captured["session_key"] = session_key
+        captured["user_id"] = user_id
+        yield OrchestratorEvent(type="token", content="ok")
+        yield OrchestratorEvent(type="status", content="done")
+
+    mock_registry.stream_response = _stream
+
+    client_untrusted.post(
+        "/v1/chat/completions",
+        json={"model": "openclaw", "messages": [{"role": "user", "content": "test"}], "stream": False},
+        headers=ha_bearer_headers,
+    )
+
+    expected = make_session_key("main", CLIENT_ID)
+    assert captured.get("session_key") == expected
+    assert captured.get("user_id") == CLIENT_ID
+
+
+def test_chat_completions_with_invalid_key_returns_401_even_from_loopback(client):
+    r = client.post(
+        "/v1/chat/completions",
+        json={"model": "openclaw", "messages": [{"role": "user", "content": "Hola"}], "stream": False},
+        headers={"authorization": "Bearer not-a-real-key"},
+    )
+    assert r.status_code == 401
+
+
+def test_chat_completions_with_inactive_client_key_returns_401(client, db_engine):
+    from sqlmodel import Session
+    from src.db.models import ClientRecord
+
+    with Session(db_engine) as s:
+        s.add(ClientRecord(
+            id="inactive-client",
+            name="Inactive",
+            client_key="inactive-key",
+            is_active=False,
+        ))
+        s.commit()
+
+    r = client.post(
+        "/v1/chat/completions",
+        json={"model": "openclaw", "messages": [{"role": "user", "content": "Hola"}], "stream": False},
+        headers={"authorization": "Bearer inactive-key"},
+    )
+    assert r.status_code == 401
+
+
+def test_chat_completions_x_real_ip_alone_does_not_grant_trust(client, monkeypatch):
+    """Peer is 127.0.0.1 (a trusted proxy), so X-Real-IP is read — but the IP it
+    names (203.0.113.9) still isn't in TRUSTED_NETWORKS, so it must still fail."""
+    monkeypatch.setattr(settings, "TRUSTED_NETWORKS", "")
+    r = client.post(
+        "/v1/chat/completions",
+        json={"model": "openclaw", "messages": [{"role": "user", "content": "Hola"}], "stream": False},
+        headers={"x-real-ip": "203.0.113.9"},
+    )
+    assert r.status_code == 401
+
+
+def test_chat_completions_trusts_x_real_ip_within_trusted_networks(client, monkeypatch):
+    monkeypatch.setattr(settings, "TRUSTED_NETWORKS", "192.168.50.0/24")
+    r = client.post(
+        "/v1/chat/completions",
+        json={"model": "openclaw", "messages": [{"role": "user", "content": "Hola"}], "stream": False},
+        headers={"x-real-ip": "192.168.50.7"},
+    )
+    assert r.status_code == 200
+
+
+def test_chat_completions_ignores_x_real_ip_from_untrusted_peer(client_untrusted):
+    """client_untrusted's peer (203.0.113.5) is not in TRUSTED_PROXIES, so a
+    spoofed X-Real-IP claiming to be loopback must be ignored."""
+    r = client_untrusted.post(
+        "/v1/chat/completions",
+        json={"model": "openclaw", "messages": [{"role": "user", "content": "Hola"}], "stream": False},
+        headers={"x-real-ip": "127.0.0.1"},
+    )
+    assert r.status_code == 401

--- a/tests/unit/test_network.py
+++ b/tests/unit/test_network.py
@@ -1,0 +1,66 @@
+import pytest
+
+from src.core.config import settings
+from src.core.network import is_trusted_origin, is_trusted_proxy, resolve_client_ip
+
+
+class _FakeClient:
+    def __init__(self, host):
+        self.host = host
+
+
+class _FakeRequest:
+    def __init__(self, host, headers=None):
+        self.client = _FakeClient(host)
+        self.headers = headers or {}
+
+
+@pytest.fixture(autouse=True)
+def _reset_network_settings(monkeypatch):
+    monkeypatch.setattr(settings, "TRUST_LOOPBACK", True)
+    monkeypatch.setattr(settings, "TRUSTED_NETWORKS", "")
+    monkeypatch.setattr(settings, "TRUSTED_PROXIES", "127.0.0.1,::1")
+
+
+def test_loopback_trusted_by_default():
+    assert is_trusted_origin("127.0.0.1") is True
+    assert is_trusted_origin("::1") is True
+
+
+def test_loopback_untrusted_when_disabled(monkeypatch):
+    monkeypatch.setattr(settings, "TRUST_LOOPBACK", False)
+    assert is_trusted_origin("127.0.0.1") is False
+
+
+def test_ip_in_trusted_networks_is_trusted(monkeypatch):
+    monkeypatch.setattr(settings, "TRUSTED_NETWORKS", "192.168.1.0/24")
+    assert is_trusted_origin("192.168.1.42") is True
+
+
+def test_ip_outside_trusted_networks_is_untrusted(monkeypatch):
+    monkeypatch.setattr(settings, "TRUSTED_NETWORKS", "192.168.1.0/24")
+    assert is_trusted_origin("203.0.113.5") is False
+
+
+def test_malformed_ip_is_untrusted():
+    assert is_trusted_origin("testclient") is False
+
+
+def test_is_trusted_proxy_matches_default_loopback():
+    assert is_trusted_proxy("127.0.0.1") is True
+    assert is_trusted_proxy("203.0.113.5") is False
+
+
+def test_resolve_client_ip_honors_x_real_ip_from_trusted_proxy():
+    request = _FakeRequest("127.0.0.1", headers={"x-real-ip": "192.168.1.50"})
+    assert resolve_client_ip(request) == "192.168.1.50"
+
+
+def test_resolve_client_ip_ignores_x_real_ip_from_untrusted_peer():
+    request = _FakeRequest("203.0.113.5", headers={"x-real-ip": "127.0.0.1"})
+    assert resolve_client_ip(request) == "203.0.113.5"
+
+
+def test_resolve_client_ip_falls_back_to_peer_when_no_header():
+    request = _FakeRequest("127.0.0.1")
+    assert resolve_client_ip(request) == "127.0.0.1"


### PR DESCRIPTION
## Summary
- Gate `GET /v1/models` and `POST /v1/chat/completions` so untrusted callers must authenticate with a `client_key`, while trusted-network callers (loopback and/or an operator-configured `TRUSTED_NETWORKS` LAN range) keep today's zero-config behavior.
- New `src/core/network.py` resolves the real client IP (trusting `X-Real-IP` only from a configured set of proxy IPs) and checks it against the trusted-origin allowlist.
- New `resolve_ha_caller` FastAPI dependency in `src/api/openai_routes.py` authenticates a `client_key` from the `Authorization` header (same mechanism as the WS handshake) or falls back to the trusted-origin check. A present-but-invalid key is always rejected, even from a trusted origin.

Closes #52

## Test plan
- [x] `PYTHONPATH=. pytest tests/unit/test_network.py -v` — 9/9 passed
- [x] `PYTHONPATH=. pytest tests/integration/test_rest_openai.py -v` — 24/24 passed (all pre-existing tests unmodified)
- [x] `PYTHONPATH=. pytest` — full suite, 332 passed
- [x] `ruff check src/ tests/` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
