### PR TITLE
fix: cache invalidation race + thread-safe lock (#107)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -181,6 +181,8 @@ db_client.invalidate(client_key)        # evict from 60s TTL cache
 
 The singleton `db_client = DbClient()` is imported from this module everywhere. An optional `engine` constructor parameter allows injecting a test engine.
 
+`invalidate()` must be called **after** the triggering `session.commit()`, never before — calling it first reopens the exact cache-repopulation race the generation-counter guard exists to close (see the Cache pattern section).
+
 ---
 
 ## WebSocket session lifecycle (`routes.py` → `bridge.py`)
@@ -328,7 +330,9 @@ The `/v1/*` routes use `Depends(resolve_ha_caller)` (`src/api/openai_routes.py`)
 
 ## Cache pattern (`src/core/cache.py`)
 
-`make_cache(maxsize, ttl)` returns `(TTLCache, asyncio.Lock)`. The lock must wrap **only dict access**, never IO calls — acquire lock to check/set, release before any await.
+`make_cache(maxsize, ttl)` returns `(TTLCache, threading.Lock)`. A real OS-level mutex, not `asyncio.Lock`, because callers span both the event loop (async handlers) and Starlette's threadpool (sync `def` route handlers, e.g. `admin_routes.py`) — `asyncio.Lock` is only safe to acquire from the loop it's bound to. The lock must wrap **only dict access, including TTLCache's internal expiry housekeeping** (`in`, `[]`, `.pop()` all trigger it), never IO calls — acquire lock to check/set, release before any query or await.
+
+Callers that cache the result of an external lookup (e.g. `DbClient._session_cache`) must guard against a stale write racing a concurrent invalidation: capture a per-key generation counter under the lock before the lookup, then only write to cache if the generation is unchanged after the lookup completes. See `DbClient.get_session` / `DbClient.invalidate` for the reference implementation.
 
 ---
 

--- a/src/api/admin_routes.py
+++ b/src/api/admin_routes.py
@@ -126,9 +126,10 @@ def delete_client(
     session: Session = Depends(get_db_session),
 ) -> None:
     rec = _get_or_404(session, client_id)
-    db_client.invalidate(rec.client_key)
+    client_key = rec.client_key
     session.delete(rec)
     session.commit()
+    db_client.invalidate(client_key)
 
 
 @router.post("/clients/{client_id}/rotate-key", response_model=ClientResponse)
@@ -137,11 +138,12 @@ def rotate_client_key(
     session: Session = Depends(get_db_session),
 ) -> ClientResponse:
     rec = _get_or_404(session, client_id)
-    db_client.invalidate(rec.client_key)
+    old_key = rec.client_key
     rec.client_key = secrets.token_urlsafe(32)
     session.add(rec)
     session.commit()
     session.refresh(rec)
+    db_client.invalidate(old_key)
     return ClientResponse.from_record(rec)
 
 

--- a/src/core/cache.py
+++ b/src/core/cache.py
@@ -1,29 +1,39 @@
-import asyncio
+import threading
+
 from cachetools import TTLCache
 
 
-def make_cache(maxsize: int, ttl: int) -> tuple[TTLCache, asyncio.Lock]:
+def make_cache(maxsize: int, ttl: int) -> tuple[TTLCache, threading.Lock]:
     """
-    Crea un par (cache, lock) listo para usar en métodos async.
+    Crea un par (cache, lock) listo para usar tanto desde código async
+    (event loop) como desde handlers síncronos ejecutados en el threadpool
+    de Starlette (p.ej. rutas `def` de admin_routes.py).
 
     Args:
         maxsize: Número máximo de entradas. Las más antiguas se expulsan (LRU) al superarse.
         ttl:     Segundos hasta que una entrada expira automáticamente.
 
     Returns:
-        (TTLCache, asyncio.Lock) — el lock debe envolver SOLO el acceso al dict,
-        nunca el IO, para no bloquear el event loop.
+        (TTLCache, threading.Lock) — el lock es un mutex real de SO, seguro
+        de adquirir desde cualquier hilo (a diferencia de asyncio.Lock, que
+        se vincula al primer event loop que lo usa y no es seguro entre
+        hilos). Debe envolver SOLO el acceso al dict — incluyendo el
+        housekeeping interno de expiración que TTLCache dispara en `in`,
+        `[]` y `.pop()` — nunca el IO. Las secciones críticas son
+        operaciones de dict puras del orden de microsegundos, así que
+        bloquear con él dentro de una corrutina no bloquea el event loop
+        de forma apreciable.
 
     Example::
 
         _cache, _lock = make_cache(maxsize=500, ttl=60)
 
-        async with _lock:
+        with _lock:
             if key in _cache:
                 return _cache[key]
         result = await fetch(key)          # IO fuera del lock
-        async with _lock:
+        with _lock:
             _cache[key] = result
         return result
     """
-    return TTLCache(maxsize=maxsize, ttl=ttl), asyncio.Lock()
+    return TTLCache(maxsize=maxsize, ttl=ttl), threading.Lock()

--- a/src/services/db_client.py
+++ b/src/services/db_client.py
@@ -58,6 +58,7 @@ class DbClient:
     def __init__(self, engine=None):
         self._engine = engine
         self._session_cache, self._session_lock = make_cache(maxsize=500, ttl=60)
+        self._generations: dict[str, int] = {}
 
     def _get_engine(self):
         return self._engine if self._engine is not None else get_engine()
@@ -66,6 +67,12 @@ class DbClient:
         """
         Resuelve client_key → (Client, ClientConfig). Resultado cacheado 60 s.
 
+        Usa un contador de generación por-key para evitar repoblar el
+        caché con un valor obsoleto: si invalidate() corre en otro hilo
+        mientras la consulta a BD está en vuelo, la generación capturada
+        antes de la consulta ya no coincide al terminar y el resultado NO
+        se escribe en caché (el siguiente acceso volverá a consultar BD).
+
         Raises:
             ClientNotFound: la key no existe.
             ClientInactive: el cliente está desactivado.
@@ -73,6 +80,7 @@ class DbClient:
         with self._session_lock:
             if client_key in self._session_cache:
                 return self._session_cache[client_key]
+            generation_before = self._generations.get(client_key, 0)
 
         with Session(self._get_engine()) as session:
             record: Optional[ClientRecord] = session.exec(
@@ -106,12 +114,21 @@ class DbClient:
         )
         result = (client, config)
         with self._session_lock:
-            self._session_cache[client_key] = result
+            if self._generations.get(client_key, 0) == generation_before:
+                self._session_cache[client_key] = result
         return result
 
     def invalidate(self, client_key: str) -> None:
-        """Elimina la entrada del caché. Llamar tras cualquier mutación en admin."""
-        self._session_cache.pop(client_key, None)
+        """Elimina la entrada del caché y avanza su generación.
+
+        Seguro de llamar desde cualquier hilo (p.ej. handlers `def`
+        síncronos de admin_routes.py, ejecutados en el threadpool de
+        Starlette, distinto del hilo del event loop). Llamar siempre
+        DESPUÉS de session.commit() en el mismo call site.
+        """
+        with self._session_lock:
+            self._session_cache.pop(client_key, None)
+            self._generations[client_key] = self._generations.get(client_key, 0) + 1
 
 
 # Singleton — importar este objeto directamente

--- a/src/services/db_client.py
+++ b/src/services/db_client.py
@@ -70,7 +70,7 @@ class DbClient:
             ClientNotFound: la key no existe.
             ClientInactive: el cliente está desactivado.
         """
-        async with self._session_lock:
+        with self._session_lock:
             if client_key in self._session_cache:
                 return self._session_cache[client_key]
 
@@ -105,7 +105,7 @@ class DbClient:
             allowed_agents=_parse_allowed_agents(record.allowed_agents),
         )
         result = (client, config)
-        async with self._session_lock:
+        with self._session_lock:
             self._session_cache[client_key] = result
         return result
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -65,10 +65,12 @@ def seed_client(db_engine):
 
 @pytest.fixture(autouse=True)
 def clear_db_cache():
-    """Limpia el caché de db_client antes y después de cada test."""
+    """Limpia el caché y el contador de generaciones de db_client antes y después de cada test."""
     db_client._session_cache.clear()
+    db_client._generations.clear()
     yield
     db_client._session_cache.clear()
+    db_client._generations.clear()
 
 
 @pytest.fixture(autouse=True)

--- a/tests/integration/test_admin_clients.py
+++ b/tests/integration/test_admin_clients.py
@@ -1,7 +1,9 @@
 """Tests para /admin/clients/* CRUD."""
 import pytest
 from sqlalchemy.pool import StaticPool
-from sqlmodel import SQLModel, create_engine
+from sqlmodel import Session, SQLModel, create_engine
+
+from src.services.db_client import db_client
 
 
 ADMIN_TOKEN = "test-admin-token"
@@ -143,6 +145,56 @@ def test_rotate_key(http):
     new_key = r.json()["client_key"]
     assert new_key != old_key
     assert len(new_key) > 20
+
+
+# --- INVALIDATE ORDERING (issue #107) ---
+
+def test_delete_client_commits_before_invalidating_cache(http, monkeypatch):
+    created = http.post("/admin/clients", json={"name": "Del"}, headers=HEADERS).json()
+
+    order = []
+    original_commit = Session.commit
+    original_invalidate = db_client.invalidate
+
+    def spy_commit(self):
+        order.append("commit")
+        return original_commit(self)
+
+    def spy_invalidate(client_key):
+        order.append("invalidate")
+        return original_invalidate(client_key)
+
+    monkeypatch.setattr(Session, "commit", spy_commit)
+    monkeypatch.setattr(db_client, "invalidate", spy_invalidate)
+
+    r = http.delete(f"/admin/clients/{created['id']}", headers=HEADERS)
+
+    assert r.status_code == 204
+    assert order == ["commit", "invalidate"]
+
+
+def test_rotate_key_commits_before_invalidating_cache(http, monkeypatch):
+    created = http.post("/admin/clients", json={"name": "R"}, headers=HEADERS).json()
+
+    order = []
+    original_commit = Session.commit
+    original_invalidate = db_client.invalidate
+
+    def spy_commit(self):
+        order.append("commit")
+        return original_commit(self)
+
+    def spy_invalidate(client_key):
+        order.append("invalidate")
+        return original_invalidate(client_key)
+
+    monkeypatch.setattr(Session, "commit", spy_commit)
+    monkeypatch.setattr(db_client, "invalidate", spy_invalidate)
+
+    r = http.post(f"/admin/clients/{created['id']}/rotate-key", headers=HEADERS)
+
+    assert r.status_code == 200
+    assert order == ["commit", "invalidate"]
 
 
 # --- AUTH ---

--- a/tests/unit/test_cache.py
+++ b/tests/unit/test_cache.py
@@ -1,0 +1,33 @@
+import asyncio
+import threading
+
+from cachetools import TTLCache
+
+from src.core.cache import make_cache
+
+
+def test_make_cache_returns_ttlcache_instance():
+    cache, _ = make_cache(maxsize=10, ttl=5)
+    assert isinstance(cache, TTLCache)
+
+
+def test_make_cache_lock_is_a_real_thread_lock_not_asyncio_lock():
+    _, lock = make_cache(maxsize=10, ttl=5)
+    assert not isinstance(lock, asyncio.Lock)
+    assert isinstance(lock, type(threading.Lock()))
+
+
+def test_make_cache_lock_is_acquirable_from_a_different_thread():
+    _, lock = make_cache(maxsize=10, ttl=5)
+    acquired_in_other_thread = {}
+
+    def worker():
+        acquired_in_other_thread["ok"] = lock.acquire(timeout=1)
+        if acquired_in_other_thread["ok"]:
+            lock.release()
+
+    t = threading.Thread(target=worker)
+    t.start()
+    t.join(timeout=2)
+
+    assert acquired_in_other_thread.get("ok") is True

--- a/tests/unit/test_db_client_local.py
+++ b/tests/unit/test_db_client_local.py
@@ -138,17 +138,42 @@ def test_generation_guard_prevents_stale_repopulation_after_concurrent_invalidat
     assert "race-key" not in client._session_cache
 
 
-def test_concurrent_readers_and_invalidate_never_leave_stale_cache():
+def test_concurrent_readers_and_invalidate_never_leave_stale_cache(tmp_path):
     """100 get_session concurrentes + 1 invalidate intercalado: una lectura
     final debe reflejar siempre el estado post-mutación, nunca el valor
-    anterior a la invalidación."""
-    engine = _engine_with(ClientRecord(name="v1", client_key="hammer-key"))
+    anterior a la invalidación.
+
+    A diferencia de `_engine_with`, este motor usa un fichero SQLite real
+    en disco (sin `StaticPool`) para que cada uno de los 100 hilos obtenga
+    su propia conexión DBAPI real en lugar de contender por la única
+    conexión compartida que `:memory:` + `StaticPool` fuerza. Con 100
+    hilos golpeando una sola conexión SQLite compartida, SQLAlchemy/SQLite
+    pueden devolver filas corruptas de forma esporádica, lo que hacía que
+    este test fallase de forma silenciosa (excepciones perdidas dentro de
+    los hilos) en vez de fallar de forma explícita.
+    """
+    engine = create_engine(
+        f"sqlite:///{tmp_path}/test.db",
+        connect_args={"check_same_thread": False},
+    )
+    SQLModel.metadata.create_all(engine)
+    with Session(engine) as s:
+        s.add(ClientRecord(name="v1", client_key="hammer-key"))
+        s.commit()
+
     client = DbClient(engine=engine)
 
-    def reader():
-        asyncio.run(client.get_session("hammer-key"))
+    reader_errors = []
+    errors_lock = threading.Lock()
 
-    threads = [threading.Thread(target=reader) for _ in range(100)]
+    def reader(idx):
+        try:
+            asyncio.run(client.get_session("hammer-key"))
+        except Exception as exc:  # cualquier fallo del lector debe ser visible, no silencioso
+            with errors_lock:
+                reader_errors.append((idx, exc))
+
+    threads = [threading.Thread(target=reader, args=(i,)) for i in range(100)]
     for t in threads:
         t.start()
 
@@ -161,6 +186,8 @@ def test_concurrent_readers_and_invalidate_never_leave_stale_cache():
 
     for t in threads:
         t.join(timeout=5)
+
+    assert reader_errors == [], f"reader thread(s) raised: {reader_errors}"
 
     client_obj, _ = asyncio.run(client.get_session("hammer-key"))
     assert client_obj.name == "v2"

--- a/tests/unit/test_db_client_local.py
+++ b/tests/unit/test_db_client_local.py
@@ -1,3 +1,6 @@
+import asyncio
+import threading
+
 import pytest
 from sqlalchemy.pool import StaticPool
 from sqlmodel import Session, SQLModel, create_engine, select
@@ -80,3 +83,142 @@ async def test_invalidate_clears_cache():
     client.invalidate("inv-key")
     c2, _ = await client.get_session("inv-key")
     assert c2.name == "After"
+
+
+@pytest.mark.asyncio
+async def test_invalidate_advances_generation_counter():
+    engine = _engine_with(ClientRecord(name="Gen", client_key="gen-key"))
+    client = DbClient(engine=engine)
+    await client.get_session("gen-key")
+    assert client._generations.get("gen-key", 0) == 0
+
+    client.invalidate("gen-key")
+    assert client._generations["gen-key"] == 1
+
+    client.invalidate("gen-key")
+    assert client._generations["gen-key"] == 2
+
+
+def test_generation_guard_prevents_stale_repopulation_after_concurrent_invalidate(monkeypatch):
+    """Si invalidate() corre en otro hilo mientras get_session() está en
+    vuelo (incluso antes de que la consulta a BD arranque), el resultado
+    obsoleto no debe repoblar el caché compartido."""
+    engine = _engine_with(ClientRecord(name="Before", client_key="race-key"))
+    client = DbClient(engine=engine)
+
+    query_started = threading.Event()
+    release_query = threading.Event()
+    original_exec = Session.exec
+
+    def slow_exec(self, *args, **kwargs):
+        query_started.set()
+        release_query.wait(timeout=5)
+        return original_exec(self, *args, **kwargs)
+
+    monkeypatch.setattr(Session, "exec", slow_exec)
+
+    reader_result = {}
+
+    def run_reader():
+        reader_result["value"] = asyncio.run(client.get_session("race-key"))
+
+    reader = threading.Thread(target=run_reader)
+    reader.start()
+    assert query_started.wait(timeout=5), "el lector nunca llegó a la consulta de BD"
+
+    # Simula la mutación de admin completándose mientras la consulta del
+    # lector sigue en vuelo: invalidate() corre en el hilo principal del
+    # test, un hilo distinto al del lector.
+    client.invalidate("race-key")
+
+    release_query.set()
+    reader.join(timeout=5)
+
+    assert "value" in reader_result
+    assert "race-key" not in client._session_cache
+
+
+def test_concurrent_readers_and_invalidate_never_leave_stale_cache():
+    """100 get_session concurrentes + 1 invalidate intercalado: una lectura
+    final debe reflejar siempre el estado post-mutación, nunca el valor
+    anterior a la invalidación."""
+    engine = _engine_with(ClientRecord(name="v1", client_key="hammer-key"))
+    client = DbClient(engine=engine)
+
+    def reader():
+        asyncio.run(client.get_session("hammer-key"))
+
+    threads = [threading.Thread(target=reader) for _ in range(100)]
+    for t in threads:
+        t.start()
+
+    with Session(engine) as s:
+        rec = s.exec(select(ClientRecord)).first()
+        rec.name = "v2"
+        s.add(rec)
+        s.commit()
+    client.invalidate("hammer-key")
+
+    for t in threads:
+        t.join(timeout=5)
+
+    client_obj, _ = asyncio.run(client.get_session("hammer-key"))
+    assert client_obj.name == "v2"
+
+
+def test_rotated_key_does_not_poison_cache_when_read_races_the_commit(monkeypatch):
+    """Simula rotate_client_key: la consulta de un lector arranca y LEE la
+    fila con la key vieja ANTES de que el admin mute + commitee + invalide
+    (orden fijado por el fix de #107 en admin_routes.py). El resultado
+    obsoleto no debe repoblar el caché, y una lectura posterior de la key
+    vieja debe fallar con ClientNotFound."""
+    engine = _engine_with(ClientRecord(name="R", client_key="old-key"))
+    client = DbClient(engine=engine)
+
+    first_call_done = threading.Event()
+    release_first_call = threading.Event()
+    call_count = {"n": 0}
+    count_lock = threading.Lock()
+    original_exec = Session.exec
+
+    def slow_exec(self, *args, **kwargs):
+        result = original_exec(self, *args, **kwargs)
+        with count_lock:
+            call_count["n"] += 1
+            is_first_call = call_count["n"] == 1
+        if is_first_call:
+            first_call_done.set()
+            release_first_call.wait(timeout=5)
+        return result
+
+    monkeypatch.setattr(Session, "exec", slow_exec)
+
+    reader_result = {}
+
+    def run_reader():
+        reader_result["value"] = asyncio.run(client.get_session("old-key"))
+
+    reader = threading.Thread(target=run_reader)
+    reader.start()
+    assert first_call_done.wait(timeout=5), "el lector nunca completó su consulta de BD"
+
+    with Session(engine) as s:
+        rec = s.exec(select(ClientRecord)).first()
+        rec.client_key = "new-key"
+        s.add(rec)
+        s.commit()
+    client.invalidate("old-key")
+
+    release_first_call.set()
+    reader.join(timeout=5)
+
+    # El lector, cuya lectura ganó la carrera contra el commit, obtiene
+    # legítimamente el dato pre-rotación...
+    reader_client, _ = reader_result["value"]
+    assert reader_client.client_key == "old-key"
+    # ...pero ese resultado obsoleto NUNCA debe repoblar el caché compartido.
+    assert "old-key" not in client._session_cache
+
+    # Cualquier lectura posterior debe reflejar la rotación ya asentada.
+    with pytest.raises(ClientNotFound):
+        asyncio.run(client.get_session("old-key"))

--- a/tests/unit/test_db_client_local.py
+++ b/tests/unit/test_db_client_local.py
@@ -99,11 +99,24 @@ async def test_invalidate_advances_generation_counter():
     assert client._generations["gen-key"] == 2
 
 
-def test_generation_guard_prevents_stale_repopulation_after_concurrent_invalidate(monkeypatch):
+def test_generation_guard_prevents_stale_repopulation_after_concurrent_invalidate(monkeypatch, tmp_path):
     """Si invalidate() corre en otro hilo mientras get_session() está en
     vuelo (incluso antes de que la consulta a BD arranque), el resultado
-    obsoleto no debe repoblar el caché compartido."""
-    engine = _engine_with(ClientRecord(name="Before", client_key="race-key"))
+    obsoleto no debe repoblar el caché compartido.
+
+    Motor de BD en fichero (sin `StaticPool`) para que el hilo lector y el
+    hilo principal del test obtengan cada uno su propia conexión DBAPI real,
+    igual que en `test_concurrent_readers_and_invalidate_never_leave_stale_cache`.
+    """
+    engine = create_engine(
+        f"sqlite:///{tmp_path}/test.db",
+        connect_args={"check_same_thread": False},
+    )
+    SQLModel.metadata.create_all(engine)
+    with Session(engine) as s:
+        s.add(ClientRecord(name="Before", client_key="race-key"))
+        s.commit()
+
     client = DbClient(engine=engine)
 
     query_started = threading.Event()
@@ -193,13 +206,26 @@ def test_concurrent_readers_and_invalidate_never_leave_stale_cache(tmp_path):
     assert client_obj.name == "v2"
 
 
-def test_rotated_key_does_not_poison_cache_when_read_races_the_commit(monkeypatch):
+def test_rotated_key_does_not_poison_cache_when_read_races_the_commit(monkeypatch, tmp_path):
     """Simula rotate_client_key: la consulta de un lector arranca y LEE la
     fila con la key vieja ANTES de que el admin mute + commitee + invalide
     (orden fijado por el fix de #107 en admin_routes.py). El resultado
     obsoleto no debe repoblar el caché, y una lectura posterior de la key
-    vieja debe fallar con ClientNotFound."""
-    engine = _engine_with(ClientRecord(name="R", client_key="old-key"))
+    vieja debe fallar con ClientNotFound.
+
+    Motor de BD en fichero (sin `StaticPool`) para que el hilo lector y el
+    hilo principal del test obtengan cada uno su propia conexión DBAPI real,
+    igual que en `test_concurrent_readers_and_invalidate_never_leave_stale_cache`.
+    """
+    engine = create_engine(
+        f"sqlite:///{tmp_path}/test.db",
+        connect_args={"check_same_thread": False},
+    )
+    SQLModel.metadata.create_all(engine)
+    with Session(engine) as s:
+        s.add(ClientRecord(name="R", client_key="old-key"))
+        s.commit()
+
     client = DbClient(engine=engine)
 
     first_call_done = threading.Event()


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
<think>
Let me analyze the code changes to understand what was implemented, fixed, or changed in this pull request.

## Summary of Changes

Looking at the patches:

### 1. `CLAUDE.md` - Documentation update
- Added a note that `invalidate()` must be called **after** `session.commit()`, never before
- Updated the cache pattern documentation: changed from `asyncio.Lock` to `threading.Lock` with explanation about thread-safety across async and sync handlers
- Added guidance about using per-key generation counters to guard against stale writes racing concurrent invalidation

### 2. `src/api/admin_routes.py` - Route handler fixes
- In `delete_client`: Changed order - now calls `invalidate()` AFTER `session.commit()` instead of before
- In `rotate_client_key`: Same fix - `invalidate()` is now called AFTER `session.commit()`

### 3. `src/core/cache.py` - Cache implementation change
- Changed from `asyncio.Lock` to `threading.Lock`
- Updated documentation to explain why `threading.Lock` is needed (to work across both event loop and Starlette's threadpool for sync `def` handlers)
- Changed `async with` to regular `with` for lock usage

### 4. `src/services/db_client.py` - Core cache logic fixes
- Added `_generations` dictionary to track per-key generation counters
- In `get_session`: Added generation counter capture before DB lookup, and check before writing to cache
- In `invalidate`: Now increments generation counter and uses lock for thread-safety
- Added thread-safety documentation

### 5. `tests/integration/conftest.py` - Test fixtures
- Updated `clear_db_cache` fixture to also clear `_generations`

### 6. `tests/integration/test_admin_clients.py` - New tests
- Added tests to verify that `invalidate()` is called AFTER `commit()` in both delete and rotate operations


- Added unit test verifying `make_cache` returns proper threading lock
- Added tests covering concurrent invalidation scenarios with generation guards, including 100 concurrent readers plus invalidate, and rotated key scenarios to prevent cache poisoning

The core issues addressed are thread-safety gaps from using `asyncio.Lock` instead of `threading.Lock` across async and sync handlers, race conditions between cache invalidation and repopulation via generation counters, and the ordering problem where `invalidate()` was being called before `session.commit()`.
</think>

## Summary

This pull request fixes a cache invalidation race condition and thread-safety issues in the Jota Gateway application.

### Key Changes

**1. Thread-Safety Fix: `asyncio.Lock` → `threading.Lock`**
- Changed the cache lock from `asyncio.Lock` to `threading.Lock` in `src/core/cache.py`
- This is necessary because callers span both the async event loop and Starlette's threadpool (for sync `def` route handlers in `admin_routes.py`)
- `asyncio.Lock` is only safe within a single event loop, while `threading.Lock` works across threads

**2. Cache Repopulation Race Fix: Generation Counters**
- Added per-key generation counters in `DbClient` (`src/services/db_client.py`)
- When reading from cache, the generation is captured before the DB lookup
- After the lookup completes, the result is only cached if the generation hasn't changed
- This prevents stale data from being written to cache when `invalidate()` runs concurrently

**3. Invalidate Ordering Fix**
- Fixed `delete_client` and `rotate_client_key` in `admin_routes.py` to call `invalidate()` **after** `session.commit()` instead of before
- Previously, calling invalidation first could reopen the race condition the generation counter was meant to prevent

**4. Test Coverage**
- Added unit tests for the thread-safe lock behavior
- Added integration tests verifying the correct order of `commit()` and `invalidate()` calls
- Added tests for concurrent scenarios: 100 readers with interleaved invalidation, generation guard preventing stale repopulation, and rotated key scenarios
<!-- kody-pr-summary:end -->