### PR TITLE
fix: reject concurrent same-session_key turns (issue #99)

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -55,7 +55,7 @@ El gateway funciona correctamente en **happy path** (sesión única + backend sa
 **Release target:** 1.15.x (patches incrementales).
 **Acceptance gate:** cero issues 🔴 abiertas, `pytest` verde, suite e2e sin regresiones, ningún log contiene `client_key` completo.
 
-- [ ] **#99** 🔴 `[001]` — `TurnRegistry` concurrent same-session_key race corrupts turns — **S** — *race en `register()` cuando dos `stream_response` comparten `session_key`*
+- [x] **#99** 🔴 `[001]` — `TurnRegistry` concurrent same-session_key race corrupts turns — **S** — *race en `register()` cuando dos `stream_response` comparten `session_key`*
 - [ ] **#100** 🔴 `[002]` — `system_prompt_extra` silently dropped before reaching OpenClaw — **M** — ⚠️ *requiere decisión: ¿concatenar al mensaje, extender `chat.send`, o eliminar el campo?*
 - [ ] **#101** 🔴 `[003]` — Pre-ready WebSocket failure paths leak transcriber, bridge, session state — **M**
 - [ ] **#102** 🔴 `[004]` — `ReconnectingOpenClawClient` has no circuit-breaker after DEGRADED — **S** — *regresión Bug 10*

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -55,7 +55,7 @@ El gateway funciona correctamente en **happy path** (sesión única + backend sa
 **Release target:** 1.15.x (patches incrementales).
 **Acceptance gate:** cero issues 🔴 abiertas, `pytest` verde, suite e2e sin regresiones, ningún log contiene `client_key` completo.
 
-- [x] **#99** 🔴 `[001]` — `TurnRegistry` concurrent same-session_key race corrupts turns — **S** — *race en `register()` cuando dos `stream_response` comparten `session_key`*
+- [x] **#99** 🔴 `[001]` — `TurnRegistry` concurrent same-session_key race corrupts turns — **S** — *race en `register()` cuando dos `stream_response` comparten `session_key`* — [PR #140](https://github.com/Jota-project/jota-gateway/pull/140)
 - [ ] **#100** 🔴 `[002]` — `system_prompt_extra` silently dropped before reaching OpenClaw — **M** — ⚠️ *requiere decisión: ¿concatenar al mensaje, extender `chat.send`, o eliminar el campo?*
 - [ ] **#101** 🔴 `[003]` — Pre-ready WebSocket failure paths leak transcriber, bridge, session state — **M**
 - [ ] **#102** 🔴 `[004]` — `ReconnectingOpenClawClient` has no circuit-breaker after DEGRADED — **S** — *regresión Bug 10*

--- a/src/api/openai_routes.py
+++ b/src/api/openai_routes.py
@@ -13,6 +13,7 @@ from src.core.network import is_trusted_origin, resolve_client_ip
 from src.core.session_key import make_session_key
 from src.models.schemas import Client, ClientConfig
 from src.services.db_client import db_client
+from src.services.openclaw.registry import TURN_IN_PROGRESS_ERROR
 from src.services.orchestration import call_orchestrator
 from src.services.pipeline_tracker import PipelineTracker, _NullWS
 
@@ -191,6 +192,8 @@ async def chat_completions(
         await tracker.close()
 
     if orchestrator_error:
+        if str(orchestrator_error) == TURN_IN_PROGRESS_ERROR:
+            return JSONResponse({"error": str(orchestrator_error)}, status_code=409)
         return JSONResponse({"error": str(orchestrator_error)}, status_code=502)
 
     content = "".join(tokens)

--- a/src/services/openclaw/client.py
+++ b/src/services/openclaw/client.py
@@ -10,7 +10,7 @@ from websockets.asyncio.client import ClientConnection
 from src.services.openclaw import frames
 from src.services.openclaw.dispatcher import FrameDispatcher
 from src.services.openclaw.models import GatewayInfo, ToolCallEvent
-from src.services.openclaw.registry import TurnRegistry
+from src.services.openclaw.registry import TURN_IN_PROGRESS_ERROR, TurnInProgress, TurnRegistry
 from src.services.protocol import OrchestratorEvent
 
 logger = logging.getLogger(__name__)
@@ -153,7 +153,11 @@ class OpenClawClient:
             raise ValueError("session_key is required — callers must provide it via make_session_key()")
 
         req_id = str(uuid.uuid4())
-        queue = self._turn_registry.register(req_id, session_key)
+        try:
+            queue = self._turn_registry.register(req_id, session_key)
+        except TurnInProgress:
+            yield OrchestratorEvent(type="error", content=TURN_IN_PROGRESS_ERROR)
+            return
         _sent = False
         _finished = False
 

--- a/src/services/openclaw/registry.py
+++ b/src/services/openclaw/registry.py
@@ -11,6 +11,17 @@ def client_id_from_session_key(session_key: str) -> str:
     return session_key.rsplit(":", 1)[-1]
 
 
+# Stable, distinguishable error content for a rejected duplicate registration —
+# defined once here so callers (OpenClawClient.stream_response, the /v1/*
+# route layer) can recognize this specific failure instead of duplicating a
+# free-form string literal in multiple files.
+TURN_IN_PROGRESS_ERROR = "turn_in_progress"
+
+
+class TurnInProgress(Exception):
+    """Raised when register() is called for a session_key with an active turn."""
+
+
 class TurnRegistry:
     """Routes active OpenClaw turns (req_id / session_key) to asyncio queues.
 
@@ -23,15 +34,28 @@ class TurnRegistry:
     def __init__(self) -> None:
         self._sessions: dict[str, asyncio.Queue] = {}
         self._req_to_session: dict[str, str] = {}
+        # session_key -> req_id of the turn that currently owns it. Lets
+        # unregister() tell an in-flight turn's belated cleanup apart from a
+        # newer turn that has since taken over the same session_key, instead
+        # of popping by session_key alone (see issue #99).
+        self._session_owner: dict[str, str] = {}
 
     def register(self, req_id: str, session_key: str) -> asyncio.Queue:
+        if session_key in self._sessions:
+            raise TurnInProgress(session_key)
         queue: asyncio.Queue = asyncio.Queue()
         self._sessions[session_key] = queue
         self._req_to_session[req_id] = session_key
+        self._session_owner[session_key] = req_id
         return queue
 
     def unregister(self, session_key: str, req_id: str) -> None:
-        self._sessions.pop(session_key, None)
+        # Only pop the session_key's queue if req_id is still its current
+        # owner — a stale/belated unregister() for a turn that was already
+        # superseded must not evict a different turn's live queue.
+        if self._session_owner.get(session_key) == req_id:
+            self._sessions.pop(session_key, None)
+            self._session_owner.pop(session_key, None)
         self._req_to_session.pop(req_id, None)
 
     def get_queue_by_session(self, session_key: str) -> Optional[asyncio.Queue]:
@@ -46,6 +70,7 @@ class TurnRegistry:
             queue.put_nowait(("error", message))
         self._sessions.clear()
         self._req_to_session.clear()
+        self._session_owner.clear()
 
 
 class ClientRegistry:

--- a/tests/integration/test_openclaw_client.py
+++ b/tests/integration/test_openclaw_client.py
@@ -8,7 +8,7 @@ import pytest
 
 from src.services.openclaw.client import OpenClawClient
 from src.services.openclaw.dispatcher import FrameDispatcher
-from src.services.openclaw.registry import TurnRegistry, ClientRegistry
+from src.services.openclaw.registry import TurnRegistry, ClientRegistry, TURN_IN_PROGRESS_ERROR
 
 HELLO_OK_PAYLOAD = {
     "type": "hello-ok", "protocol": 4,
@@ -405,4 +405,78 @@ async def test_stream_response_yields_tool_call_events():
     assert tool_events[1].phase == "result"
     assert tool_events[1].result == "file.txt"
     assert tool_events[1].is_error is False
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_concurrent_stream_response_same_session_key_rejects_one():
+    """Issue #99: two concurrent stream_response() calls sharing a session_key
+    must not corrupt each other's queue. Reproduced via asyncio.gather, per the
+    issue's repro steps — exactly one call is rejected immediately with the
+    stable TURN_IN_PROGRESS_ERROR content, the other completes normally, and
+    neither hangs."""
+    fake_ws = SmartFakeWS({"agent:main:client-a": ["Hola ", "mundo"]})
+    client = await connected_client(fake_ws)
+
+    async def _consume():
+        events = []
+        async for event in client.stream_response(
+            "hola", "client-a", session_key="agent:main:client-a"
+        ):
+            events.append(event)
+        return events
+
+    results = await asyncio.wait_for(
+        asyncio.gather(_consume(), _consume()),
+        timeout=1.0,
+    )
+
+    rejected = [r for r in results if r[0].type == "error"]
+    succeeded = [r for r in results if r[0].type != "error"]
+    assert len(rejected) == 1, f"expected exactly one rejected call, got: {results}"
+    assert len(succeeded) == 1, f"expected exactly one successful call, got: {results}"
+
+    assert len(rejected[0]) == 1  # rejected call yields exactly the error event, nothing else
+    assert rejected[0][0].content == TURN_IN_PROGRESS_ERROR
+
+    tokens = [e.content for e in succeeded[0] if e.type == "token"]
+    assert tokens == ["Hola ", "mundo"]
+    assert succeeded[0][-1].type == "status"
+    assert succeeded[0][-1].content == "done"
+
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_concurrent_stream_response_different_session_keys_both_succeed():
+    """Regression guard: rejecting duplicate session_keys must not affect
+    unrelated sessions multiplexed on the same connection — both complete
+    normally when run concurrently via asyncio.gather."""
+    fake_ws = SmartFakeWS({
+        "agent:main:client-a": ["Hola ", "mundo"],
+        "agent:main:client-b": ["Adios ", "mundo"],
+    })
+    client = await connected_client(fake_ws)
+
+    async def _consume(user_id, session_key):
+        events = []
+        async for event in client.stream_response("hola", user_id, session_key=session_key):
+            events.append(event)
+        return events
+
+    events_a, events_b = await asyncio.wait_for(
+        asyncio.gather(
+            _consume("client-a", "agent:main:client-a"),
+            _consume("client-b", "agent:main:client-b"),
+        ),
+        timeout=1.0,
+    )
+
+    tokens_a = [e.content for e in events_a if e.type == "token"]
+    tokens_b = [e.content for e in events_b if e.type == "token"]
+    assert tokens_a == ["Hola ", "mundo"]
+    assert tokens_b == ["Adios ", "mundo"]
+    assert events_a[-1].content == "done"
+    assert events_b[-1].content == "done"
+
     await client.close()

--- a/tests/integration/test_rest_openai.py
+++ b/tests/integration/test_rest_openai.py
@@ -180,6 +180,25 @@ def test_non_streaming_orchestrator_error_returns_502(client, mock_orchestrator)
     assert r.status_code == 502, f"Esperado 502, recibido {r.status_code}: {r.text}"
 
 
+def test_non_streaming_turn_conflict_returns_409(client, mock_orchestrator):
+    """Issue #99: a rejected duplicate-session_key turn must map to HTTP 409,
+    distinguishable from a generic orchestrator failure (502)."""
+    from src.services.openclaw.registry import TURN_IN_PROGRESS_ERROR
+
+    async def _conflict_stream(*args, **kwargs):
+        yield OrchestratorEvent(type="error", content=TURN_IN_PROGRESS_ERROR)
+
+    mock_orchestrator.stream_response = _conflict_stream
+
+    r = client.post("/v1/chat/completions", json={
+        "model": "openclaw",
+        "messages": [{"role": "user", "content": "Hola"}],
+        "stream": False,
+    })
+
+    assert r.status_code == 409, f"Esperado 409, recibido {r.status_code}: {r.text}"
+
+
 def test_streaming_done_delivered_when_tracker_close_raises(client, mock_orchestrator, monkeypatch):
     """[DONE] debe llegar aunque tracker.close() lance una excepción.
 

--- a/tests/unit/test_bridge_send_guards.py
+++ b/tests/unit/test_bridge_send_guards.py
@@ -141,6 +141,30 @@ async def test_audio_send_failure_does_not_propagate(mock_tracker):
     await b._call_orchestrator("test")  # must not raise
 
 
+async def test_turn_in_progress_error_event_sends_non_fatal_turn_error_frame(bridge):
+    """Issue #99: when the orchestrator rejects a duplicate session_key turn
+    (an 'error' event with TURN_IN_PROGRESS_ERROR content — see
+    OpenClawClient.stream_response), the existing generic RuntimeError
+    handling in pipe_tokens() must already surface it to the client as a
+    non-fatal TURN_ERROR frame, without closing the WS. No WS-specific
+    code should be needed for this issue — this test verifies that."""
+    from src.services.openclaw.registry import TURN_IN_PROGRESS_ERROR
+
+    bridge.orchestrator.stream_response = make_stream_with_event("error", TURN_IN_PROGRESS_ERROR)
+
+    await bridge._call_orchestrator("test")  # must not raise — session stays open
+
+    error_msgs = [
+        c.args[0] for c in bridge.client_ws.send_json.await_args_list
+        if c.args[0].get("type") == "error"
+    ]
+    assert len(error_msgs) == 1
+    assert error_msgs[0]["code"] == "TURN_ERROR"
+    assert error_msgs[0]["fatal"] is False
+    assert error_msgs[0]["message"] == TURN_IN_PROGRESS_ERROR
+    assert error_msgs[0]["turn_id"] == "t-1"
+
+
 async def test_tts_end_called_when_orchestrator_raises_non_runtime_error(mock_tracker):
     """tts.end() debe llamarse aunque call_orchestrator lance algo distinto de RuntimeError (e.g. OSError)."""
     ws = AsyncMock()

--- a/tests/unit/test_openclaw_registry.py
+++ b/tests/unit/test_openclaw_registry.py
@@ -1,6 +1,14 @@
 import asyncio
 from unittest.mock import AsyncMock
-from src.services.openclaw.registry import TurnRegistry, ClientRegistry, client_id_from_session_key
+
+import pytest
+
+from src.services.openclaw.registry import (
+    TurnRegistry,
+    ClientRegistry,
+    TurnInProgress,
+    client_id_from_session_key,
+)
 
 
 # --- client_id_from_session_key ---
@@ -43,6 +51,41 @@ def test_unregister_clears_both():
     reg.unregister("agent:main:client-a", "req-1")
     assert reg.get_queue_by_session("agent:main:client-a") is None
     assert reg.get_queue_by_req("req-1") is None
+
+def test_register_rejects_duplicate_session_key():
+    reg = TurnRegistry()
+    qa = reg.register("req-a", "agent:main:client-a")
+
+    with pytest.raises(TurnInProgress):
+        reg.register("req-b", "agent:main:client-a")
+
+    # The first caller's queue is untouched by the rejected attempt.
+    assert reg.get_queue_by_session("agent:main:client-a") is qa
+    assert reg.get_queue_by_req("req-a") is qa
+    # The rejected req_id was never registered.
+    assert reg.get_queue_by_req("req-b") is None
+
+
+def test_unregister_does_not_pop_unrelated_queue():
+    """Locks in the identity-confusion half of the bug: unregister() must
+    only remove a session_key's queue if the caller is still its current
+    owner, not just because the session_key string matches."""
+    reg = TurnRegistry()
+    reg.register("req-a", "agent:main:client-a")
+
+    # Simulate the desync a pre-fix duplicate registration would have left
+    # behind: the session_key's queue entry disappears (as if overwritten)
+    # while the stale req_id -> session_key mapping for A survives.
+    del reg._sessions["agent:main:client-a"]
+
+    qb = reg.register("req-b", "agent:main:client-a")
+
+    # A's belated cleanup call must not evict B's live queue.
+    reg.unregister("agent:main:client-a", "req-a")
+
+    assert reg.get_queue_by_session("agent:main:client-a") is qb
+    assert reg.get_queue_by_req("req-b") is qb
+
 
 def test_two_sessions_independent():
     reg = TurnRegistry()


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
<think>
The user wants me to analyze the code changes provided in the patch and generate a precise description for a pull request.

Let me analyze the changes:

1. **ROADMAP.md**: Marked issue #99 as completed (from `[ ]` to `[x]`)

2. **src/services/openclaw/registry.py**: 
   - Added `TURN_IN_PROGRESS_ERROR` constant
   - Added `TurnInProgress` exception class
   - Modified `TurnRegistry` to track session ownership with `_session_owner` dict
   - Modified `register()` to raise `TurnInProgress` if session_key already exists
   - Modified `unregister()` to only remove queue if the caller is still the owner
   - Modified `error_all()` to clear `_session_owner` as well

3. **src/services/openclaw/client.py**:
   - Import `TurnInProgress` and `TURN_IN_PROGRESS_ERROR`
   - In `stream_response()`, catch `TurnInProgress` exception and yield an error event instead of raising

4. **src/api/openai_routes.py**:
   - Import `TURN_IN_PROGRESS_ERROR`
   - In the error handling, check if the error is `TURN_IN_PROGRESS_ERROR` and return HTTP 409 instead of 502

5. **Tests added**:
   - Integration tests for concurrent stream_response with same/different session keys
   - REST test for 409 status code on turn conflict
   - Unit test for bridge handling of turn error events
   - Unit tests for TurnRegistry

The core fix is:
- Issue #99 was about a race condition in `TurnRegistry.register()` when two `stream_response` calls share the same `session_key`
- The fix adds ownership tracking to prevent concurrent registrations for the same session_key
- The second caller gets an immediate error instead of corrupting the first caller's queue


- HTTP layer returns 409 Conflict when this occurs
- This prevents the race condition and ensures only one turn executes per session at any given time
</think>

## Pull Request Description

**Fix: Reject concurrent same-session_key turns (issue #99)**

This patch addresses a race condition in the `TurnRegistry` when multiple `stream_response` calls share the same `session_key`. Previously, concurrent requests with identical session keys could corrupt each other's turn queues, causing events to be misrouted between sessions.

### Changes Made:

1. **TurnRegistry Race Protection** (`src/services/openclaw/registry.py`):
   - Added `TurnInProgress` exception and `TURN_IN_PROGRESS_ERROR` constant
   - Added ownership tracking (`_session_owner` dict) to track which request_id currently owns a session_key
   - Modified `register()` to reject duplicate session_key registrations by raising `TurnInProgress`
   - Modified `unregister()` to only clear the queue if the caller is still the current owner, preventing stale cleanup from evicting a newer turn's queue

2. **Client Handling** (`src/services/openclaw/client.py`):
   - Added exception handling in `stream_response()` to catch `TurnInProgress` and yield an error event instead of propagating the exception

3. **HTTP Layer** (`src/api/openai_routes.py`):
   - Returns HTTP 409 Conflict (instead of 502) when a duplicate session_key turn is rejected, distinguishing this specific error from generic orchestrator failures

4. **Tests**: Added integration and unit tests verifying:
   - Concurrent same-session_key calls: exactly one rejected with error, the other succeeds
   - Different session_keys on same connection: both succeed independently
   - HTTP 409 response for duplicate turns
   - Bridge correctly propagates the error as a non-fatal TURN_ERROR frame
<!-- kody-pr-summary:end -->