### PR TITLE
docs: document Transcriber/TTS reconnection system (follow-up to #88)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,6 +63,12 @@ OPENCLAW_TOKEN=<secret>
 ORCHESTRATOR_RECONNECT_INITIAL_BACKOFF=1.0
 ORCHESTRATOR_RECONNECT_MAX_BACKOFF=60.0
 ORCHESTRATOR_RECONNECT_MAX_DURATION=300.0
+
+TRANSCRIBER_RECONNECT_INITIAL_BACKOFF=1.0
+TRANSCRIBER_RECONNECT_MAX_BACKOFF=60.0
+TRANSCRIBER_RECONNECT_MAX_DURATION=300.0
+TTS_RECONNECT_INITIAL_BACKOFF=1.0
+TTS_RECONNECT_MAX_BACKOFF=60.0
 ```
 
 All service addresses are `host:port` **without protocol**. Each client injects the protocol itself (`http://`, `ws://`).
@@ -190,10 +196,10 @@ The singleton `db_client = DbClient()` is imported from this module everywhere. 
 2. Gateway resolves identity via `db_client.get_session(client_key)` → `(Client, ClientConfig)`.
    - `ClientNotFound` or `ClientInactive` → close 1008.
 3. If `agent` is specified, `routes.py` validates it against `openclaw.gateway_info.has_agent(agent)` — unknown agents close with code 1008.
-4. `JotaBridge` is instantiated with client, config, WebSocket, the singleton `ReconnectingOpenClawClient` (from `app.state.openclaw`), `app.state.client_registry`, and `default_agent`.
-5. `bridge.connect_internal_services()` — starts `TranscriberClient` only if `input_mode == "audio"`; registers the bridge in `ClientRegistry`.
-6. `bridge.health_check()` — pings each microservice; orchestrator failure is fatal, TTS failure is degraded.
-7. `bridge.run()` — launches concurrent tasks: `_client_input_loop` + transcriber `listen_loop` + silence watchdog.
+4. `JotaBridge` is instantiated with client, config, WebSocket, the singleton `ReconnectingOpenClawClient` (from `app.state.openclaw`), the singleton `ReconnectingTTSClient` (from `app.state.tts`), `app.state.client_registry`, and `default_agent`.
+5. `bridge.connect_internal_services()` — starts a `ReconnectingTranscriberClient` only if `input_mode == "audio"`; registers the bridge in `ClientRegistry`. `ReconnectingTranscriberClient.connect()` never raises — a failed initial connect just leaves it in `RECONNECTING` state for `health_check()`/the background `run()` loop to handle, it no longer aborts session setup.
+6. `bridge.health_check()` — pings each microservice; **only the orchestrator is fatal** (its failure returns `False`, closing the WebSocket with code 1011 before `ready` is ever sent). Transcriber and TTS failures are both non-fatal — the session opens normally and the client is notified via `status` messages (see "Service reconnection" below).
+7. `bridge.run()` — launches concurrent tasks: `_client_input_loop` + `transcriber.run()` (listen + background reconnect) + silence watchdog.
 
 ### JotaBridge data flow
 
@@ -215,7 +221,8 @@ The singleton `db_client = DbClient()` is imported from this module everywhere. 
 
 - Polls every 2s for transcription activity.
 - If `elapsed > config.silence_timeout_s` and no new transcription has arrived, increments an internal counter and sends `{"type":"status","service":"transcriber","state":"degraded"}` to the client.
-- If the counter reaches `config.max_silence_turns` **consecutively** (reset to 0 whenever a transcription arrives), calls `_close_all()` to terminate the session.
+- If the counter reaches `config.max_silence_turns` **consecutively** (reset to 0 whenever a transcription arrives), calls `close_all()` to terminate the session.
+- Only exits permanently when `self.transcriber.state == ConnectionState.DEGRADED` (or the transcriber was never constructed). A transient `RECONNECTING` blip — the transcriber's background reconnect loop retrying after an unexpected drop — no longer kills the watchdog; it skips silence-counting for that tick and resumes normally once the transcriber is back to `CONNECTED`. Before this fix, any drop (even a successfully-recovered one) permanently stopped silence monitoring for the rest of the session.
 
 ### Session key derivation
 
@@ -239,8 +246,23 @@ The HA REST endpoint (`/v1/chat/completions`) uses a fixed key: `agent:{default_
 | `DbClient` | SQLite (SQLModel) | Singleton; reads `ClientRecord`; caches sessions 60s via TTLCache |
 | `OpenClawClient` | WebSocket v4 | Singleton per app; multiplexed — N concurrent sessions on one connection; sends `chat.abort` on barge-in |
 | `ReconnectingOpenClawClient` | — | Wraps `OpenClawClient`; auto-reconnects with exponential backoff; exposes state (CONNECTED/RECONNECTING/DEGRADED) |
-| `TranscriberClient` | WebSocket | One instance per session (audio mode only); receives PCM Float32 16kHz |
-| `TTSClient` | WebSocket | **Created fresh per turn** (both normal and push turns), not per session; receives tokens, yields PCM16 24kHz |
+| `TranscriberClient` | WebSocket | Protocol-only, unchanged; one instance per session (audio mode only); receives PCM Float32 16kHz |
+| `ReconnectingTranscriberClient` | — | Wraps `TranscriberClient`; **one per audio session**, constructed in `connect_internal_services()`; same CONNECTED/RECONNECTING/DEGRADED state machine as the orchestrator, background-task-driven (`run()` supervises listen + reconnect for the session's lifetime) |
+| `TTSClient` | WebSocket | Protocol-only, unchanged; **created fresh per turn** (both normal and push turns), not per session; receives tokens, yields PCM16 24kHz |
+| `ReconnectingTTSClient` | — | Wraps `TTSClient`; **process-level singleton** (`app.state.tts`, one per app, shared across all sessions) since TTS has no persistent connection to hold — a lazy backoff gate checked on each new per-turn attempt instead of a background reconnect loop |
+
+### Service reconnection (`src/services/reconnection.py`)
+
+`ConnectionState` (`CONNECTED`/`RECONNECTING`/`DEGRADED`) and `ServiceStatus` (dataclass: `name`, `state`, `connected_at`, `reconnect_attempts`, `last_error`) are shared across all three reconnection wrappers — `ReconnectingOpenClawClient`, `ReconnectingTranscriberClient`, `ReconnectingTTSClient` — so the pattern reads as one system rather than three accidental variations. `to_wire_state(state)` maps a transition to the client-facing `status` wire vocabulary (`CONNECTED→"restored"`, `RECONNECTING→"reconnecting"`, `DEGRADED→"unavailable"`); callers decide *whether* a transition merits notifying (e.g. never fire "restored" for a session's very first successful connect, since nothing was ever broken), this only decides *what word* to send.
+
+- **Trigger mechanism differs by service lifetime, deliberately**: OpenClaw and Transcriber hold a real socket open continuously, so losing it is an event (`on_disconnect` callback) and recovery is a background task retrying with backoff. TTS has no socket between turns by design (`TTSClient` is reconstructed every turn) — there's nothing to hold open in the background, so `ReconnectingTTSClient.connect()` is a lazy gate: if the last failure was more recent than the current backoff window, it returns `None` immediately without even attempting a socket; otherwise it tries, and records success/failure. No `DEGRADED` terminal state and no max-duration for TTS — every eligible turn always gets a fresh attempt, capped at 60s between attempts.
+- **Client notification** — every state-change path funnels through `JotaBridge.notify_service_status(service, state)`, a thin wrapper around `client_ws.send_json({"type":"status",...})`. Never a separate ad-hoc send call site.
+  - **Transcriber**: `ReconnectingTranscriberClient.on_state_change` is wired *after* the session's initial `connect()` call (not before) to avoid a spurious `"restored"` notice on a normal first-time success.
+  - **TTS**: since the singleton is shared, `JotaBridge._maybe_notify_tts_state()` tracks a per-bridge `_tts_degraded_notified` flag and compares it against `app.state.tts.status().state` after each attempted turn, sending `status` only on an actual transition — avoids spamming a message on every turn while the breaker is open.
+  - **Orchestrator**: `ClientRegistry.broadcast_status(service, state)` — wired via `openclaw.on_state_change` in `main.py`'s lifespan, after the initial `connect()` — notifies **every** connected session, not just the one attempting a turn. Closes a gap where an idle-but-connected client only learned about a drop/recovery reactively, on its next turn attempt.
+- **Never force-closes a session**: only the orchestrator remains a fatal dependency (in `health_check()`, at session start). Transcriber/TTS failures — at start or mid-session — degrade the session, they never close the WebSocket.
+- **Settings are dedicated per service** (`TRANSCRIBER_RECONNECT_*`, `TTS_RECONNECT_*`), not shared with `ORCHESTRATOR_RECONNECT_*` — see Environment variables above.
+- **Admin observability**: `GET /admin/transcriber/status` (live reachability via `TranscriberClient.ping()`, since Transcriber has no process-level connection to report — one instance per session) and `GET /admin/tts/status` (`app.state.tts.status()` — real memory of consecutive failures, current backoff, last error), same shape as the pre-existing `GET /admin/orchestrators/{name}/status`.
 
 ### OpenClaw package (`src/services/openclaw/`)
 

--- a/README.md
+++ b/README.md
@@ -19,9 +19,10 @@ ESP32 / Web / App / Home Assistant
   │  OpenClaw         WebSocket v4           │
   │  jota-transcriber WebSocket              │
   │  jota-tts         WebSocket              │
-  │  jota-db          HTTP REST (solo auth)  │
   └──────────────────────────────────────────┘
 ```
+
+No hay dependencia de `jota-db` — la identidad y configuración de clientes viven en una base de datos SQLite local (`data/gateway.db`).
 
 ---
 
@@ -62,12 +63,16 @@ Ver [`docs/client-protocol.md`](docs/client-protocol.md) para la guía completa 
 | `/admin/sessions/{id}` | GET | Detalle con eventos y latencias por turno |
 | `/admin/orchestrators/{name}/status` | GET | Estado del orquestador (CONNECTED / RECONNECTING / DEGRADED) |
 | `/admin/orchestrators/{name}/reconnect` | POST | Fuerza reconexión — responde 202 |
-| `/admin/clients` | GET | Lista clientes *(pendiente DB interna — devuelve 501)* |
-| `/admin/clients` | POST | Crear cliente *(pendiente — 501)* |
-| `/admin/clients/{id}` | GET | Detalle *(pendiente — 501)* |
-| `/admin/clients/{id}` | PATCH | Actualizar *(pendiente — 501)* |
-| `/admin/clients/{id}` | DELETE | Borrar *(pendiente — 501)* |
-| `/admin/clients/{id}/rotate-key` | POST | Rotar `client_key` *(pendiente — 501)* |
+| `/admin/transcriber/status` | GET | Reachability en vivo del transcriptor (`TranscriberClient.ping()` — no hay conexión de proceso, es uno por sesión) |
+| `/admin/tts/status` | GET | Estado del breaker de reconexión de TTS (CONNECTED / RECONNECTING, intentos, último error) |
+| `/admin/clients` | GET | Lista clientes |
+| `/admin/clients` | POST | Crear cliente (`client_key` generado o provisto) |
+| `/admin/clients/{id}` | GET | Detalle de un cliente |
+| `/admin/clients/{id}` | PATCH | Actualizar cliente (campos parciales) |
+| `/admin/clients/{id}` | DELETE | Borrar cliente |
+| `/admin/clients/{id}/rotate-key` | POST | Rotar `client_key` |
+
+Los tres endpoints `*/status` devuelven la misma forma: `{"name", "state", "connected_at", "reconnect_attempts", "last_error"}`.
 
 Auth: header `X-Admin-Token`. Sin header → 422. Token incorrecto → 401. `ADMIN_TOKEN` vacío → 503.
 
@@ -113,8 +118,7 @@ Variables en `.env` (formato `host:port` sin protocolo para todos los URLs):
 
 | Variable | Default | Descripción |
 |----------|---------|-------------|
-| `JOTA_DB_BASE_URL` | `localhost:8001` | jota-db — solo para auth de clientes |
-| `JOTA_DB_API_KEY` | — | API key para jota-db |
+| `DATABASE_URL` | `sqlite:///data/gateway.db` | Ruta a la base de datos SQLite local (identidad y configuración de clientes) |
 | `TRANSCRIBER_WS_URL` | `localhost:9000` | jota-transcriber |
 | `TTS_WS_URL` | `localhost:8005` | jota-tts |
 | `TTS_TOKEN` | `gateway` | Token de auth para jota-tts |
@@ -122,10 +126,16 @@ Variables en `.env` (formato `host:port` sin protocolo para todos los URLs):
 | `OPENCLAW_PORT` | `18789` | Puerto de OpenClaw |
 | `OPENCLAW_TOKEN` | — | Token de auth para OpenClaw (obligatorio) |
 | `ADMIN_TOKEN` | — | Token para endpoints `/admin/*`; vacío deshabilita el admin API |
-| `ORCHESTRATOR_RECONNECT_INITIAL_BACKOFF` | `1.0` | Backoff inicial en reconexión (s) |
-| `ORCHESTRATOR_RECONNECT_MAX_BACKOFF` | `60.0` | Backoff máximo en reconexión (s) |
-| `ORCHESTRATOR_RECONNECT_MAX_DURATION` | `300.0` | Tiempo hasta DEGRADED (s) |
-| `TRANSCRIBER_SILENCE_TIMEOUT_S` | `25` | Silencio máximo sin transcripción antes de degradar (s) |
+| `ORCHESTRATOR_RECONNECT_INITIAL_BACKOFF` | `1.0` | Backoff inicial en reconexión del orquestador (s) |
+| `ORCHESTRATOR_RECONNECT_MAX_BACKOFF` | `60.0` | Backoff máximo en reconexión del orquestador (s) |
+| `ORCHESTRATOR_RECONNECT_MAX_DURATION` | `300.0` | Tiempo hasta DEGRADED del orquestador (s) |
+| `TRANSCRIBER_RECONNECT_INITIAL_BACKOFF` | `1.0` | Backoff inicial en reconexión del transcriptor (s) |
+| `TRANSCRIBER_RECONNECT_MAX_BACKOFF` | `60.0` | Backoff máximo en reconexión del transcriptor (s) |
+| `TRANSCRIBER_RECONNECT_MAX_DURATION` | `300.0` | Tiempo hasta DEGRADED del transcriptor (s) |
+| `TTS_RECONNECT_INITIAL_BACKOFF` | `1.0` | Backoff inicial del breaker de TTS (s) |
+| `TTS_RECONNECT_MAX_BACKOFF` | `60.0` | Backoff máximo del breaker de TTS (s) — sin estado DEGRADED, cada turno elegible reintenta |
+
+`silence_timeout_s` y `max_silence_turns` (umbral del watchdog de silencio) son campos de configuración **por cliente** en la base de datos, no variables de entorno globales — ver `ClientRecord` en `CLAUDE.md`.
 
 ---
 
@@ -192,13 +202,13 @@ real.
 
 ## Arquitectura interna
 
-El gateway instancia un `JotaBridge` por cada sesión WebSocket. `OpenClawClient` es un singleton persistente envuelto en `ReconnectingOpenClawClient` (reconexión automática con backoff exponencial; estados CONNECTED / RECONNECTING / DEGRADED).
+El gateway instancia un `JotaBridge` por cada sesión WebSocket. Los tres servicios downstream (OpenClaw, Transcriber, TTS) tienen reconexión automática con backoff exponencial, unificada en `services/reconnection.py` (estados compartidos CONNECTED / RECONNECTING / DEGRADED). `OpenClawClient` y `ReconnectingTTSClient` son singletons de proceso; `ReconnectingTranscriberClient` es uno por sesión de audio.
 
 ```
 src/
 ├── api/
 │   ├── routes.py            WebSocket /ws/stream — handshake, ready, bridge lifecycle
-│   ├── admin_routes.py      /admin/* — observabilidad + CRUD stubs
+│   ├── admin_routes.py      /admin/* — CRUD de clientes + observabilidad (sesiones, orquestador, transcriptor, TTS)
 │   ├── openai_routes.py     /v1/models, /v1/chat/completions
 │   ├── health_routes.py     /healthz, /ready
 │   └── deps.py              get_admin_auth — dependencia de auth para admin
@@ -206,11 +216,18 @@ src/
 │   ├── config.py            Settings (pydantic-settings, .env)
 │   ├── cache.py             make_cache() — TTLCache + asyncio.Lock
 │   └── session_key.py       make_session_key() — formato canónico de session key
+├── db/
+│   ├── models.py            ClientRecord (SQLModel) — identidad y config por cliente
+│   └── database.py          get_engine() / create_db_and_tables() / get_db_session()
+├── cli.py                   CLI — add-client / list-clients / (de)activate-client / delete-client
 └── services/
     ├── bridge.py            JotaBridge — coordinador de sesión WS
-    ├── db_client.py         HTTP → jota-db (singleton, caché 60s)
-    ├── transcriber_client.py  WebSocket → jota-transcriber (por sesión)
-    ├── tts_client.py        WebSocket → jota-tts (creado por turno)
+    ├── db_client.py         DbClient — lee ClientRecord de SQLite local (singleton, caché 60s)
+    ├── reconnection.py      ConnectionState / ServiceStatus / to_wire_state() — compartido por los 3 wrappers
+    ├── transcriber_client.py       WebSocket → jota-transcriber, protocolo puro (sin reconexión)
+    ├── transcriber_reconnecting.py ReconnectingTranscriberClient — uno por sesión de audio, backoff en background
+    ├── tts_client.py                WebSocket → jota-tts, protocolo puro, creado por turno
+    ├── tts_reconnecting.py          ReconnectingTTSClient — singleton, backoff perezoso por turno
     ├── orchestration.py     call_orchestrator() — helper compartido WS+HTTP
     ├── pipeline_tracker.py  PipelineTracker — latencias por turno
     ├── session_registry.py  SessionRegistry — observabilidad de sesiones
@@ -218,6 +235,6 @@ src/
         ├── client.py        OpenClawClient — WebSocket v4, multiplexado
         ├── reconnecting.py  ReconnectingOpenClawClient — backoff + DEGRADED
         ├── dispatcher.py    FrameDispatcher — enruta frames a turn/client registry
-        ├── registry.py      TurnRegistry + ClientRegistry
+        ├── registry.py      TurnRegistry + ClientRegistry (+ broadcast_status a todas las sesiones)
         └── models.py        GatewayInfo, AgentInfo
 ```

--- a/docs/client-protocol.md
+++ b/docs/client-protocol.md
@@ -51,7 +51,11 @@ El **primer mensaje** que envíes DEBE ser el handshake. Es el único mensaje si
 | `client_key` inválida o cliente inactivo | 1008 | `"Clave de cliente invalida o inactiva"` |
 | Servicio de identidad no disponible | 1011 | `"Servicio de identidad no disponible"` |
 | Agente solicitado no existe en OpenClaw | 1008 | `"Agent '{name}' not available"` |
-| Servicio crítico no disponible tras health check | 1011 | `"Servicio crítico no disponible"` |
+| Orquestador no disponible tras health check | 1011 | `"Servicio crítico no disponible"` |
+
+> **El orquestador (OpenClaw) es el único servicio que puede cerrar la conexión en el handshake.** Transcriber y TTS ya **no** son críticos: si cualquiera de los dos no responde al arrancar la sesión, el gateway la abre igualmente en modo degradado y te lo notifica vía `status` (ver §8) — nunca cierra el WebSocket por esto. Antes de la versión que introdujo la reconexión automática (issue #46), un fallo de Transcriber en este punto sí cerraba la conexión con 1011; ya no es el caso.
+>
+> Estos mensajes `status` de arranque pueden llegar **antes** del `ready` (el health check se ejecuta justo antes de enviarlo) — no asumas que `ready` es el primer mensaje posible tras el handshake, solo que es el primero que confirma que la sesión quedó establecida.
 
 ---
 
@@ -355,12 +359,22 @@ El gateway notifica cambios en el estado de sus microservicios durante la sesió
 { "type": "status", "service": "tts", "state": "degraded" }
 ```
 
-| `service` | `state` | Impacto |
-|-----------|---------|---------|
-| `orchestrator` | `unavailable` | **Fatal** — el gateway cerrará la sesión |
-| `transcriber` | `unavailable` | Degradado — sin transcripción automática; puedes seguir en modo texto |
-| `transcriber` | `degraded` | Parcial — el transcriptor responde pero detectó un problema (buffer lleno, etc.) |
-| `tts` | `unavailable` | Degradado — sin audio; los tokens de texto siguen llegando |
+Los tres microservicios downstream (orquestador, Transcriber, TTS) tienen reconexión automática con backoff exponencial. El vocabulario de conectividad es:
+
+| `state` | Significado |
+|---------|-------------|
+| `unavailable` | El servicio está caído. Puede o no estar reintentando activamente en segundo plano (ver tabla siguiente). |
+| `reconnecting` | Reintentando activamente ahora mismo. |
+| `restored` | Volvió a la normalidad tras haber estado `unavailable`/`reconnecting`. |
+| `degraded` | Solo para `transcriber` — señal de **calidad**, no de conectividad (silencio prolongado, buffer lleno). No forma parte del ciclo unavailable→reconnecting→restored. |
+
+Por servicio:
+
+| `service` | Comportamiento e impacto en la sesión |
+|-----------|-----------------------------------------|
+| `orchestrator` | Reintenta en segundo plano con backoff mientras la sesión está activa. Si cae **antes o durante el handshake** (health check inicial), es el único caso fatal: el gateway cierra el WebSocket con 1011 y nunca llega a enviar `ready` (ver §1). Si cae **durante una sesión ya establecida**, el WebSocket **no se cierra** — solo falla el turno en curso (`error` con `code: "TURN_ERROR"`, `fatal: false`) y **todas** las sesiones conectadas reciben proactivamente `status: {orchestrator, unavailable→reconnecting→restored}`, incluso si están inactivas en ese momento (no hace falta intentar un turno para enterarte). |
+| `transcriber` | Un `TranscriberClient` por sesión de audio; reconecta en segundo plano. `unavailable` significa que no hay transcripción automática — puedes seguir enviando texto con `send`. Puede llegar desde el arranque mismo de la sesión (ver nota en §1) o en cualquier punto intermedio. Nunca cierra la sesión. |
+| `tts` | Sin conexión persistente — TTS se reconstruye en cada turno por diseño. `reconnecting`/`unavailable` aquí significa "el último intento falló y el siguiente turno con audio puede fallar también hasta que pase el backoff" — no hay un reintento en segundo plano independiente del propio turno. Los `token` de texto siguen llegando igual; solo falta el audio. |
 
 Los mensajes de estado también pueden incluir `code` y `message` con detalles adicionales:
 
@@ -399,15 +413,17 @@ Los errores llegan independientemente de `output_mode`:
 
 ### Códigos de error
 
+> **Nota de precisión:** en la implementación actual, el único código que el gateway envía de verdad como mensaje `{"type":"error",...}` es `TURN_ERROR` (fallo dentro de un turno ya en marcha, `fatal: false`). Los fallos de handshake (`client_key` inválida, agente inexistente, orquestador no disponible al arrancar) **no** se comunican con un mensaje `error` previo — el gateway cierra directamente el WebSocket con el código y `reason` de la tabla de la §1. La tabla siguiente documenta la intención original del formato `code`/`fatal`; trátala como referencia de forma, no como lista exhaustiva de códigos que verás en producción hoy.
+
 | Código | Fatal | Cuándo ocurre |
 |--------|-------|---------------|
-| `AUTH_FAILED` | true | `client_key` inválida o inactiva |
-| `AGENT_NOT_FOUND` | true | El agente solicitado no existe en OpenClaw |
-| `ORCHESTRATOR_UNAVAILABLE` | true | OpenClaw no disponible al iniciar la sesión |
-| `TTS_UNAVAILABLE` | false | TTS caído; la sesión continúa sin audio |
-| `TRANSCRIBER_UNAVAILABLE` | false | Transcriber caído; puedes cambiar a modo texto |
-| `TURN_ERROR` | false | Fallo en un turno concreto; la sesión continúa |
-| `INTERNAL_ERROR` | true/false | Error inesperado; `fatal` según criticidad |
+| `TURN_ERROR` | false | Fallo en un turno concreto (incluye orquestador caído/reconectando durante una sesión activa); la sesión continúa — **el único código realmente emitido hoy** |
+| `AUTH_FAILED` | true | Documentado para `client_key` inválida o inactiva — en la práctica se señaliza cerrando el WS con 1008, sin este mensaje previo |
+| `AGENT_NOT_FOUND` | true | Documentado para agente inexistente — en la práctica se señaliza cerrando el WS con 1008, sin este mensaje previo |
+| `ORCHESTRATOR_UNAVAILABLE` | true | Documentado para orquestador no disponible al iniciar — en la práctica se señaliza cerrando el WS con 1011, sin este mensaje previo |
+| `TTS_UNAVAILABLE` | false | Documentado para TTS caído — en la práctica ver `status: {tts, unavailable}` (§8), no este código |
+| `TRANSCRIBER_UNAVAILABLE` | false | Documentado para Transcriber caído — en la práctica ver `status: {transcriber, unavailable}` (§8), no este código |
+| `INTERNAL_ERROR` | true/false | Reservado para error inesperado; no confirmado en el código actual |
 
 Si `fatal: true`, no envíes más mensajes — el servidor cerrará la conexión WS inmediatamente.
 
@@ -425,6 +441,8 @@ OpenClaw puede iniciar turnos proactivamente sin que el usuario haya enviado nad
 ```
 
 El cliente no necesita distinguirlos de los turnos normales — el `turn_id` y `turn_seq` siguen la misma secuencia. Si `tool_calls_enabled` está activo, también pueden llegar mensajes `tool_call` (§5) intercalados.
+
+> **Garantía de un único par por respuesta (issue #84):** cuando el agente hace tool use o razonamiento multi-paso, OpenClaw puede emitir varios eventos internos de inicio/fin para una sola respuesta LLM. El gateway los colapsa siempre en exactamente **un** `turn_start`/`turn_end` de cara al cliente — nunca verás duplicados. Si tu cliente implementó algún workaround para deduplicar `turn_end` repetidos (grace period, etc.) porque llegaban 2-3 veces por turno, ya no hace falta; puedes simplificarlo o quitarlo con seguridad.
 
 ---
 


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
<think>
The user is asking me to analyze the code changes (patches) provided and generate a precise description for a pull request. Let me examine the changes:

1. **CLAUDE.md changes**:
   - Added new environment variables for Transcriber and TTS reconnection settings
   - Updated the session initialization flow documentation to describe how reconnection wrappers work for Transcriber and TTS
   - Updated the silence watchdog behavior - now only exits when transcriber is in DEGRADED state, not during transient RECONNECTING
   - Added new reconnection classes and their behavior:
     - `ReconnectingTranscriberClient` - one per audio session
     - `ReconnectingTTSClient` - process-level singleton with lazy backoff
   - Added comprehensive documentation about the service reconnection system
   - Added admin observability endpoints

2. **README.md changes**:
   - Added clarification that there's no dependency on jota-db - identity/config is in local SQLite
   - Updated admin endpoints list with new transcriber and TTS status endpoints
   - Removed "pending" status from client CRUD endpoints (they're now implemented)
   - Updated environment variables table with new Transcriber and TTS reconnection settings
   - Updated architecture diagram to reflect new reconnection system

3. **docs/client-protocol.md changes**:
   - Clarified that only orchestrator (OpenClaw) can close connection during handshake - Transcriber and TTS failures result in degraded mode instead of closure
   - Added note about status messages potentially arriving before `ready`
   - Updated status message section with more detailed explanation of the reconnection system
   - Added new state vocabulary (unavailable, reconnecting, restored, degraded)
   - Added per-service behavior explanation
   - Updated error codes section with clarification that only TURN_ERROR is actually emitted today
   - Added note about guaranteed single turn_start/turn_end pair (issue #84)

The patch introduces a comprehensive service reconnection system across all three downstream services. The orchestrator remains the only fatal failure point, while Transcriber and TTS now gracefully handle disconnections without terminating sessions. New configuration options, admin endpoints, and client-facing status mechanisms provide visibility into connection health, with documentation reflecting these architectural changes.
</think>

## Pull Request Description

This follow-up documentation PR (#89) expands on the reconnection system introduced in #88, providing comprehensive documentation for the Transcriber and TTS reconnection mechanisms that were previously only documented for the orchestrator.

**Key changes:**

1. **New environment variables**: Added `TRANSCRIBER_RECONNECT_*` and `TTS_RECONNECT_*` settings (initial backoff, max backoff, max duration) to CLAUDE.md and README.md.

2. **Session initialization flow updates**: Clarified that the orchestrator is the only fatal dependency at session start. Transcriber and TTS failures during health check now result in a degraded session instead of closing the WebSocket.

3. **Silence watchdog behavior**: Documented the fix where transient RECONNECTING states no longer permanently disable silence monitoring — the watchdog now correctly skips counting during reconnection and resumes normally once the transcriber recovers.

4. **New reconnection architecture**: Added documentation for two new reconnection wrappers:
   - `ReconnectingTranscriberClient` — one instance per audio session, with background reconnect loop
   - `ReconnectingTTSClient` — process-level singleton with lazy backoff (no persistent connection by design)

5. **Client notification system**: Documented the unified `ConnectionState` / `ServiceStatus` pattern and how state changes are communicated to clients via `status` messages, with special handling to avoid spurious notifications.

6. **Admin endpoints**: Added documentation for new `/admin/transcriber/status` and `/admin/tts/status` endpoints.

7. **Client protocol updates**: Clarified error handling (only orchestrator failures are fatal at handshake), documented the new state vocabulary (`unavailable`, `reconnecting`, `restored`, `degraded`), and added the guarantee for single `turn_start`/`turn_end` pair per response (issue #84).
<!-- kody-pr-summary:end -->