### PR TITLE
fix: gate deliver_push/deliver_push_tool_call on push_enabled (#109)

### DIFF
--- a/src/services/bridge.py
+++ b/src/services/bridge.py
@@ -552,6 +552,17 @@ class JotaBridge:
         except Exception:
             pass
 
+    def _push_allowed(self) -> bool:
+        """Single decision point for whether an unsolicited (orchestrator-pushed)
+        frame may reach the client (issue #109): the client must have push
+        enabled AND a push turn must currently be open. Used by deliver_push
+        and deliver_push_tool_call so the check isn't duplicated/inconsistent
+        across the start vs. payload code paths — on_push_turn_start is the
+        only place that sets _push_turn_open True, and it already gates on
+        push_enabled before doing so.
+        """
+        return self.config.push_enabled and self._push_turn_open
+
     async def on_push_turn_start(self, session_key: str) -> None:
         if not self.config.push_enabled:
             # Intentionally do NOT set _push_turn_open here — push_enabled=False
@@ -603,6 +614,8 @@ class JotaBridge:
         self._push_audio_task = asyncio.create_task(_pipe_push_audio())
 
     async def deliver_push(self, payload: dict) -> None:
+        if not self._push_allowed():
+            return
         delta = payload.get("deltaText", "")
         if not delta:
             return
@@ -619,6 +632,8 @@ class JotaBridge:
             await self._push_tts.send_text_chunk(delta)
 
     async def deliver_push_tool_call(self, data: dict) -> None:
+        if not self._push_allowed():
+            return
         if not self.config.tool_calls_enabled:
             return
         tool_call = ToolCallEvent.from_session_tool_payload(data)

--- a/tests/unit/test_bridge_push.py
+++ b/tests/unit/test_bridge_push.py
@@ -63,6 +63,7 @@ async def test_close_unregisters_from_client_registry():
 async def test_deliver_push_text_sends_push_message():
     bridge, _ = make_bridge(output_mode=("text",))
     bridge._push_turn_id = "t-1"
+    bridge._push_turn_open = True
     payload = {"sessionKey": "agent:main:hab_sito", "deltaText": "Buenos días!"}
     await bridge.deliver_push(payload)
     bridge.client_ws.send_json.assert_awaited_once_with({
@@ -75,6 +76,7 @@ async def test_deliver_push_text_sends_push_message():
 @pytest.mark.asyncio
 async def test_deliver_push_empty_delta_ignored():
     bridge, _ = make_bridge(output_mode=("text",))
+    bridge._push_turn_open = True
     payload = {"sessionKey": "agent:main:hab_sito", "deltaText": ""}
     await bridge.deliver_push(payload)
     bridge.client_ws.send_json.assert_not_awaited()
@@ -170,6 +172,7 @@ async def test_on_push_turn_end_sends_turn_end_message():
 async def test_deliver_push_with_tts_sends_to_tts():
     bridge, _ = make_bridge(output_mode=("audio", "text"))
     bridge._push_turn_id = "t-1"
+    bridge._push_turn_open = True
     mock_tts = AsyncMock()
     bridge._push_tts = mock_tts
     payload = {"sessionKey": "agent:main:hab_sito", "deltaText": "Hola!"}
@@ -214,6 +217,7 @@ async def test_deliver_push_tool_call_forwarded_when_enabled():
         client_registry=ClientRegistry(), default_agent="main",
     )
     bridge._push_turn_id = "t-1"
+    bridge._push_turn_open = True
     data = {"phase": "start", "name": "exec", "toolCallId": "call-1", "args": {"command": "ls"}}
     await bridge.deliver_push_tool_call(data)
     ws.send_json.assert_awaited_once_with({
@@ -235,6 +239,7 @@ async def test_deliver_push_tool_call_not_forwarded_when_disabled():
         client_registry=ClientRegistry(), default_agent="main",
     )
     bridge._push_turn_id = "t-1"
+    bridge._push_turn_open = True
     data = {"phase": "start", "name": "exec", "toolCallId": "call-1", "args": {}}
     await bridge.deliver_push_tool_call(data)
     ws.send_json.assert_not_awaited()
@@ -252,6 +257,7 @@ async def test_deliver_push_tool_call_malformed_payload_ignored():
         client_registry=ClientRegistry(), default_agent="main",
     )
     bridge._push_turn_id = "t-1"
+    bridge._push_turn_open = True
     await bridge.deliver_push_tool_call({"phase": "update"})  # must not raise
     ws.send_json.assert_not_awaited()
 
@@ -362,3 +368,70 @@ async def test_on_push_turn_end_with_no_open_turn_does_not_emit():
     )
     # Flag must stay False (we never set it True).
     assert bridge._push_turn_open is False
+
+
+@pytest.mark.asyncio
+async def test_deliver_push_rejected_when_push_disabled():
+    """#109: push_enabled=False must block deliver_push even if _push_turn_open
+    is (incorrectly, or from stale state) True."""
+    client = Client(id="hab_sito", client_key="key-123", is_active=True)
+    config = ClientConfig(push_enabled=False)
+    ws = AsyncMock()
+    handshake = Handshake(client_key="key-123", input_mode="text", output_mode=["text"], agent="main")
+    bridge = JotaBridge(
+        client=client, config=config, client_ws=ws,
+        orchestrator=AsyncMock(), tts=AsyncMock(), tracker=AsyncMock(), handshake=handshake,
+        client_registry=ClientRegistry(), default_agent="main",
+    )
+    bridge._push_turn_id = "t-1"
+    bridge._push_turn_open = True  # simulates stale/inconsistent state — must still be blocked
+    payload = {"sessionKey": "agent:main:hab_sito", "deltaText": "Buenos días!"}
+    await bridge.deliver_push(payload)
+    ws.send_json.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_deliver_push_rejected_when_no_turn_open():
+    """#109 core bug: push_enabled=True but no turn_start was ever sent
+    (on_push_turn_start never ran) — deliver_push must not leak a token
+    frame with a stale/None turn_id outside any turn_start/turn_end envelope."""
+    bridge, _ = make_bridge(output_mode=("text",))
+    assert bridge._push_turn_open is False
+    payload = {"sessionKey": "agent:main:hab_sito", "deltaText": "Buenos días!"}
+    await bridge.deliver_push(payload)
+    bridge.client_ws.send_json.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_deliver_push_tool_call_rejected_when_push_disabled():
+    client = Client(id="hab_sito", client_key="key-123", is_active=True)
+    config = ClientConfig(push_enabled=False, tool_calls_enabled=True)
+    ws = AsyncMock()
+    handshake = Handshake(client_key="key-123", input_mode="text", output_mode=["text"], agent="main")
+    bridge = JotaBridge(
+        client=client, config=config, client_ws=ws,
+        orchestrator=AsyncMock(), tts=AsyncMock(), tracker=AsyncMock(), handshake=handshake,
+        client_registry=ClientRegistry(), default_agent="main",
+    )
+    bridge._push_turn_id = "t-1"
+    bridge._push_turn_open = True
+    data = {"phase": "start", "name": "exec", "toolCallId": "call-1", "args": {"command": "ls"}}
+    await bridge.deliver_push_tool_call(data)
+    ws.send_json.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_deliver_push_tool_call_rejected_when_no_turn_open():
+    client = Client(id="hab_sito", client_key="key-123", is_active=True)
+    config = ClientConfig(tool_calls_enabled=True)  # push_enabled defaults True
+    ws = AsyncMock()
+    handshake = Handshake(client_key="key-123", input_mode="text", output_mode=["text"], agent="main")
+    bridge = JotaBridge(
+        client=client, config=config, client_ws=ws,
+        orchestrator=AsyncMock(), tts=AsyncMock(), tracker=AsyncMock(), handshake=handshake,
+        client_registry=ClientRegistry(), default_agent="main",
+    )
+    assert bridge._push_turn_open is False
+    data = {"phase": "start", "name": "exec", "toolCallId": "call-1", "args": {"command": "ls"}}
+    await bridge.deliver_push_tool_call(data)
+    ws.send_json.assert_not_awaited()

--- a/tests/unit/test_openclaw_dispatcher.py
+++ b/tests/unit/test_openclaw_dispatcher.py
@@ -2,6 +2,9 @@ import pytest
 from unittest.mock import AsyncMock
 from src.services.openclaw.dispatcher import FrameDispatcher
 from src.services.openclaw.registry import TurnRegistry, ClientRegistry
+from src.services.bridge import JotaBridge
+from src.services.reconnection import ConnectionState, ServiceStatus
+from src.models.schemas import Client, ClientConfig, Handshake
 
 
 def make_dispatcher():
@@ -9,6 +12,34 @@ def make_dispatcher():
     client_reg = ClientRegistry()
     dispatcher = FrameDispatcher(turn_reg, client_reg)
     return dispatcher, turn_reg, client_reg
+
+
+def _connected_status() -> ServiceStatus:
+    return ServiceStatus(
+        name="tts", state=ConnectionState.CONNECTED,
+        connected_at=None, reconnect_attempts=0, last_error=None,
+    )
+
+
+def make_real_bridge(client_id="hab_sito", push_enabled=True, tool_calls_enabled=False):
+    """A real JotaBridge (not AsyncMock) so dispatcher tests can exercise
+    _push_allowed() gating — mirrors tests/unit/test_bridge_push.py's
+    make_bridge(), kept local here to stay self-contained (issue #109)."""
+    client = Client(id=client_id, client_key="key-123", is_active=True)
+    config = ClientConfig(push_enabled=push_enabled, tool_calls_enabled=tool_calls_enabled)
+    ws = AsyncMock()
+    orchestrator = AsyncMock()
+    orchestrator.ping = AsyncMock(return_value=True)
+    tracker = AsyncMock()
+    handshake = Handshake(client_key="key-123", input_mode="text", output_mode=["text"], agent="main")
+    tts = AsyncMock()
+    tts.connect = AsyncMock(return_value=None)
+    bridge = JotaBridge(
+        client=client, config=config, client_ws=ws,
+        orchestrator=orchestrator, tts=tts, tracker=tracker, handshake=handshake,
+        client_registry=ClientRegistry(), default_agent="main",
+    )
+    return bridge, ws
 
 
 @pytest.mark.asyncio
@@ -183,3 +214,72 @@ async def test_session_tool_no_session_key_ignored():
         "payload": {"data": {"phase": "start", "name": "exec", "toolCallId": "call-1"}},
     }
     await dispatcher.dispatch(frame)  # must not raise
+
+
+@pytest.mark.asyncio
+async def test_dispatcher_chat_event_push_disabled_client_receives_nothing():
+    """#109: a chat push event routed through the real dispatcher→bridge
+    wiring for a push_enabled=False client, with NO turn_start ever sent,
+    must not reach the client — the acceptance criterion verbatim."""
+    dispatcher, _, client_reg = make_dispatcher()
+    bridge, ws = make_real_bridge(push_enabled=False)
+    client_reg.register("hab_sito", bridge)
+
+    payload = {"sessionKey": "agent:main:hab_sito", "runId": "r1", "seq": 1, "deltaText": "Push!"}
+    frame = {"type": "event", "event": "chat", "payload": payload}
+    await dispatcher.dispatch(frame)
+
+    ws.send_json.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_dispatcher_session_tool_push_disabled_client_receives_nothing():
+    dispatcher, _, client_reg = make_dispatcher()
+    bridge, ws = make_real_bridge(push_enabled=False, tool_calls_enabled=True)
+    client_reg.register("hab_sito", bridge)
+
+    payload = {
+        "sessionKey": "agent:main:hab_sito",
+        "data": {"phase": "start", "name": "exec", "toolCallId": "call-1", "args": {"command": "ls"}},
+    }
+    frame = {"type": "event", "event": "session.tool", "payload": payload}
+    await dispatcher.dispatch(frame)
+
+    ws.send_json.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_dispatcher_full_push_lifecycle_disabled_client_receives_nothing():
+    """Full agent start → chat → tool → agent end sequence through the real
+    dispatcher for a push_enabled=False client: zero frames at any point,
+    not just the first one — on_push_turn_start's own gate (Task-1-independent,
+    predates #109) already no-ops on start; this confirms deliver_push and
+    deliver_push_tool_call independently hold the line for whatever arrives
+    in between, and that nothing leaks around the (correctly) skipped
+    turn_start/turn_end pair."""
+    dispatcher, _, client_reg = make_dispatcher()
+    bridge, ws = make_real_bridge(push_enabled=False, tool_calls_enabled=True)
+    client_reg.register("hab_sito", bridge)
+
+    await dispatcher.dispatch({
+        "type": "event", "event": "agent",
+        "payload": {"sessionKey": "agent:main:hab_sito", "data": {"phase": "start"}},
+    })
+    await dispatcher.dispatch({
+        "type": "event", "event": "chat",
+        "payload": {"sessionKey": "agent:main:hab_sito", "deltaText": "Push!"},
+    })
+    await dispatcher.dispatch({
+        "type": "event", "event": "session.tool",
+        "payload": {
+            "sessionKey": "agent:main:hab_sito",
+            "data": {"phase": "start", "name": "exec", "toolCallId": "call-1", "args": {}},
+        },
+    })
+    await dispatcher.dispatch({
+        "type": "event", "event": "agent",
+        "payload": {"sessionKey": "agent:main:hab_sito", "data": {"phase": "end"}},
+    })
+
+    ws.send_json.assert_not_awaited()
+    assert bridge._push_turn_open is False


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
<think>
Let me analyze the code changes to understand what was implemented, fixed, or changed.

Looking at the changes:

1. **src/services/bridge.py**:
   - Added a new method `_push_allowed()` that checks both `self.config.push_enabled` AND `self._push_turn_open` - this is a single decision point for whether an unsolicited (orchestrator-pushed) frame may reach the client.
   - Modified `deliver_push()` method to call `_push_allowed()` at the beginning and return early if not allowed.
   - Modified `deliver_push_tool_call()` method to call `_push_allowed()` at the beginning and return early if not allowed.

2. **tests/unit/test_bridge_push.py**:
   - Updated existing tests to set `bridge._push_turn_open = True` since the new logic requires this flag to be true for push to work.
   - Added new test cases:
     - `test_deliver_push_rejected_when_push_disabled` - verifies that push is rejected when push_enabled=False
     - `test_deliver_push_rejected_when_no_turn_open` - verifies that push is rejected when no turn is open
     - `test_deliver_push_tool_call_rejected_when_push_disabled` - verifies tool calls are rejected when push is disabled
     - `test_deliver_push_tool_call_rejected_when_no_turn_open` - verifies tool calls are rejected when no turn is open

3. **tests/unit/test_openclaw_dispatcher.py**:
   - Added helper function `_connected_status()` and `make_real_bridge()` to create real JotaBridge instances for testing.
   - Added new test cases:
     - `test_dispatcher_chat_event_push_disabled_client_receives_nothing`
     - `test_dispatcher_session_tool_push_disabled_client_receives_nothing`
     - `test_dispatcher_full_push_lifecycle_disabled_client_receives_nothing`

The core problem involves push functionality being accessible to clients despite push being disabled. When push_enabled is set to False, the system should completely block push frames from reaching the client, but the previous implementation was leaking these frames. Additionally, push frames could be sent outside the proper turn_start/turn_end envelope, creating a security vulnerability.

The solution introduces `_push_allowed()` as a unified gate that validates both push_enabled status and whether a turn is currently open. Both `deliver_push()` and `deliver_push_tool_call()` now invoke this check before processing any payloads, and corresponding tests verify the fix works as intended.
</think>

## Summary

This pull request fixes a security vulnerability (issue #109) where push payloads could leak to clients even when `push_enabled` is disabled, or when no push turn is open.

### Changes Made

1. **Added `_push_allowed()` method** in `bridge.py`: A single decision point that checks both `push_enabled` configuration AND whether a push turn is currently open (`_push_turn_open`). This ensures consistent gating across all push delivery code paths.

2. **Updated `deliver_push()` and `deliver_push_tool_call()`**: Both methods now call `_push_allowed()` at the start and return early if the check fails, preventing any push payloads from reaching clients when:
   - `push_enabled` is `False`, OR
   - No push turn is currently open (i.e., no prior `on_push_turn_start` was called)

3. **Added comprehensive test coverage**: New unit tests verify that push payloads are properly rejected in both disabled scenarios, including integration tests through the dispatcher to ensure the full lifecycle respects the push_enabled flag.
<!-- kody-pr-summary:end -->