### PR TITLE
fix: gate barge-in cancellation on barge_in_enabled (#108)

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -86,7 +86,7 @@ Ambas #149 y #150 arregladas antes de empezar Fase 2 (decisión 2026-07-18, rama
 - [x] **#105** 🟠 `[007]` — `default_agent`/`allowed_agents` persisted but never enforced — **M** — semántica decidida: `None`=sin restricción, `[]`=denegado, `["x"]`=solo `x` — cerrado por #154
 - [x] **#106** 🟠 `[008]` — Full `client_key` written to logs — **XS** — fingerprint SHA-256 de 8 hex + request ID + client.id post-auth; transcripts a DEBUG truncado — cerrado por #155
 - [x] **#107** 🟠 `[009]` — Cache invalidation race + thread-safety — **M** — threading.Lock cross-thread + contador de generación por-key + orden commit-antes-que-invalidate en admin_routes.py — cerrado por #157
-- [ ] **#108** 🟠 `[010]` — `barge_in_enabled=False` ignored by the bridge — **XS**
+- [x] **#108** 🟠 `[010]` — `barge_in_enabled=False` ignored by the bridge — **XS** — gate en `_on_transcription` (`bridge.py:425`), partial siempre se reenvía al cliente independientemente del flag — cerrado por #158
 - [ ] **#109** 🟠 `[011]` — `push_enabled=False` suppresses only lifecycle start, not push payloads — **S**
 
 ### 🟠 Fase 3 — Lifecycle & producción (semanas 4–5)

--- a/src/services/bridge.py
+++ b/src/services/bridge.py
@@ -421,8 +421,8 @@ class JotaBridge:
                 return  # client disconnected
             await self.tracker.record("transcription_partial", text_len=len(text))
 
-            # Barge-in: interrupt active turn if partial is substantial enough
-            if len(text) >= self.config.barge_in_min_chars:
+            # Barge-in: interrupt active turn if enabled and partial is substantial enough
+            if self.config.barge_in_enabled and len(text) >= self.config.barge_in_min_chars:
                 if await self._cancel_active_turn():
                     logger.info(f"[{self.client_id}] Barge-in: turno cancelado por parcial '{text[:30]}'")
                     await self.tracker.record("barge_in")

--- a/tests/integration/test_bridge_barge_in_flow.py
+++ b/tests/integration/test_bridge_barge_in_flow.py
@@ -1,0 +1,172 @@
+"""
+Integration test for #108: barge_in_enabled=False must not interrupt
+an in-flight orchestrator response when a partial transcription arrives.
+"""
+import asyncio
+import json
+import threading
+import time
+
+import pytest
+import websockets
+
+from sqlmodel import Session
+from starlette.testclient import TestClient
+
+from src.db.models import ClientRecord
+from src.main import app
+from src.core.config import settings
+from src.services.protocol import OrchestratorEvent
+from tests.integration.conftest import (
+    VALID_KEY, CLIENT_ID, CLIENT_NAME,
+    make_mock_orchestrator, make_mock_registry,
+)
+
+HANDSHAKE_AUDIO = {
+    "client_key": VALID_KEY,
+    "input_mode": "audio",
+    "output_mode": ["text"],
+}
+
+# ---------------------------------------------------------------------------
+# Fake transcriber WS server: sends a final transcription on the first audio
+# chunk, then a long partial (is_final=False) on the second chunk.
+# ---------------------------------------------------------------------------
+
+_FAKE_TRANSCRIBER_PORT = 19011
+_fake_transcriber_started = False
+
+
+def _start_fake_transcriber():
+    global _fake_transcriber_started
+    if _fake_transcriber_started:
+        return
+    _fake_transcriber_started = True
+
+    async def handler(ws):
+        raw = await ws.recv()
+        msg = json.loads(raw)
+        assert msg["type"] == "config"
+        await ws.send(json.dumps({
+            "type": "ready",
+            "protocol_version": 1,
+            "session_id": "test-barge-in-session",
+        }))
+        chunk_count = 0
+        async for chunk in ws:
+            if isinstance(chunk, bytes) and len(chunk) > 0:
+                chunk_count += 1
+                if chunk_count == 1:
+                    await ws.send(json.dumps({
+                        "type": "transcription",
+                        "text": "hola audio",
+                        "is_final": True,
+                    }))
+                elif chunk_count == 2:
+                    await ws.send(json.dumps({
+                        "type": "transcription",
+                        "text": "esto es una interrupcion larga",
+                        "is_final": False,
+                    }))
+                    break
+
+    loop = asyncio.new_event_loop()
+
+    async def run():
+        async with websockets.serve(handler, "localhost", _FAKE_TRANSCRIBER_PORT):
+            await asyncio.Future()
+
+    thread = threading.Thread(
+        target=lambda: loop.run_until_complete(run()),
+        daemon=True,
+    )
+    thread.start()
+    time.sleep(0.15)  # esperar a que el servidor arranque
+
+
+@pytest.fixture(scope="module", autouse=True)
+def start_fake_transcriber():
+    _start_fake_transcriber()
+    old_url = settings.TRANSCRIBER_WS_URL
+    settings.TRANSCRIBER_WS_URL = f"localhost:{_FAKE_TRANSCRIBER_PORT}"
+    yield
+    settings.TRANSCRIBER_WS_URL = old_url
+
+
+# ---------------------------------------------------------------------------
+# Test
+# ---------------------------------------------------------------------------
+
+
+def test_disabled_barge_in_does_not_interrupt_in_flight_response(mock_services, db_engine, monkeypatch):
+    """#108: handshake with barge_in_enabled=False + a slow (long) agent response
+    + a partial transcription mid-response → the response keeps streaming to
+    completion, no {"type": "interrupted"} is ever sent."""
+    with Session(db_engine) as s:
+        s.add(ClientRecord(
+            id=CLIENT_ID, name=CLIENT_NAME, client_key=VALID_KEY,
+            is_active=True, barge_in_enabled=False, barge_in_min_chars=5,
+        ))
+        s.commit()
+
+    mock_orch = make_mock_orchestrator()
+
+    async def _stream(text, user_id, model_id=None, session_key=None):
+        yield OrchestratorEvent(type="token", content="respuesta ")
+        await asyncio.sleep(0.3)  # keeps the turn active while the partial arrives
+        yield OrchestratorEvent(type="token", content="larga completa")
+        yield OrchestratorEvent(type="status", content="done")
+
+    mock_orch.stream_response = _stream
+    mock_reg = make_mock_registry(mock_orch)
+
+    from unittest.mock import MagicMock, AsyncMock as _AM
+    monkeypatch.setattr("src.main.ReconnectingOpenClawClient", lambda *a, **kw: mock_reg)
+    monkeypatch.setattr("src.main.OpenClawClient", lambda *a, **kw: MagicMock())
+    monkeypatch.setattr("src.main.FrameDispatcher", lambda *a, **kw: MagicMock())
+    mock_reg.connect = _AM()
+    mock_reg.close = _AM()
+
+    received_types = []
+
+    with TestClient(app) as client:
+        with client.websocket_connect("/ws/stream") as ws:
+            ws.send_json(HANDSHAKE_AUDIO)
+            ws.send_bytes(b"\x00" * 512)  # chunk 1 -> final transcription
+
+            msg = None
+            for _ in range(10):
+                msg = ws.receive_json()
+                if msg.get("type") == "transcription":
+                    break
+            assert msg["type"] == "transcription"
+            assert msg["text"] == "hola audio"
+
+            ws.send_json({"type": "send", "text": msg["text"]})  # starts the turn
+
+            msg = ws.receive_json()  # turn_start
+            assert msg["type"] == "turn_start"
+
+            msg = ws.receive_json()  # first token
+            assert msg["type"] == "token"
+            assert msg["text"] == "respuesta "
+
+            ws.send_bytes(b"\x00" * 512)  # chunk 2 -> partial while turn is active
+
+            # The turn completes with a {"type": "turn_end"} wire frame (see
+            # bridge.py's pipe_tokens()) — the mock orchestrator's internal
+            # OrchestratorEvent(type="status", content="done") is consumed by
+            # call_orchestrator() and never reaches the client verbatim. Also
+            # break on "interrupted": if barge-in wrongly fires, the active
+            # turn is cancelled and turn_end never arrives, so waiting only
+            # for turn_end would hang until the silence watchdog force-closes
+            # the connection instead of failing the assertion below cleanly.
+            for _ in range(10):
+                msg = ws.receive_json()
+                received_types.append(msg.get("type"))
+                if msg.get("type") in ("turn_end", "interrupted"):
+                    break
+
+    assert "interrupted" not in received_types
+    assert "transcription_partial" in received_types
+    assert "token" in received_types  # second token still delivered, response not cut off

--- a/tests/unit/test_bridge_barge_in.py
+++ b/tests/unit/test_bridge_barge_in.py
@@ -285,6 +285,34 @@ async def test_barge_in_triggers_when_above_custom_threshold(mock_tracker):
     assert any(c[0][0].get("type") == "interrupted" for c in calls)
 
 
+async def test_barge_in_disabled_forwards_partial_but_does_not_cancel(mock_tracker):
+    """#108: barge_in_enabled=False → partial still forwarded, but no cancellation
+    and no 'interrupted' message, even when text is above barge_in_min_chars."""
+    from src.models.schemas import ClientConfig
+    ws = AsyncMock()
+    config = ClientConfig(barge_in_enabled=False, barge_in_min_chars=3)
+    bridge = JotaBridge(client=_CLIENT, config=config, client_ws=ws, orchestrator=AsyncMock(), tts=AsyncMock(), tracker=mock_tracker,
+                        handshake=Handshake(client_key="test-key", input_mode="audio", output_mode=["audio", "text", "status"]),
+                        client_registry=ClientRegistry(), default_agent="main")
+    bridge._active_turn = asyncio.create_task(asyncio.sleep(60))
+    await asyncio.sleep(0)
+
+    # 10 chars >= barge_in_min_chars(3), but barge-in is disabled
+    await bridge._on_transcription("hola mundo", False)
+
+    calls = ws.send_json.call_args_list
+    assert len(calls) == 1  # only the partial, no "interrupted"
+    assert calls[0][0][0] == {"type": "transcription_partial", "text": "hola mundo"}
+    assert bridge._active_turn is not None
+    assert not bridge._active_turn.done()
+
+    bridge._active_turn.cancel()
+    try:
+        await bridge._active_turn
+    except (asyncio.CancelledError, Exception):
+        pass
+
+
 # ── _on_transcriber_warning ──────────────────────────────────────────────────
 
 async def test_transcriber_warning_forwarded_to_client(make_bridge):


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
<think>
Let me analyze the code changes to understand what was implemented, fixed, or changed in this pull request.

## Analysis of Code Changes

### 1. `src/services/bridge.py` - Core Fix
The main fix is in the `_on_transcription` method. The original code:
```python
# Barge-in: interrupt active turn if partial is substantial enough
if len(text) >= self.config.barge_in_min_chars:
```

Was changed to:
```python
# Barge-in: interrupt active turn if enabled and partial is substantial enough
if self.config.barge_in_enabled and len(text) >= self.config.barge_in_min_chars:
```

This adds a check for `self.config.barge_in_enabled` before attempting to cancel the active turn for barge-in. Previously, even if `barge_in_enabled` was set to `False`, the system would still interrupt active turns when partial transcriptions exceeded the `barge_in_min_chars` threshold.

### 2. `tests/unit/test_bridge_barge_in.py` - Unit Test
Added a new unit test `test_barge_in_disabled_forwards_partial_but_does_not_cancel` that:
- Creates a bridge with `barge_in_enabled=False` and `barge_in_min_chars=3`
- Sends a partial transcription of 10 characters (which exceeds the 3 char threshold)
- Verifies that:
  - The partial is still forwarded to the client
  - No "interrupted" message is sent
  - The active turn is NOT cancelled

### 3. `tests/integration/test_bridge_barge_in_flow.py` - Integration Test
Added a comprehensive integration test that:
- Sets up a fake transcriber that sends a final transcription first, then a partial
- Configures a client with `barge_in_enabled=False`


- Simulates a slow agent response while a partial transcription arrives mid-response
- Verifies that the response completes without interruption

## Summary

This fix addresses issue #108 where the `barge_in_enabled` configuration flag was being ignored. Even when users disabled barge-in functionality by setting `barge_in_enabled=False`, the system would still interrupt in-flight responses when partial transcriptions exceeded the `barge_in_min_chars` threshold. The fix ensures the configuration flag is properly respected, preventing unwanted interruptions when barge-in is disabled while still allowing partial transcriptions to be forwarded to the client.
</think>

## Summary

This pull request fixes issue #108 where the `barge_in_enabled` configuration flag was being ignored. Previously, even when barge-in was explicitly disabled in the client configuration, the system would still interrupt active responses when partial transcriptions exceeded the `barge_in_min_chars` threshold.

### Changes Made

1. **`src/services/bridge.py`**: Added a check for `self.config.barge_in_enabled` in the `_on_transcription` method. The barge-in cancellation logic now only executes when barge-in is explicitly enabled, ensuring the configuration flag is properly respected.

2. **`tests/unit/test_bridge_barge_in.py`**: Added a unit test `test_barge_in_disabled_forwards_partial_but_does_not_cancel` that verifies:
   - Partial transcriptions are still forwarded to the client when barge-in is disabled
   - No "interrupted" message is sent
   - The active turn is NOT cancelled even when text exceeds `barge_in_min_chars`

3. **`tests/integration/test_bridge_barge_in_flow.py`**: Added a full integration test that simulates a real-world scenario with a slow agent response arriving while a partial transcription arrives, confirming the response completes uninterrupted when `barge_in_enabled=False`.

### Impact

- Users who have disabled barge-in (`barge_in_enabled=False`) will no longer have their in-flight responses unexpectedly interrupted
- Partial transcriptions continue to be forwarded to the client regardless of the barge-in setting
- The configuration flag now works as documented/expected
<!-- kody-pr-summary:end -->