### PR TITLE
fix(#113): ClientRegistry.unregister checks bridge identity

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -106,7 +106,7 @@ Ambas #149 y #150 arregladas antes de empezar Fase 2 (decisión 2026-07-18, rama
 - [ ] **#110** 🟠 `[012]` — Lifespan shutdown doesn't drain active sessions — **XL** — *bloqueado por #101*
 - [ ] **#111** 🟠 `[013]` — Streaming SSE returns 200 on orchestrator error — **S**
 - [ ] **#112** 🟠 `[014]` — Normal vs push turn coordination — **L** — ⚠️ *requiere decisión de política*
-- [ ] **#113** 🟠 `[015]` — Bridge unregisters newer bridge for same `client_id` — **S**
+- [x] **#113** 🟠 `[015]` — Bridge unregisters newer bridge for same `client_id` — **S** — `ClientRegistry.unregister(client_id, expected_bridge)` ahora sólo desregistra si el bridge sigue siendo el dueño actual (mismo patrón de identidad que `TurnRegistry` para #99); `bridge.close_all()` pasa `self`. Un cierre tardío del bridge viejo ya no expulsa la sesión reconectada.
 - [ ] **#114** 🟠 `[016]` — `ready.capabilities` contradicts actual service availability — **S** — ⚠️ *requiere decisión de semántica*
 - [ ] **#115** 🟠 `[017]` — No bounded deadlines (handshake/turn/idle/shutdown drain) — **M**
 - [ ] **#116** 🟠 `[018]` — `TTSClient.connect()` leaks WebSocket on `CancelledError` — **S**

--- a/src/services/bridge.py
+++ b/src/services/bridge.py
@@ -134,7 +134,7 @@ class JotaBridge:
             if self._closed:
                 return
 
-            self._client_registry.unregister(self.client_id)
+            self._client_registry.unregister(self.client_id, self)
             # Await (don't cancel) the active turn so the orchestrator response is
             # delivered before we tear down microservice clients.  Explicit cancellation
             # only happens via _cancel_active_turn() (barge-in) or task cancellation

--- a/src/services/openclaw/registry.py
+++ b/src/services/openclaw/registry.py
@@ -1,5 +1,8 @@
 import asyncio
+import logging
 from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
 
 
 def client_id_from_session_key(session_key: str) -> str:
@@ -80,10 +83,26 @@ class ClientRegistry:
         self._clients: dict[str, Any] = {}
 
     def register(self, client_id: str, bridge: Any) -> None:
+        # A live mapping being overwritten means a client reconnected while the
+        # previous session's bridge was still registered (reconnect race, #113).
+        # The stale bridge's later unregister() is now a safe no-op (identity
+        # check below), but surface the overlap so it's diagnosable. client_id
+        # is the client UUID, safe to log (never the client_key).
+        if self._clients.get(client_id) is not None:
+            logger.warning(
+                "ClientRegistry: client_id=%s re-registered while a previous "
+                "bridge was still active (reconnect race)", client_id
+            )
         self._clients[client_id] = bridge
 
-    def unregister(self, client_id: str) -> None:
-        self._clients.pop(client_id, None)
+    def unregister(self, client_id: str, expected_bridge: Any) -> None:
+        # Only remove the mapping if expected_bridge is still the current owner
+        # of client_id. A reconnect race can register a newer bridge under the
+        # same client_id (register() overwrites); when the older bridge tears
+        # down late it must not evict the live newer one (issue #113). Mirrors
+        # TurnRegistry.unregister's owner check for #99.
+        if self._clients.get(client_id) is expected_bridge:
+            self._clients.pop(client_id, None)
 
     def get(self, client_id: str) -> Optional[Any]:
         return self._clients.get(client_id)

--- a/tests/unit/test_bridge_close_all.py
+++ b/tests/unit/test_bridge_close_all.py
@@ -99,3 +99,41 @@ async def test_close_all_completes_teardown_after_earlier_call_is_interrupted(br
     await bridge.close_all()
 
     bridge.tracker._registry.close.assert_called_once()
+
+
+async def test_late_close_of_old_bridge_keeps_reconnected_session(mock_tracker):
+    """Issue #113 reconnect race, end to end through JotaBridge.close_all().
+
+    A client disconnects and reconnects: the new session registers a second
+    bridge under the SAME client_id, overwriting the old one in ClientRegistry.
+    When the old bridge finally tears down (close_all → unregister) it must not
+    evict the live new bridge — otherwise the reconnected client silently stops
+    receiving push events and status broadcasts.
+    """
+    registry = ClientRegistry()
+
+    def _make_bridge():
+        return JotaBridge(
+            client=_CLIENT, config=_CONFIG, client_ws=AsyncMock(),
+            orchestrator=AsyncMock(), tts=AsyncMock(), tracker=mock_tracker,
+            handshake=Handshake(client_key="test-key", input_mode="text", output_mode=["text"]),
+            client_registry=registry, default_agent="main",
+        )
+
+    old_bridge = _make_bridge()
+    new_bridge = _make_bridge()
+    registry.register(old_bridge.client_id, old_bridge)
+    registry.register(new_bridge.client_id, new_bridge)  # reconnect overwrites
+
+    # Old bridge tears down late.
+    await old_bridge.close_all()
+
+    # The reconnected session survives...
+    assert registry.get(new_bridge.client_id) is new_bridge
+
+    # ...and still receives status broadcasts (old bridge's ws must not).
+    await registry.broadcast_status("orchestrator", "restored")
+    new_bridge.client_ws.send_json.assert_awaited_once_with(
+        {"type": "status", "service": "orchestrator", "state": "restored"}
+    )
+    old_bridge.client_ws.send_json.assert_not_awaited()

--- a/tests/unit/test_openclaw_registry.py
+++ b/tests/unit/test_openclaw_registry.py
@@ -116,9 +116,46 @@ def test_client_registry_register_get():
 
 def test_client_registry_unregister():
     reg = ClientRegistry()
-    reg.register("hab_sito", object())
-    reg.unregister("hab_sito")
+    bridge = object()
+    reg.register("hab_sito", bridge)
+    reg.unregister("hab_sito", bridge)
     assert reg.get("hab_sito") is None
+
+
+def test_client_registry_unregister_stale_bridge_keeps_newer():
+    """Regression for #113: a reconnect race registers a new bridge for the
+    same client_id (overwriting the old one). When the OLD bridge later closes
+    and calls unregister(), it must not evict the NEW bridge that now owns that
+    client_id — otherwise the live session stops receiving push events and
+    status broadcasts."""
+    reg = ClientRegistry()
+    bridge_a = object()
+    bridge_b = object()
+    reg.register("client-x", bridge_a)
+    reg.register("client-x", bridge_b)  # new session overwrites the old one
+
+    # Old bridge (A) tears down late and unregisters itself.
+    reg.unregister("client-x", bridge_a)
+
+    # The new bridge (B) must survive.
+    assert reg.get("client-x") is bridge_b
+
+
+def test_client_registry_unregister_is_noop_for_any_superseded_owner():
+    """After multiple reconnects (A→B→C), a late unregister() from ANY former
+    owner (A or B) must be a no-op — only the current owner (C) can evict."""
+    reg = ClientRegistry()
+    bridge_a, bridge_b, bridge_c = object(), object(), object()
+    reg.register("client-x", bridge_a)
+    reg.register("client-x", bridge_b)
+    reg.register("client-x", bridge_c)
+
+    reg.unregister("client-x", bridge_a)  # oldest, long gone
+    reg.unregister("client-x", bridge_b)  # superseded too
+    assert reg.get("client-x") is bridge_c
+
+    reg.unregister("client-x", bridge_c)  # current owner tears down
+    assert reg.get("client-x") is None
 
 def test_client_registry_missing_returns_none():
     reg = ClientRegistry()


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
<think>
The user wants me to analyze the code changes in this pull request and generate a precise description of what was changed and why.

Let me analyze the changes:

1. **src/services/openclaw/registry.py**:
   - Added logging import
   - Modified `register()` to log a warning when a client_id is re-registered while a previous bridge is still active (reconnect race detection)
   - Modified `unregister()` to take an `expected_bridge` parameter and only unregister if the current owner matches the expected bridge

2. **src/services/bridge.py**:
   - Modified `close_all()` to pass `self` (the bridge instance) when calling `unregister()`

3. **tests/unit/test_bridge_close_all.py**:
   - Added a test `test_late_close_of_old_bridge_keeps_reconnected_session` that verifies issue #113 is fixed

4. **tests/unit/test_openclaw_registry.py**:
   - Updated `test_client_registry_unregister` to pass the bridge object
   - Added `test_client_registry_unregister_stale_bridge_keeps_newer` - regression test for #113
   - Added `test_client_registry_unregister_is_noop_for_any_superseded_owner` - tests multiple reconnects

5. **docs/ROADMAP.md**:
   - Marked #113 as completed with description

The functional purpose:
- This fix addresses issue #113 where a bridge unregisters a newer bridge for the same client_id
- When a client disconnects and reconnects, a new session registers a second bridge under the same client_id
- Previously, when the old bridge closed late, it would evict the new bridge from the registry
- Now, unregister() checks if the bridge trying to unregister is still the current owner before removing it
- This prevents the reconnected client from silently stopping receiving push events and status broadcasts


- Mirrors the pattern used in TurnRegistry for issue #99, which already implements this owner check to prevent stale bridges from removing active ones
</think>

## Summary

This pull request fixes issue #113 where a bridge could incorrectly unregister a newer bridge for the same `client_id` during a reconnect race condition.

### What Was Changed

**1. ClientRegistry.unregister() now requires identity verification** (`src/services/openclaw/registry.py`):
   - Added an `expected_bridge` parameter to `unregister()`
   - The method now only removes the mapping if `expected_bridge` is still the current owner of the `client_id`
   - Added warning logging in `register()` when a client_id is re-registered while a previous bridge is still active

**2. Bridge.close_all() passes its identity** (`src/services/bridge.py`):
   - Modified to pass `self` when calling `unregister()`, enabling the ownership check

**3. Added comprehensive tests**:
   - Unit tests verifying stale bridge unregistration doesn't evict newer bridges
   - End-to-end test through `JotaBridge.close_all()` confirming reconnected sessions survive old bridge teardown

### Why This Matters

Previously, when a client disconnected and reconnected, the new session's bridge would overwrite the old one in the registry. When the old bridge finally closed (late tear-down), it would call `unregister()` and evict the new bridge. This caused the reconnected client to silently stop receiving push events and status broadcasts.

The fix ensures that only the current owner of a `client_id` can unregister it, matching the pattern already used in `TurnRegistry` for issue #99.
<!-- kody-pr-summary:end -->