### PR TITLE
fix: remove system_prompt_extra entirely (issue #100)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,7 +108,6 @@ SQLModel table (`__tablename__ = "clients"`) with the following columns:
 | `max_silence_turns` | `int` | `3` | Consecutive silence events before session is closed |
 | `push_enabled` | `bool` | `True` | Whether agent-initiated push turns are accepted |
 | `tool_calls_enabled` | `bool` | `False` | Whether `tool_call` WS messages are sent for this client (opt-in) |
-| `system_prompt_extra` | `str?` | `None` | Appended to the system prompt for all turns |
 
 ### `src/db/database.py`
 
@@ -178,7 +177,7 @@ db_client.invalidate(client_key)        # evict from 60s TTL cache
 ```
 
 `ClientConfig` fields mapped from `ClientRecord`:
-`stt_language`, `stt_vad_thold`, `tts_voice`, `tts_speed`, `barge_in_enabled`, `barge_in_min_chars`, `system_prompt_extra`, `silence_timeout_s`, `max_silence_turns`, `push_enabled`.
+`stt_language`, `stt_vad_thold`, `tts_voice`, `tts_speed`, `barge_in_enabled`, `barge_in_min_chars`, `silence_timeout_s`, `max_silence_turns`, `push_enabled`.
 
 The singleton `db_client = DbClient()` is imported from this module everywhere. An optional `engine` constructor parameter allows injecting a test engine.
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -56,7 +56,7 @@ El gateway funciona correctamente en **happy path** (sesión única + backend sa
 **Acceptance gate:** cero issues 🔴 abiertas, `pytest` verde, suite e2e sin regresiones, ningún log contiene `client_key` completo.
 
 - [x] **#99** 🔴 `[001]` — `TurnRegistry` concurrent same-session_key race corrupts turns — **S** — *race en `register()` cuando dos `stream_response` comparten `session_key`* — [PR #140](https://github.com/Jota-project/jota-gateway/pull/140)
-- [ ] **#100** 🔴 `[002]` — `system_prompt_extra` silently dropped before reaching OpenClaw — **M** — ⚠️ *requiere decisión: ¿concatenar al mensaje, extender `chat.send`, o eliminar el campo?*
+- [x] **#100** 🔴 `[002]` — `system_prompt_extra` silently dropped before reaching OpenClaw — **M** — *decisión: eliminar el campo por completo (no había hook viable en el wire protocol de OpenClaw)*
 - [ ] **#101** 🔴 `[003]` — Pre-ready WebSocket failure paths leak transcriber, bridge, session state — **M**
 - [ ] **#102** 🔴 `[004]` — `ReconnectingOpenClawClient` has no circuit-breaker after DEGRADED — **S** — *regresión Bug 10*
 - [ ] **#103** 🔴 `[005]` — `OpenClawClient.connect()` does not close prior socket/tasks on reconnect — **S**

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -56,7 +56,7 @@ El gateway funciona correctamente en **happy path** (sesión única + backend sa
 **Acceptance gate:** cero issues 🔴 abiertas, `pytest` verde, suite e2e sin regresiones, ningún log contiene `client_key` completo.
 
 - [x] **#99** 🔴 `[001]` — `TurnRegistry` concurrent same-session_key race corrupts turns — **S** — *race en `register()` cuando dos `stream_response` comparten `session_key`* — [PR #140](https://github.com/Jota-project/jota-gateway/pull/140)
-- [x] **#100** 🔴 `[002]` — `system_prompt_extra` silently dropped before reaching OpenClaw — **M** — *decisión: eliminar el campo por completo (no había hook viable en el wire protocol de OpenClaw)*
+- [x] **#100** 🔴 `[002]` — `system_prompt_extra` silently dropped before reaching OpenClaw — **M** — *decisión: eliminar el campo por completo (no había hook viable en el wire protocol de OpenClaw)* — [PR #141](https://github.com/Jota-project/jota-gateway/pull/141)
 - [ ] **#101** 🔴 `[003]` — Pre-ready WebSocket failure paths leak transcriber, bridge, session state — **M**
 - [ ] **#102** 🔴 `[004]` — `ReconnectingOpenClawClient` has no circuit-breaker after DEGRADED — **S** — *regresión Bug 10*
 - [ ] **#103** 🔴 `[005]` — `OpenClawClient.connect()` does not close prior socket/tasks on reconnect — **S**

--- a/docs/openclaw-protocol.md
+++ b/docs/openclaw-protocol.md
@@ -224,8 +224,69 @@ turn's tokens mid-word (reproduced twice: an empty tool-use response, `"CHARLIE"
 
 ---
 
+## No per-session/per-message system-prompt hook exists (as of npm `openclaw@2026.4.12`)
+
+**Investigated 2026-07-18** while resolving issue #100 (`system_prompt_extra` silently dropped).
+Source: the local `openclaw` npm package (`~/node_modules/openclaw`, version `2026.4.12` —
+**older** than the `2026.6.11` server version referenced elsewhere in this file; not verified
+live against a running instance, but these are long-stable core schema/session methods, not the
+volatile turn-completion signal documented above). If behavior here ever contradicts a real
+server response, trust the server and update this section.
+
+**`chat.send` cannot carry a system prompt.** Its wire schema
+(`ChatSendParamsSchema`, TypeBox, `additionalProperties: false`) accepts exactly: `sessionKey,
+message, thinking, deliver, originatingChannel, originatingTo, originatingAccountId,
+originatingThreadId, attachments, timeoutMs, systemInputProvenance, systemProvenanceReceipt,
+idempotencyKey`. `systemInputProvenance`/`systemProvenanceReceipt` are about *tracking where an
+input message originated* (subagent lineage, cross-session sourcing), not a prompt field. With
+`additionalProperties: false`, any extra field a client sends is rejected outright by the
+server — there is no soft/ignored extension point here.
+
+**`chat.inject` exists but is the wrong tool for this.** `{sessionKey, message, label?}` →
+writes the message into the session's persisted transcript via
+`appendAssistantTranscriptMessage` (so it *does* become context for future turns, despite the
+gateway protocol doc's "transcript-only chat event" phrasing) — but always as an **assistant**
+role message, and it broadcasts a visible `chat` event (`state: "final"`) to every subscribed
+UI/node client for that session. Using it to carry system instructions would make the model
+appear to have said its own steering instructions, and would show up as a visible transcript
+entry — wrong role semantics and wrong visibility for an invisible system-level prompt.
+
+**`sessions.patch` does not support a system-prompt field either.** Confirmed directly against
+its handler (`applySessionsPatchToStore`, `src/gateway/sessions-patch.ts` in the OpenClaw
+source): the only patchable fields are `spawnedBy, spawnedWorkspaceDir, spawnDepth,
+subagentRole, subagentControlScope, label, thinkingLevel, fastMode, verboseLevel, traceLevel,
+reasoningLevel, responseUsage, elevatedLevel, execHost, execSecurity, execAsk, execNode, model,
+sendPolicy, groupActivation`.
+
+**The only real system-prompt mechanisms in OpenClaw, and why neither fits jota-gateway's
+per-client model:**
+
+1. `agents.defaults.systemPromptOverride` / `agents.list[].systemPromptOverride` — static,
+   per-**agent** config (settable via `agents.update`), documented in OpenClaw's own changelog
+   as being for "controlled prompt experiments." Every session sharing that `agent` — i.e.
+   every jota-gateway client using the same `agent` name — would get the same override. Wrong
+   granularity: jota-gateway's `system_prompt_extra` is per-**client**, not per-agent.
+2. The `before_prompt_build` plugin hook (`docs/concepts/agent-loop.md` in the OpenClaw
+   package) can inject `systemPrompt`/`prependSystemContext`/`appendSystemContext` dynamically
+   per turn — but only from **inside an OpenClaw plugin running on the OpenClaw server itself**.
+   Not reachable from a remote WS "backend" client like jota-gateway. Building this would mean
+   writing and installing a custom OpenClaw plugin with its own way of learning each
+   jota-gateway client's `system_prompt_extra` — a separate, cross-repo project, not a
+   same-scope fix.
+
+**Conclusion applied in issue #100:** with no wire-level hook available today, the field was
+removed from jota-gateway entirely (schema, DB, admin API, CLI) rather than faked via
+message-concatenation. Revisit if OpenClaw ever adds a `chat.send` field for this, or if a
+dedicated OpenClaw plugin becomes worth building.
+
+---
+
 ## Change log of this file
 
+- **2026-07-18**: added "No per-session/per-message system-prompt hook exists" — researched
+  while resolving issue #100. Confirmed against OpenClaw's own source (`chat.send`'s strict
+  TypeBox schema, `chat.inject`'s assistant-role transcript-write behavior, `sessions.patch`'s
+  full field list) that there is no wire-level way to set a per-client system prompt today.
 - **2026-07-10**: added the issue #84 mitigation note — `JotaBridge` now collapses multiple
   OpenClaw agent start/end pairs into a single client-facing turn_start/turn_end. Previously
   the bridge was emitting one pair per agent event, causing jota-voice (and any other client)

--- a/migrations/versions/106077a95a0f_drop_system_prompt_extra_column.py
+++ b/migrations/versions/106077a95a0f_drop_system_prompt_extra_column.py
@@ -1,0 +1,29 @@
+"""drop system_prompt_extra column
+
+Revision ID: 106077a95a0f
+Revises: 21cb0cf4f6f9
+Create Date: 2026-07-18 00:41:33.958978
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+import sqlmodel
+
+
+# revision identifiers, used by Alembic.
+revision: str = '106077a95a0f'
+down_revision: Union[str, None] = '21cb0cf4f6f9'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("clients") as batch_op:
+        batch_op.drop_column("system_prompt_extra")
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("clients") as batch_op:
+        batch_op.add_column(sa.Column("system_prompt_extra", sqlmodel.sql.sqltypes.AutoString(), nullable=True))

--- a/src/api/admin_routes.py
+++ b/src/api/admin_routes.py
@@ -83,7 +83,6 @@ def create_client(
         max_silence_turns=body.max_silence_turns,
         push_enabled=body.push_enabled,
         tool_calls_enabled=body.tool_calls_enabled,
-        system_prompt_extra=body.system_prompt_extra,
     )
     session.add(record)
     session.commit()

--- a/src/api/openai_routes.py
+++ b/src/api/openai_routes.py
@@ -111,10 +111,8 @@ async def chat_completions(
 
     if caller.client is not None:
         client_id = caller.client.id
-        system_prompt_extra = caller.config.system_prompt_extra
     else:
         client_id = "ha"
-        system_prompt_extra = None
 
     session_key = make_session_key(default_agent, client_id)
 
@@ -137,7 +135,6 @@ async def chat_completions(
                 try:
                     await call_orchestrator(
                         orchestrator, text, session_key, client_id,
-                        system_prompt_extra=system_prompt_extra,
                         tracker=tracker, on_token=_on_token,
                     )
                 except RuntimeError as e:
@@ -182,7 +179,6 @@ async def chat_completions(
     try:
         await call_orchestrator(
             orchestrator, text, session_key, client_id,
-            system_prompt_extra=system_prompt_extra,
             tracker=tracker, on_token=_on_token,
         )
     except RuntimeError as e:

--- a/src/db/models.py
+++ b/src/db/models.py
@@ -33,6 +33,3 @@ class ClientRecord(SQLModel, table=True):
     max_silence_turns: int = Field(default=3)
     push_enabled: bool = Field(default=True)
     tool_calls_enabled: bool = Field(default=False)
-
-    # Personalización
-    system_prompt_extra: Optional[str] = Field(default=None)

--- a/src/models/admin_schemas.py
+++ b/src/models/admin_schemas.py
@@ -33,8 +33,6 @@ class ClientCreate(BaseModel):
     max_silence_turns: int = 3
     push_enabled: bool = True
     tool_calls_enabled: bool = False
-    # Personalización
-    system_prompt_extra: Optional[str] = None
 
 
 class ClientUpdate(BaseModel):
@@ -55,7 +53,6 @@ class ClientUpdate(BaseModel):
     max_silence_turns: Optional[int] = None
     push_enabled: Optional[bool] = None
     tool_calls_enabled: Optional[bool] = None
-    system_prompt_extra: Optional[str] = None
 
 
 class ClientResponse(BaseModel):
@@ -79,8 +76,6 @@ class ClientResponse(BaseModel):
     max_silence_turns: int
     push_enabled: bool
     tool_calls_enabled: bool
-    # Personalización
-    system_prompt_extra: Optional[str]
 
     @classmethod
     def from_record(cls, r: ClientRecord) -> "ClientResponse":
@@ -104,5 +99,4 @@ class ClientResponse(BaseModel):
             max_silence_turns=r.max_silence_turns,
             push_enabled=r.push_enabled,
             tool_calls_enabled=r.tool_calls_enabled,
-            system_prompt_extra=r.system_prompt_extra,
         )

--- a/src/models/schemas.py
+++ b/src/models/schemas.py
@@ -21,7 +21,6 @@ class ClientConfig(BaseModel):
     stt_vad_thold: float = 0.0
     tts_voice: str = "af_heart"
     tts_speed: float = 1.0
-    system_prompt_extra: Optional[str] = None
     barge_in_enabled: bool = True
     barge_in_min_chars: int = 5
     silence_timeout_s: float = 2.0

--- a/src/services/bridge.py
+++ b/src/services/bridge.py
@@ -464,7 +464,6 @@ class JotaBridge:
             try:
                 await call_orchestrator(
                     self.orchestrator, text, session_key, self.client_id,
-                    system_prompt_extra=self.config.system_prompt_extra,
                     tracker=self.tracker,
                     on_token=_on_token,
                     on_tool_call=_on_tool_call,

--- a/src/services/db_client.py
+++ b/src/services/db_client.py
@@ -71,7 +71,6 @@ class DbClient:
             tts_speed=record.tts_speed,
             barge_in_enabled=record.barge_in_enabled,
             barge_in_min_chars=record.barge_in_min_chars,
-            system_prompt_extra=record.system_prompt_extra,
             silence_timeout_s=record.silence_timeout_s,
             max_silence_turns=record.max_silence_turns,
             push_enabled=record.push_enabled,

--- a/src/services/openclaw/client.py
+++ b/src/services/openclaw/client.py
@@ -143,7 +143,6 @@ class OpenClawClient:
         text: str,
         user_id: str,
         model_id: Optional[str] = None,
-        system_prompt_extra: Optional[str] = None,
         session_key: Optional[str] = None,
     ) -> AsyncIterator[OrchestratorEvent]:
         if not self._ws:

--- a/src/services/openclaw/reconnecting.py
+++ b/src/services/openclaw/reconnecting.py
@@ -78,7 +78,6 @@ class ReconnectingOpenClawClient:
         text: str,
         user_id: str,
         model_id: Optional[str] = None,
-        system_prompt_extra: Optional[str] = None,
         session_key: Optional[str] = None,
     ) -> AsyncIterator[OrchestratorEvent]:
         if self.state != ConnectionState.CONNECTED:
@@ -91,7 +90,6 @@ class ReconnectingOpenClawClient:
                 text=text,
                 user_id=user_id,
                 model_id=model_id,
-                system_prompt_extra=system_prompt_extra,
                 session_key=session_key,
             ):
                 yield event

--- a/src/services/orchestration.py
+++ b/src/services/orchestration.py
@@ -14,7 +14,6 @@ async def call_orchestrator(
     session_key: str,
     user_id: str,
     model_id: Optional[str] = None,
-    system_prompt_extra: Optional[str] = None,
     tracker: Optional[PipelineTracker] = None,
     on_token: Optional[Callable[[str], Awaitable[None]]] = None,
     on_tool_call: Optional[Callable[[ToolCallEvent], Awaitable[None]]] = None,
@@ -34,7 +33,6 @@ async def call_orchestrator(
         text=text,
         user_id=user_id,
         model_id=model_id,
-        system_prompt_extra=system_prompt_extra,
         session_key=session_key,
     ):
         if event.type == "token":

--- a/src/services/protocol.py
+++ b/src/services/protocol.py
@@ -22,6 +22,5 @@ class OrchestratorProtocol(Protocol):
         text: str,
         user_id: str,
         model_id: Optional[str] = None,
-        system_prompt_extra: Optional[str] = None,
         session_key: Optional[str] = None,
     ) -> AsyncIterator[OrchestratorEvent]: ...

--- a/tests/integration/test_admin_clients.py
+++ b/tests/integration/test_admin_clients.py
@@ -180,3 +180,30 @@ def test_patch_client_tool_calls_enabled(http):
     )
     assert r.status_code == 200
     assert r.json()["tool_calls_enabled"] is True
+
+
+# --- system_prompt_extra removed (#100) ---
+# `ClientCreate`/`ClientUpdate` have no `model_config` overriding pydantic's
+# default `extra="ignore"` behavior, so an unrecognized field in the request
+# body is silently dropped rather than rejected with 422.
+
+def test_create_client_ignores_system_prompt_extra(http):
+    r = http.post(
+        "/admin/clients",
+        json={"name": "Legacy", "system_prompt_extra": "Habla en inglés"},
+        headers=HEADERS,
+    )
+    assert r.status_code == 201
+    data = r.json()
+    assert "system_prompt_extra" not in data
+
+
+def test_patch_client_ignores_system_prompt_extra(http):
+    created = http.post("/admin/clients", json={"name": "Legacy"}, headers=HEADERS).json()
+    r = http.patch(
+        f"/admin/clients/{created['id']}",
+        json={"system_prompt_extra": "Habla en inglés"},
+        headers=HEADERS,
+    )
+    assert r.status_code == 200
+    assert "system_prompt_extra" not in r.json()

--- a/tests/integration/test_bridge_audio_flow.py
+++ b/tests/integration/test_bridge_audio_flow.py
@@ -102,7 +102,7 @@ def test_audio_chunk_transcribed_and_forwarded_to_orchestrator(mock_services, se
     called_with_text = {}
     mock_orch = make_mock_orchestrator()
 
-    async def _stream(text, user_id, model_id=None, system_prompt_extra=None, session_key=None):
+    async def _stream(text, user_id, model_id=None, session_key=None):
         called_with_text["text"] = text
         yield OrchestratorEvent(type="token", content="ok")
         yield OrchestratorEvent(type="status", content="done")

--- a/tests/integration/test_bridge_flow.py
+++ b/tests/integration/test_bridge_flow.py
@@ -3,12 +3,8 @@
 input_mode=text: sin transcriber. El cliente manda texto plano,
 recibe tokens del orchestrator.
 """
-from sqlmodel import Session
-from unittest.mock import AsyncMock, MagicMock
-
-from src.db.models import ClientRecord
 from src.services.protocol import OrchestratorEvent
-from tests.integration.conftest import VALID_KEY, CLIENT_ID, CLIENT_NAME
+from tests.integration.conftest import VALID_KEY, CLIENT_ID
 
 HANDSHAKE_TEXT = {
     "client_key": VALID_KEY,
@@ -37,7 +33,7 @@ def test_orchestrator_receives_correct_user_id(client, mock_registry, mock_orche
     """El user_id pasado a stream_response coincide con el client UUID."""
     captured = {}
 
-    async def _stream(text, user_id, model_id=None, system_prompt_extra=None, session_key=None):
+    async def _stream(text, user_id, model_id=None, session_key=None):
         captured["user_id"] = user_id
         yield OrchestratorEvent(type="token", content="ok")
         yield OrchestratorEvent(type="status", content="done")
@@ -52,54 +48,3 @@ def test_orchestrator_receives_correct_user_id(client, mock_registry, mock_orche
         ws.receive_json()  # token
 
     assert captured["user_id"] == CLIENT_ID
-
-
-def _make_client_with(db_engine, mock_services, mock_registry, monkeypatch, **fields):
-    """Inserta un ClientRecord con los campos especificados y devuelve un TestClient."""
-    from starlette.testclient import TestClient
-    from src.main import app
-    from src.services.openclaw.registry import TurnRegistry, ClientRegistry
-
-    with Session(db_engine) as s:
-        s.add(ClientRecord(
-            id=CLIENT_ID,
-            name=CLIENT_NAME,
-            client_key=VALID_KEY,
-            is_active=True,
-            **fields,
-        ))
-        s.commit()
-
-    monkeypatch.setattr("src.main.ReconnectingOpenClawClient", lambda *a, **kw: mock_registry)
-    monkeypatch.setattr("src.main.OpenClawClient", lambda *a, **kw: MagicMock())
-    monkeypatch.setattr("src.main.FrameDispatcher", lambda *a, **kw: MagicMock())
-    monkeypatch.setattr("src.main.TurnRegistry", lambda: TurnRegistry())
-    monkeypatch.setattr("src.main.ClientRegistry", lambda: ClientRegistry())
-    mock_registry.connect = AsyncMock()
-    mock_registry.close = AsyncMock()
-    return TestClient(app)
-
-
-def test_system_prompt_extra_included_in_orchestrator_payload(
-    db_engine, mock_services, mock_registry, mock_orchestrator, monkeypatch
-):
-    """system_prompt_extra de ClientConfig se pasa a stream_response."""
-    captured = {}
-
-    async def _stream(text, user_id, model_id=None, system_prompt_extra=None, session_key=None):
-        captured["system_prompt_extra"] = system_prompt_extra
-        yield OrchestratorEvent(type="token", content="ok")
-        yield OrchestratorEvent(type="status", content="done")
-
-    mock_orchestrator.stream_response = _stream
-
-    with _make_client_with(db_engine, mock_services, mock_registry, monkeypatch,
-                           system_prompt_extra="Habla en inglés") as c:
-        with c.websocket_connect("/ws/stream") as ws:
-            ws.send_json(HANDSHAKE_TEXT)
-            ws.receive_json()  # ready
-            ws.send_text("test")
-            ws.receive_json()  # turn_start
-            ws.receive_json()  # token
-
-    assert captured.get("system_prompt_extra") == "Habla en inglés"

--- a/tests/integration/test_rest_openai.py
+++ b/tests/integration/test_rest_openai.py
@@ -32,7 +32,7 @@ def test_chat_completions_uses_correct_session_key(client, mock_registry, mock_o
     from src.core.session_key import make_session_key
     captured = {}
 
-    async def _stream(text, user_id, model_id=None, system_prompt_extra=None, session_key=None):
+    async def _stream(text, user_id, model_id=None, session_key=None):
         captured["session_key"] = session_key
         yield OrchestratorEvent(type="token", content="ok")
         yield OrchestratorEvent(type="status", content="done")
@@ -293,7 +293,7 @@ def test_chat_completions_with_valid_key_uses_real_client_session_key(client_unt
     from src.core.session_key import make_session_key
     captured = {}
 
-    async def _stream(text, user_id, model_id=None, system_prompt_extra=None, session_key=None):
+    async def _stream(text, user_id, model_id=None, session_key=None):
         captured["session_key"] = session_key
         captured["user_id"] = user_id
         yield OrchestratorEvent(type="token", content="ok")

--- a/tests/unit/test_migrations.py
+++ b/tests/unit/test_migrations.py
@@ -1,3 +1,4 @@
+from alembic import command
 from sqlalchemy import create_engine, inspect, text
 from sqlmodel import SQLModel
 
@@ -22,7 +23,8 @@ def test_fresh_db_upgrades_from_scratch(tmp_path, monkeypatch):
     assert "clients" in tables
     assert "alembic_version" in tables
     columns = {c["name"] for c in inspect(engine).get_columns("clients")}
-    assert {"id", "client_key", "tool_calls_enabled", "system_prompt_extra"} <= columns
+    assert {"id", "client_key", "tool_calls_enabled"} <= columns
+    assert "system_prompt_extra" not in columns
 
 
 def test_legacy_db_gets_stamped_without_altering_schema(tmp_path, monkeypatch):
@@ -57,3 +59,34 @@ def test_already_versioned_db_is_a_clean_noop(tmp_path, monkeypatch):
 
     engine = create_engine(f"sqlite:///{db_path}")
     assert "clients" in inspect(engine).get_table_names()
+
+
+def test_drop_system_prompt_extra_migration_applies_and_rolls_back(tmp_path, monkeypatch):
+    """Revision 106077a95a0f drops `system_prompt_extra`; downgrading restores it
+    with the same type/nullability as the initial migration (#100)."""
+    db_path = tmp_path / "rollback.db"
+    _point_at(monkeypatch, db_path)
+    cfg = database._alembic_config()
+
+    # Start from the initial schema — column present.
+    command.upgrade(cfg, "21cb0cf4f6f9")
+    engine = create_engine(f"sqlite:///{db_path}")
+    columns = {c["name"]: c for c in inspect(engine).get_columns("clients")}
+    assert "system_prompt_extra" in columns
+    assert columns["system_prompt_extra"]["nullable"] is True
+    engine.dispose()
+
+    # Upgrade to head (106077a95a0f) — column dropped.
+    command.upgrade(cfg, "106077a95a0f")
+    engine = create_engine(f"sqlite:///{db_path}")
+    columns = {c["name"] for c in inspect(engine).get_columns("clients")}
+    assert "system_prompt_extra" not in columns
+    engine.dispose()
+
+    # Downgrade back to the initial revision — column restored.
+    command.downgrade(cfg, "21cb0cf4f6f9")
+    engine = create_engine(f"sqlite:///{db_path}")
+    columns = {c["name"]: c for c in inspect(engine).get_columns("clients")}
+    assert "system_prompt_extra" in columns
+    assert columns["system_prompt_extra"]["nullable"] is True
+    engine.dispose()


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
<think>
Let me analyze the code changes to understand what was implemented in this pull request.

Looking at the changes:

1. **Database model (`src/db/models.py`)**: The `system_prompt_extra` field was removed from `ClientRecord`.

2. **Admin schemas (`src/models/admin_schemas.py`)**: The `system_prompt_extra` field was removed from `ClientCreate`, `ClientUpdate`, and `ClientResponse` models.

3. **Client config (`src/models/schemas.py`)**: The `system_prompt_extra` field was removed from `ClientConfig`.

4. **Database client (`src/services/db_client.py`)**: The `system_prompt_extra` field is no longer mapped from the database record to the config.

5. **Admin routes (`src/api/admin_routes.py`)**: The `system_prompt_extra` field is no longer passed when creating a client.

6. **OpenAI routes (`src/api/openai_routes.py`)**: The `system_prompt_extra` variable was removed.

7. **Bridge service (`src/services/bridge.py`)**: The `system_prompt_extra` parameter was removed from the `call_orchestrator` call.

8. **Orchestration service (`src/services/orchestration.py`)**: The `system_prompt_extra` parameter was removed from `call_orchestrator`.

9. **Protocol (`src/services/protocol.py`)**: The `system_prompt_extra` parameter was removed from the `stream_response` interface.

10. **OpenClaw client (`src/services/openclaw/client.py`)**: The `system_prompt_extra` parameter was removed from `stream_response`.

11. **Reconnecting client (`src/services/openclaw/reconnecting.py`)**: The `system_prompt_extra` parameter was removed from `stream_response`.
 
A new Alembic migration (`migrations/versions/106077a95a0f_drop_system_prompt_extra_column.py`) drops the `system_prompt_extra` column from the database. Documentation was updated in `CLAUDE.md` and `docs/ROADMAP.md` to reflect this removal, with the roadmap marking issue #100 as resolved. The `docs/openclaw-protocol.md` file now includes investigation notes explaining that OpenClaw lacks a per-session or per-message system prompt hook, which justified the field's removal.

The test suite was adjusted to account for the field's deletion. Tests in `tests/integration/test_admin_clients.py` verify that creating or patching a client with `system_prompt_extra` is silently ignored rather than causing errors. Unit tests were updated to remove `system_prompt_extra` from mock signatures, and `tests/integration/test_bridge_flow.py` dropped a test case that validated the field's inclusion in orchestrator payloads. A migration test was added to confirm the column drop and rollback work correctly.

This pull request resolves issue #100 by completely removing the `system_prompt_extra` field throughout the codebase. The investigation revealed no viable wire protocol mechanism to transmit per-client system prompts to OpenClaw, so the field was eliminated entirely from the database schema, API, and configuration rather than kept as non-functional code. The implementation includes a migration to drop the column, documentation updates, and tests confirming the field is properly ignored.
</think>

## Summary

This pull request removes the `system_prompt_extra` field entirely from the jota-gateway codebase, addressing issue #100.

**What was changed:**

The `system_prompt_extra` field (which allowed adding custom instructions to the system prompt per client) was completely removed from:

- **Database**: Removed the column from `ClientRecord` model and added an Alembic migration to drop it
- **API schemas**: Removed from `ClientCreate`, `ClientUpdate`, and `ClientResponse` 
- **Client config**: Removed from `ClientConfig` 
- **All service layers**: Removed from `call_orchestrator`, `stream_response` methods in bridge, orchestration, OpenClaw client, and reconnecting client
- **Admin routes**: No longer accepts the field when creating clients

**Why:**

The investigation revealed there is no wire-level hook in OpenClaw's protocol to support per-client system prompts. The `chat.send` API has `additionalProperties: false` so extra fields are rejected, `chat.inject` writes as assistant role (wrong visibility), and `sessions.patch` doesn't support system prompts. The only mechanisms are agent-level overrides (wrong granularity) or server-side plugins (not reachable from a remote gateway).

**Result:**

Requests with `system_prompt_extra` are now silently ignored (Pydantic's default `extra="ignore"` behavior) rather than silently dropped before reaching OpenClaw. The field was completely eliminated rather than kept as non-functional code.
<!-- kody-pr-summary:end -->