### PR TITLE
fix: split ready capabilities into requested and live

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -107,7 +107,7 @@ Ambas #149 y #150 arregladas antes de empezar Fase 2 (decisión 2026-07-18, rama
 - [x] **#111** 🟠 `[013]` — Streaming SSE returns 200 on orchestrator error — **S** — los fallos pre-token y post-token emiten `server_error` + `finish_reason="error"`, no emiten `[DONE]` y cierran el tracker con estado `error`.
 - [ ] **#112** 🟠 `[014]` — Normal vs push turn coordination — **L** — ⚠️ *requiere decisión de política*
 - [x] **#113** 🟠 `[015]` — Bridge unregisters newer bridge for same `client_id` — **S** — `ClientRegistry.unregister(client_id, expected_bridge)` ahora sólo desregistra si el bridge sigue siendo el dueño actual (mismo patrón de identidad que `TurnRegistry` para #99); `bridge.close_all()` pasa `self`. Un cierre tardío del bridge viejo ya no expulsa la sesión reconectada.
-- [ ] **#114** 🟠 `[016]` — `ready.capabilities` contradicts actual service availability — **S** — ⚠️ *requiere decisión de semántica*
+- [x] **#114** 🟠 `[016]` — `ready.capabilities` contradicts actual service availability — **S** — `ready` separa `requested_capabilities` y `live_capabilities` (instantánea de health check).
 - [ ] **#115** 🟠 `[017]` — No bounded deadlines (handshake/turn/idle/shutdown drain) — **M**
 - [x] **#116** 🟠 `[018]` — `TTSClient.connect()` leaks WebSocket on `CancelledError` — **S** — cleanup gobernado por `_authenticated`, cancellation relanzada y auth `recv()` acotado por `TTS_AUTH_TIMEOUT_S=10.0`.
 - [ ] **#117** 🟠 `[019]` — `ReconnectingTTSClient` missing `on_state_change` hook — **M**

--- a/docs/client-protocol.md
+++ b/docs/client-protocol.md
@@ -78,7 +78,12 @@ Si el handshake es válido y todos los servicios críticos responden, el gateway
   "agent": "main",
   "input_mode": "audio",
   "output_mode": ["audio", "text"],
-  "capabilities": {
+  "requested_capabilities": {
+    "barge_in": true,
+    "tts": true,
+    "transcriber": true
+  },
+  "live_capabilities": {
     "barge_in": true,
     "tts": true,
     "transcriber": true
@@ -92,13 +97,20 @@ Si el handshake es válido y todos los servicios críticos responden, el gateway
 | `agent` | Agente OpenClaw activo (el solicitado o el por defecto) |
 | `input_mode` | Modo de entrada confirmado |
 | `output_mode` | Modos de salida activos |
-| `capabilities.barge_in` | Si el barge-in está habilitado para este cliente |
-| `capabilities.tts` | Si el audio TTS está disponible (`"audio"` en `output_mode` y TTS responde) |
-| `capabilities.transcriber` | Si el transcriptor está activo (`input_mode == "audio"`) |
+| `requested_capabilities.barge_in` | Si el barge-in está habilitado para este cliente |
+| `requested_capabilities.tts` | Si el cliente pidió salida de audio (`"audio"` en `output_mode`) |
+| `requested_capabilities.transcriber` | Si el cliente pidió modo audio (`input_mode == "audio"`) |
+| `live_capabilities.barge_in` | Si el barge-in está operativos (requiere transcriber activo) |
+| `live_capabilities.tts` | Si TTS responde en este momento |
+| `live_capabilities.transcriber` | Si el transcriptor está conectado (`input_mode == "audio"`) |
 
 Espera este mensaje antes de enviar audio o texto. Si no llega, la conexión fue cerrada por un error de handshake.
 
----
+> **Incompatibilidad de protocolo — #114 (v1.15.0)**
+> `ready.capabilities` fue reemplazado por `ready.requested_capabilities` + `ready.live_capabilities`.
+> `requested_capabilities` refleja lo que el cliente pidió en el handshake.
+> `live_capabilities` refleja el resultado del health check en el momento de la conexión.
+> Clientes que aún lean `capabilities` dejarán de encontrar el campo — deben actualizarse.
 
 ## 3. Enviar audio de micrófono
 
@@ -235,7 +247,8 @@ async for msg in ws:
             case "ready":
                 session_id = data["session_id"]
                 agent = data["agent"]
-                capabilities = data["capabilities"]
+                requested = data["requested_capabilities"]
+                live = data["live_capabilities"]
 
             case "turn_start":
                 turn_id = data["turn_id"]

--- a/docs/superpowers/specs/2026-07-21-114-ready-capabilities-design.md
+++ b/docs/superpowers/specs/2026-07-21-114-ready-capabilities-design.md
@@ -1,0 +1,113 @@
+# Diseño: fix #114 — renombrar `ready.capabilities` y añadir `live_capabilities`
+
+**Fecha:** 2026-07-21
+**Rama base:** `phase/3-lifecycle`
+**Rama de trabajo:** `fix/114-ready-capabilities-rename`
+
+## Objetivo
+
+Cerrar la contradicción que el cliente ve entre `ready.capabilities` y los mensajes `status` posteriores, separando de forma explícita la intención del handshake de la disponibilidad real de cada servicio.
+
+## Decisión confirmada
+
+ROADMAP (commit `8554148`):
+- Renombrar `capabilities` → `requested_capabilities`.
+- Añadir `live_capabilities` como instantánea tomada justo antes de enviar `ready`.
+- No mantener alias del campo antiguo: cualquier cliente que aún espere `capabilities` debe actualizarse.
+- `status` sigue siendo la fuente de cambios de disponibilidad tras el handshake; no se reenvía `ready` ni se añade un canal de actualización de capacidades.
+
+## Causa raíz
+
+`src/api/routes.py:115-132` construye `capabilities` a partir de la intención del handshake y de la configuración estática, ignorando los resultados de `JotaBridge.health_check()` (`src/services/bridge.py:183-218`). El cliente ve `tts: true` aunque TTS no responda al ping, y lo nota sólo cuando llega el `status` posterior.
+
+## Diseño
+
+### `JotaBridge.health_check()` (firma nueva)
+
+```python
+async def health_check(self) -> dict[str, bool] | None
+```
+
+- `None`: el orquestador no responde; el caller cierra el WS con 1011 y no envía `ready`. Antes de devolverlo se envía el `status` `orchestrator: unavailable` ya existente.
+- `dict`: instantánea con tres claves (`barge_in`, `tts`, `transcriber`) y su valor live booleano. La rama no fatal ya no devuelve un `bool` opaco.
+
+Construcción del diccionario (todos los campos se calculan una sola vez, sin pings duplicados):
+
+| Clave | Live cuando |
+|-------|-------------|
+| `transcriber` | `handshake.input_mode == "audio"` y `self.transcriber` está `ConnectionState.CONNECTED`. |
+| `tts` | `"audio" in handshake.output_mode` y `await TTSClient.ping(settings.TTS_WS_URL)` devuelve `True`. |
+| `barge_in` | `config.barge_in_enabled` y el transcriber está conectado. |
+
+Los `status` enviados en `health_check()` para transcriber/TTS no cambian: el cliente ve primero el aviso de indisponibilidad y, cuando llegue `ready`, ya dispone de `live_capabilities` para confirmar.
+
+### `src/api/routes.py` (handshake)
+
+```python
+live = await bridge.health_check()
+if live is None:
+    await websocket.close(code=1011, reason="Servicio crítico no disponible.")
+    return
+
+await websocket.send_json({
+    "type": "ready",
+    "session_id": session_id,
+    "agent": resolved_agent,
+    "input_mode": handshake.input_mode,
+    "output_mode": handshake.output_mode,
+    "requested_capabilities": {
+        "barge_in": config.barge_in_enabled,
+        "tts": "audio" in handshake.output_mode,
+        "transcriber": handshake.input_mode == "audio",
+    },
+    "live_capabilities": live,
+})
+```
+
+No se emite la clave antigua `capabilities`. `live_capabilities` y `requested_capabilities` siempre se envían con las mismas tres claves, en el mismo orden.
+
+### `docs/client-protocol.md`
+
+- Tabla del mensaje `ready` actualizada: dos filas nuevas `requested_capabilities` y `live_capabilities`; se retira la fila `capabilities`.
+- Párrafo introductorio: explica que `live_capabilities` es instantánea del handshake y que cualquier transición posterior se comunica vía `status`.
+- Bloque "Incompatibilidades": una nota describiendo el cambio de contrato y la obligación de actualizar el cliente.
+
+### `tests/e2e/ws_helpers.py`
+
+`ws_handshake()` actualmente asume que el primer frame es `ready`. Cambia a:
+
+1. Consumir frames hasta `type == "ready"` o agotar el timeout.
+2. Si el primer frame es `status` u otro tipo, seguir iterando.
+3. Si vence el timeout sin `ready`, cerrar el WS y lanzar un `AssertionError` con el último frame observado.
+
+Mantiene la semántica de retorno y no rompe los tests existentes cuyo primer frame sigue siendo `ready`.
+
+## Pruebas TDD
+
+### Unit (`tests/unit/test_bridge_health_check.py`)
+
+Reemplazar las aserciones `is True/False` por verificaciones del nuevo contrato:
+
+- todos los servicios OK → `dict` con `barge_in, tts, transcriber` `True` en modo audio.
+- TTS caído (`TTSClient.ping` patched a `False`) y `output_mode=["audio","text"]` → `tts: False`, `transcriber: True`, `barge_in: True`.
+- Transcriber degradado → `transcriber: False`, `barge_in: False`.
+- Handshake text-only → `dict` con las tres claves a `False`.
+- Orquestador caído → `None` y `status` con `service: orchestrator, state: unavailable` enviado.
+
+### Integración (`tests/integration/test_ws_handshake.py`)
+
+- `ready` contiene `requested_capabilities` y `live_capabilities` con las tres claves; `capabilities` no aparece.
+- Con TTS apagado (mock puntual) el handshake audio → `live_capabilities.tts == False`, `requested_capabilities.tts == True` y un `status` `tts: unavailable` precede al `ready`.
+- Handshake text-only → ambas secciones coinciden y todas las claves `False`.
+
+### Helper E2E
+
+- Test que consume un `status` antes del `ready` y verifica que el helper lo trata como estado intermedio.
+- Test que mantiene el comportamiento "primer frame es `ready`" cuando el servicio está sano.
+
+## Commits y entrega
+
+- Especificación committeada primero.
+- Único commit de producción: `fix(#114): split ready capabilities into requested and live`, con todos los cambios y el trailer `Co-Authored-By: Claude <noreply@anthropic.com>`.
+- `docs/ROADMAP.md`: marcar #114 `[x]`.
+- Verificación final: `PYTHONPATH=. pytest`, `ruff check src/ tests/`, revisión global por subagente, push y PR contra `phase/3-lifecycle` con `Closes #114`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,3 +34,32 @@ where = ["."]
 include = ["src*"]
 
 
+
+[tool.ruff]
+line-length = 100
+target-version = "py312"
+
+[tool.ruff.lint]
+select = ["E", "F", "W", "I", "UP", "B", "SIM", "RUF"]
+ignore = [
+    "BLE001",
+    "S110",
+    "TRY002",
+    "TRY203",
+    "TRY004",
+    "ASYNC251",
+    "B008",
+    "B017",
+    "RUF059",
+    "RUF013",
+    "SIM102",
+    "SIM117",
+    "SIM105",
+    "B904",
+    "B905",
+    "RUF002",
+]
+
+[tool.ruff.lint.per-file-ignores]
+"tests/**" = ["E501", "SIM105"]
+"src/**" = ["E501"]

--- a/src/api/admin_routes.py
+++ b/src/api/admin_routes.py
@@ -21,6 +21,7 @@ Observabilidad:
   GET    /admin/transcriber/status
   GET    /admin/tts/status
 """
+
 import json
 import secrets
 from collections import defaultdict
@@ -44,6 +45,7 @@ router = APIRouter(prefix="/admin", dependencies=[Depends(get_admin_auth)])
 # Helpers
 # ---------------------------------------------------------------------------
 
+
 def _get_or_404(session: Session, client_id: str) -> ClientRecord:
     rec = session.get(ClientRecord, client_id)
     if rec is None:
@@ -54,6 +56,7 @@ def _get_or_404(session: Session, client_id: str) -> ClientRecord:
 # ---------------------------------------------------------------------------
 # Client CRUD
 # ---------------------------------------------------------------------------
+
 
 @router.get("/clients", response_model=list[ClientResponse])
 def list_clients(session: Session = Depends(get_db_session)) -> list[ClientResponse]:
@@ -110,7 +113,9 @@ def update_client(
     # Serializar listas a JSON antes de escribir en la BD
     for list_field in ("allowed_agents", "output_mode", "tags"):
         if list_field in patch:
-            patch[list_field] = json.dumps(patch[list_field]) if patch[list_field] is not None else None
+            patch[list_field] = (
+                json.dumps(patch[list_field]) if patch[list_field] is not None else None
+            )
     for field, value in patch.items():
         setattr(rec, field, value)
     session.add(rec)
@@ -150,6 +155,7 @@ def rotate_client_key(
 # ---------------------------------------------------------------------------
 # Sessions — observabilidad en memoria
 # ---------------------------------------------------------------------------
+
 
 def _serialize_events(events) -> list[dict]:
     return [
@@ -198,7 +204,9 @@ def _session_detail(record) -> dict:
         for turn_events in by_turn.values()
         if "llm_start" in turn_events and "llm_first_token" in turn_events
     ]
-    avg_llm_first_token_ms = round(sum(llm_latencies) / len(llm_latencies), 1) if llm_latencies else None
+    avg_llm_first_token_ms = (
+        round(sum(llm_latencies) / len(llm_latencies), 1) if llm_latencies else None
+    )
 
     e2e_latencies = [
         round(turn_events["tts_done"].ts_ms - turn_events["transcription_final"].ts_ms, 1)
@@ -244,6 +252,7 @@ async def get_session(session_id: str, request: Request) -> dict:
 # Orchestrators — estado y control
 # ---------------------------------------------------------------------------
 
+
 @router.get("/orchestrators/{name}/status")
 async def get_orchestrator_status(name: str, request: Request) -> dict:
     openclaw = request.app.state.openclaw
@@ -271,6 +280,7 @@ async def post_orchestrator_reconnect(name: str, request: Request) -> dict:
 # ---------------------------------------------------------------------------
 # Transcriber / TTS — estado (solo lectura; ver docstring del módulo)
 # ---------------------------------------------------------------------------
+
 
 @router.get("/transcriber/status")
 async def get_transcriber_status() -> dict:

--- a/src/api/deps.py
+++ b/src/api/deps.py
@@ -3,6 +3,7 @@ deps.py
 ~~~~~~~
 FastAPI dependencies compartidas.
 """
+
 from fastapi import Header, HTTPException
 
 from src.core.config import settings

--- a/src/api/health_routes.py
+++ b/src/api/health_routes.py
@@ -8,7 +8,9 @@ OpenClaw down → 503 "unavailable"
 TTS or transcriber down → 200 "degraded"
 All ok → 200 "ok"
 """
+
 import asyncio
+
 from fastapi import APIRouter, Request, Response
 
 from src.core.config import settings

--- a/src/api/openai_routes.py
+++ b/src/api/openai_routes.py
@@ -1,16 +1,16 @@
 import asyncio
 import json
-import uuid
 import logging
+import uuid
 from dataclasses import dataclass
 
 from fastapi import APIRouter, Depends, HTTPException, Request
-from fastapi.responses import StreamingResponse, JSONResponse
+from fastapi.responses import JSONResponse, StreamingResponse
 from pydantic import BaseModel
 
+from src.core.agent_policy import AgentPolicyError, resolve_agent
 from src.core.exceptions import ClientInactive, ClientNotFound
 from src.core.network import is_trusted_origin, resolve_client_ip
-from src.core.agent_policy import AgentPolicyError, resolve_agent
 from src.core.session_key import make_session_key
 from src.models.schemas import Client, ClientConfig
 from src.services.db_client import db_client
@@ -41,6 +41,7 @@ class HACaller:
     client/config son None en el path legacy (origen de red confiable,
     sin Authorization) — preserva el comportamiento histórico fijo "ha".
     """
+
     client: Client | None
     config: ClientConfig | None
 
@@ -57,7 +58,7 @@ async def resolve_ha_caller(request: Request) -> HACaller:
     if auth:
         if not auth.startswith("Bearer "):
             raise HTTPException(status_code=401, detail="authentication required")
-        client_key = auth[len("Bearer "):]
+        client_key = auth[len("Bearer ") :]
         try:
             client, config = await db_client.get_session(client_key)
         except (ClientNotFound, ClientInactive):
@@ -73,10 +74,14 @@ async def resolve_ha_caller(request: Request) -> HACaller:
 
 @router.get("/models")
 async def list_models(request: Request, caller: HACaller = Depends(resolve_ha_caller)):
-    return JSONResponse({
-        "object": "list",
-        "data": [{"id": "jota-gateway", "object": "model", "created": 0, "owned_by": "jota-gateway"}],
-    })
+    return JSONResponse(
+        {
+            "object": "list",
+            "data": [
+                {"id": "jota-gateway", "object": "model", "created": 0, "owned_by": "jota-gateway"}
+            ],
+        }
+    )
 
 
 def _extract_last_user_message(messages: list[_ChatMessage]) -> str:
@@ -140,8 +145,7 @@ async def chat_completions(
     else:
         # Legacy trusted-origin path: no policy checks, use gateway default.
         resolved_agent = (
-            orchestrator.gateway_info.default_agent_id
-            if orchestrator.gateway_info else "main"
+            orchestrator.gateway_info.default_agent_id if orchestrator.gateway_info else "main"
         )
 
     client_id = caller.client.id if caller.client else "ha"
@@ -151,6 +155,7 @@ async def chat_completions(
     session_registry.register(tracker)
 
     if stream:
+
         async def generate():
             queue: asyncio.Queue[str | None] = asyncio.Queue()
             orchestrator_error: RuntimeError | None = None
@@ -167,14 +172,20 @@ async def chat_completions(
                 nonlocal orchestrator_error
                 try:
                     await call_orchestrator(
-                        orchestrator, text, session_key, client_id,
-                        tracker=tracker, on_token=_on_token,
+                        orchestrator,
+                        text,
+                        session_key,
+                        client_id,
+                        tracker=tracker,
+                        on_token=_on_token,
                     )
                 except RuntimeError as e:
                     logger.error(f"HTTP orchestrator error: {e}")
                     orchestrator_error = e
                 finally:
-                    await queue.put(None)  # sentinel siempre primero — garantiza que el generador puede avanzar
+                    await queue.put(
+                        None
+                    )  # sentinel siempre primero — garantiza que el generador puede avanzar
                     try:
                         await tracker.close(
                             status="error" if orchestrator_error is not None else "completed"
@@ -220,6 +231,7 @@ async def chat_completions(
             }
             yield f"data: {json.dumps(final)}\n\n"
             yield "data: [DONE]\n\n"
+
         return StreamingResponse(generate(), media_type="text/event-stream")
 
     tokens: list[str] = []
@@ -230,8 +242,12 @@ async def chat_completions(
     orchestrator_error: Exception | None = None
     try:
         await call_orchestrator(
-            orchestrator, text, session_key, client_id,
-            tracker=tracker, on_token=_on_token,
+            orchestrator,
+            text,
+            session_key,
+            client_id,
+            tracker=tracker,
+            on_token=_on_token,
         )
     except RuntimeError as e:
         logger.error(f"HTTP orchestrator error: {e}")
@@ -245,10 +261,21 @@ async def chat_completions(
         return JSONResponse({"error": str(orchestrator_error)}, status_code=502)
 
     content = "".join(tokens)
-    return JSONResponse({
-        "id": completion_id,
-        "object": "chat.completion",
-        "choices": [{"message": {"role": "assistant", "content": content},
-                     "index": 0, "finish_reason": "stop"}],
-        "usage": {"prompt_tokens": 0, "completion_tokens": len(tokens), "total_tokens": len(tokens)},
-    })
+    return JSONResponse(
+        {
+            "id": completion_id,
+            "object": "chat.completion",
+            "choices": [
+                {
+                    "message": {"role": "assistant", "content": content},
+                    "index": 0,
+                    "finish_reason": "stop",
+                }
+            ],
+            "usage": {
+                "prompt_tokens": 0,
+                "completion_tokens": len(tokens),
+                "total_tokens": len(tokens),
+            },
+        }
+    )

--- a/src/api/routes.py
+++ b/src/api/routes.py
@@ -107,7 +107,8 @@ async def gateway_websocket(websocket: WebSocket):
             return
 
         # 3.5 HEALTH CHECK — verifica disponibilidad de servicios antes de abrir la sesión
-        if not await bridge.health_check():
+        live_capabilities = await bridge.health_check()
+        if live_capabilities is None:
             logger.warning(f"[{client.id}] Health check falló. Cerrando sesión.")
             await websocket.close(code=1011, reason="Servicio crítico no disponible.")
             return
@@ -121,11 +122,12 @@ async def gateway_websocket(websocket: WebSocket):
                 "agent": resolved_agent,
                 "input_mode": handshake.input_mode,
                 "output_mode": handshake.output_mode,
-                "capabilities": {
+                "requested_capabilities": {
                     "barge_in": config.barge_in_enabled,
                     "tts": "audio" in handshake.output_mode,
                     "transcriber": handshake.input_mode == "audio",
                 },
+                "live_capabilities": live_capabilities,
             })
         except Exception as e:
             logger.warning(f"[{client.id}] Failed to send ready: {e}")

--- a/src/api/routes.py
+++ b/src/api/routes.py
@@ -1,8 +1,9 @@
+import json
+import logging
+import time
+
 from fastapi import APIRouter, WebSocket, WebSocketDisconnect
 from pydantic import ValidationError
-import logging
-import json
-import time
 
 from src.core.agent_policy import AgentPolicyError, resolve_agent
 from src.core.exceptions import ClientInactive, ClientNotFound
@@ -17,6 +18,7 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
+
 @router.websocket("/ws/stream")
 async def gateway_websocket(websocket: WebSocket):
     await websocket.accept()
@@ -28,7 +30,9 @@ async def gateway_websocket(websocket: WebSocket):
         handshake = Handshake(**msg_data)
     except (json.JSONDecodeError, ValidationError) as e:
         logger.error(f"Payload inicial inválido de handshake. {e}")
-        await websocket.close(code=1008, reason="Handshake invalido. Se esperaba JSON de configuración.")
+        await websocket.close(
+            code=1008, reason="Handshake invalido. Se esperaba JSON de configuración."
+        )
         return
     except WebSocketDisconnect:
         logger.info("Cliente desconectado antes o durante el handshake.")
@@ -48,8 +52,7 @@ async def gateway_websocket(websocket: WebSocket):
         return
 
     logger.info(
-        f"request_id={request_id} client_id={client.id} fp={key_fingerprint} "
-        "Handshake verificado."
+        f"request_id={request_id} client_id={client.id} fp={key_fingerprint} Handshake verificado."
     )
 
     # 3. INSTANCIAR EL PUENTE DE MICROSERVICIOS
@@ -83,9 +86,13 @@ async def gateway_websocket(websocket: WebSocket):
     )
     session_registry.register(tracker)
     bridge = JotaBridge(
-        client=client, config=config, client_ws=websocket, orchestrator=openclaw,
+        client=client,
+        config=config,
+        client_ws=websocket,
+        orchestrator=openclaw,
         tts=app_state.tts,
-        tracker=tracker, handshake=handshake,
+        tracker=tracker,
+        handshake=handshake,
         client_registry=app_state.client_registry,
         default_agent=resolved_agent,
     )
@@ -103,7 +110,9 @@ async def gateway_websocket(websocket: WebSocket):
             await bridge.connect_internal_services()
         except Exception as e:
             logger.error(f"[{client.id}] Fallo al inicializar puentes internos. {e}")
-            await websocket.close(code=1011, reason="Problema estableciendo microservicios internos del hub.")
+            await websocket.close(
+                code=1011, reason="Problema estableciendo microservicios internos del hub."
+            )
             return
 
         # 3.5 HEALTH CHECK — verifica disponibilidad de servicios antes de abrir la sesión
@@ -116,19 +125,21 @@ async def gateway_websocket(websocket: WebSocket):
         # 3.6 SEND READY — confirms session is established and announces capabilities
         # resolved_agent comes from the policy helper above.
         try:
-            await websocket.send_json({
-                "type": "ready",
-                "session_id": session_id,
-                "agent": resolved_agent,
-                "input_mode": handshake.input_mode,
-                "output_mode": handshake.output_mode,
-                "requested_capabilities": {
-                    "barge_in": config.barge_in_enabled,
-                    "tts": "audio" in handshake.output_mode,
-                    "transcriber": handshake.input_mode == "audio",
-                },
-                "live_capabilities": live_capabilities,
-            })
+            await websocket.send_json(
+                {
+                    "type": "ready",
+                    "session_id": session_id,
+                    "agent": resolved_agent,
+                    "input_mode": handshake.input_mode,
+                    "output_mode": handshake.output_mode,
+                    "requested_capabilities": {
+                        "barge_in": config.barge_in_enabled,
+                        "tts": "audio" in handshake.output_mode,
+                        "transcriber": handshake.input_mode == "audio",
+                    },
+                    "live_capabilities": live_capabilities,
+                }
+            )
         except Exception as e:
             logger.warning(f"[{client.id}] Failed to send ready: {e}")
             return

--- a/src/cli.py
+++ b/src/cli.py
@@ -4,13 +4,13 @@ cli.py
 CLI de gestión de clientes jota-gateway.
 Uso: python src/cli.py <command> [options]
 """
+
 import secrets
 import sys
-from typing import Optional
 
 from sqlmodel import Session, select
 
-from src.db.database import run_migrations, get_engine
+from src.db.database import get_engine, run_migrations
 from src.db.models import ClientRecord
 
 
@@ -27,8 +27,9 @@ def _require(session: Session, client_key: str) -> ClientRecord:
     return rec
 
 
-def cmd_add(name: str, client_type: Optional[str], agent: Optional[str], engine,
-            client_key: Optional[str] = None) -> None:
+def cmd_add(
+    name: str, client_type: str | None, agent: str | None, engine, client_key: str | None = None
+) -> None:
     key = client_key or secrets.token_urlsafe(32)
     with Session(engine) as s:
         rec = ClientRecord(name=name, client_key=key, client_type=client_type, default_agent=agent)
@@ -88,7 +89,9 @@ def run(argv: list[str]) -> None:
 
     a = sub.add_parser("add-client")
     a.add_argument("--name", required=True)
-    a.add_argument("--key", dest="client_key", help="client_key exacto a usar (si se omite, se genera uno)")
+    a.add_argument(
+        "--key", dest="client_key", help="client_key exacto a usar (si se omite, se genera uno)"
+    )
     a.add_argument("--type", dest="client_type")
     a.add_argument("--agent")
 
@@ -103,7 +106,11 @@ def run(argv: list[str]) -> None:
     # unknown option instead of the positional value ("the following
     # arguments are required: client_key"). Force positional parsing for it
     # by inserting `--` right after the subcommand name.
-    if len(argv) >= 2 and argv[0] in ("deactivate-client", "activate-client", "delete-client") and argv[1] != "--":
+    if (
+        len(argv) >= 2
+        and argv[0] in ("deactivate-client", "activate-client", "delete-client")
+        and argv[1] != "--"
+    ):
         argv = [argv[0], "--", *argv[1:]]
 
     args = p.parse_args(argv)

--- a/src/core/agent_policy.py
+++ b/src/core/agent_policy.py
@@ -5,6 +5,7 @@ two policy checks (allowlist, global roster). Pure helper — no DB, no
 FastAPI, no WebSocket. Translation of AgentPolicyError into wire formats
 (close 1008 reason / 403 JSON body) happens at the call sites.
 """
+
 from typing import TYPE_CHECKING, Optional
 
 if TYPE_CHECKING:
@@ -22,14 +23,14 @@ class AgentPolicyError(Exception):
         agent_name: the offending agent, or None if no name is meaningful.
     """
 
-    def __init__(self, kind: str, agent_name: Optional[str], message: str):
+    def __init__(self, kind: str, agent_name: str | None, message: str):
         super().__init__(message)
         self.kind = kind
         self.agent_name = agent_name
 
 
 def resolve_agent(
-    requested: Optional[str],
+    requested: str | None,
     client_config: Optional["ClientConfig"],
     gateway_info: Optional["GatewayInfo"],
 ) -> str:
@@ -86,11 +87,7 @@ def resolve_agent(
     # 2b. Global roster check (only when agent was explicitly requested,
     # not when it came from the cascade — gateway/client defaults are
     # trusted configuration, not user input).
-    if (
-        requested is not None
-        and gateway_info is not None
-        and effective not in gateway_info.agents
-    ):
+    if requested is not None and gateway_info is not None and effective not in gateway_info.agents:
         raise AgentPolicyError(
             "not_available",
             effective,

--- a/src/core/config.py
+++ b/src/core/config.py
@@ -12,7 +12,9 @@ class Settings(BaseSettings):
 
     # /v1/* trusted-origin auth (issue #52)
     TRUST_LOOPBACK: bool = True
-    TRUSTED_NETWORKS: str = ""              # CSV of CIDRs, e.g. "192.168.1.0/24". Empty = only loopback trusted.
+    TRUSTED_NETWORKS: str = (
+        ""  # CSV of CIDRs, e.g. "192.168.1.0/24". Empty = only loopback trusted.
+    )
     TRUSTED_PROXIES: str = "127.0.0.1,::1"  # CSV of IPs/CIDRs allowed to set X-Real-IP
 
     # Servicios externos

--- a/src/core/logging.py
+++ b/src/core/logging.py
@@ -1,4 +1,5 @@
 """Safe logging helpers for secrets and credentials."""
+
 import hashlib
 
 

--- a/src/core/network.py
+++ b/src/core/network.py
@@ -8,6 +8,7 @@ resolve_client_ip(conn)  -> str   — IP real a evaluar, respetando X-Real-IP
                                     solo cuando el peer TCP es un proxy confiable.
                                     Compartido por HTTP y WebSocket.
 """
+
 import ipaddress
 import logging
 
@@ -73,7 +74,6 @@ def resolve_client_ip(connection: HTTPConnection) -> str:
 
     if connection.headers.get("x-real-ip"):
         logger.warning(
-            f"Ignoring X-Real-IP header from untrusted peer {peer!r} "
-            "(possible spoofing attempt)"
+            f"Ignoring X-Real-IP header from untrusted peer {peer!r} (possible spoofing attempt)"
         )
     return peer

--- a/src/core/request_id.py
+++ b/src/core/request_id.py
@@ -1,4 +1,5 @@
 """Gateway-owned correlation IDs for inbound ASGI connections."""
+
 from uuid import uuid4
 
 from starlette.types import ASGIApp, Receive, Scope, Send

--- a/src/db/database.py
+++ b/src/db/database.py
@@ -1,5 +1,5 @@
+from collections.abc import Generator
 from pathlib import Path
-from typing import Generator
 
 from alembic import command
 from alembic.config import Config

--- a/src/db/models.py
+++ b/src/db/models.py
@@ -1,6 +1,5 @@
 import uuid
 from datetime import UTC, datetime
-from typing import Optional
 
 from sqlmodel import Field, SQLModel
 
@@ -16,9 +15,9 @@ class ClientRecord(SQLModel, table=True):
     name: str
     client_key: str = Field(unique=True, index=True)
     is_active: bool = Field(default=True)
-    client_type: Optional[str] = Field(default=None)
-    default_agent: Optional[str] = Field(default=None)
-    allowed_agents: Optional[str] = Field(default=None)   # JSON list serializado
+    client_type: str | None = Field(default=None)
+    default_agent: str | None = Field(default=None)
+    allowed_agents: str | None = Field(default=None)  # JSON list serializado
     created_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
 
     # Pipeline config
@@ -28,7 +27,7 @@ class ClientRecord(SQLModel, table=True):
     tts_speed: float = Field(default=1.0)
     barge_in_enabled: bool = Field(default=True)
     barge_in_min_chars: int = Field(default=5)
-    output_mode: Optional[str] = Field(default=None)      # JSON list, e.g. '["audio","text"]'
+    output_mode: str | None = Field(default=None)  # JSON list, e.g. '["audio","text"]'
     silence_timeout_s: float = Field(default=2.0)
     max_silence_turns: int = Field(default=3)
     push_enabled: bool = Field(default=True)

--- a/src/main.py
+++ b/src/main.py
@@ -1,26 +1,26 @@
 import asyncio
 import logging
 from contextlib import asynccontextmanager
+
 from fastapi import FastAPI
 
-from src.api.routes import router as stream_router
+from src.api.admin_routes import router as admin_router
 from src.api.health_routes import router as health_router
 from src.api.openai_routes import router as openai_router
-from src.api.admin_routes import router as admin_router
+from src.api.routes import router as stream_router
 from src.core.config import settings
 from src.core.request_id import RequestIdMiddleware
 from src.db.database import run_migrations
 from src.services.openclaw.client import OpenClawClient
 from src.services.openclaw.dispatcher import FrameDispatcher
 from src.services.openclaw.reconnecting import ReconnectingOpenClawClient
-from src.services.openclaw.registry import TurnRegistry, ClientRegistry
+from src.services.openclaw.registry import ClientRegistry, TurnRegistry
 from src.services.reconnection import ConnectionState, to_wire_state
 from src.services.session_registry import SessionRegistry
 from src.services.tts_reconnecting import ReconnectingTTSClient
 
 logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s | %(name)s | %(levelname)s | %(message)s"
+    level=logging.INFO, format="%(asctime)s | %(name)s | %(levelname)s | %(message)s"
 )
 logger = logging.getLogger(__name__)
 
@@ -97,11 +97,12 @@ app = FastAPI(
 
 app.add_middleware(RequestIdMiddleware)
 
-app.include_router(stream_router)           # WS /ws/stream
-app.include_router(openai_router)           # HTTP /v1/*
-app.include_router(health_router)           # HTTP /healthz, /ready
-app.include_router(admin_router)            # HTTP /admin/*
+app.include_router(stream_router)  # WS /ws/stream
+app.include_router(openai_router)  # HTTP /v1/*
+app.include_router(health_router)  # HTTP /healthz, /ready
+app.include_router(admin_router)  # HTTP /admin/*
 
 if __name__ == "__main__":
     import uvicorn
+
     uvicorn.run(app, host="0.0.0.0", port=8004)

--- a/src/models/admin_schemas.py
+++ b/src/models/admin_schemas.py
@@ -6,9 +6,9 @@ Schemas Pydantic para la API de administración /admin/clients/*.
 Separados de schemas.py (modelos runtime del bridge) para no mezclar
 contratos internos con la interfaz HTTP de administración.
 """
+
 import json
 from datetime import datetime
-from typing import Optional
 
 from pydantic import BaseModel
 
@@ -17,10 +17,10 @@ from src.db.models import ClientRecord
 
 class ClientCreate(BaseModel):
     name: str
-    client_key: Optional[str] = None  # si se omite, se genera uno aleatorio
-    client_type: Optional[str] = None
-    default_agent: Optional[str] = None
-    allowed_agents: Optional[list[str]] = None
+    client_key: str | None = None  # si se omite, se genera uno aleatorio
+    client_type: str | None = None
+    default_agent: str | None = None
+    allowed_agents: list[str] | None = None
     # Pipeline config
     stt_language: str = "es"
     stt_vad_thold: float = 0.0
@@ -28,7 +28,7 @@ class ClientCreate(BaseModel):
     tts_speed: float = 1.0
     barge_in_enabled: bool = True
     barge_in_min_chars: int = 5
-    output_mode: Optional[list[str]] = None
+    output_mode: list[str] | None = None
     silence_timeout_s: float = 2.0
     max_silence_turns: int = 3
     push_enabled: bool = True
@@ -37,22 +37,23 @@ class ClientCreate(BaseModel):
 
 class ClientUpdate(BaseModel):
     """Todos los campos opcionales — PATCH semántico (exclude_unset)."""
-    name: Optional[str] = None
-    is_active: Optional[bool] = None
-    client_type: Optional[str] = None
-    default_agent: Optional[str] = None
-    allowed_agents: Optional[list[str]] = None
-    stt_language: Optional[str] = None
-    stt_vad_thold: Optional[float] = None
-    tts_voice: Optional[str] = None
-    tts_speed: Optional[float] = None
-    barge_in_enabled: Optional[bool] = None
-    barge_in_min_chars: Optional[int] = None
-    output_mode: Optional[list[str]] = None
-    silence_timeout_s: Optional[float] = None
-    max_silence_turns: Optional[int] = None
-    push_enabled: Optional[bool] = None
-    tool_calls_enabled: Optional[bool] = None
+
+    name: str | None = None
+    is_active: bool | None = None
+    client_type: str | None = None
+    default_agent: str | None = None
+    allowed_agents: list[str] | None = None
+    stt_language: str | None = None
+    stt_vad_thold: float | None = None
+    tts_voice: str | None = None
+    tts_speed: float | None = None
+    barge_in_enabled: bool | None = None
+    barge_in_min_chars: int | None = None
+    output_mode: list[str] | None = None
+    silence_timeout_s: float | None = None
+    max_silence_turns: int | None = None
+    push_enabled: bool | None = None
+    tool_calls_enabled: bool | None = None
 
 
 class ClientResponse(BaseModel):
@@ -60,9 +61,9 @@ class ClientResponse(BaseModel):
     name: str
     client_key: str
     is_active: bool
-    client_type: Optional[str]
-    default_agent: Optional[str]
-    allowed_agents: Optional[list[str]]
+    client_type: str | None
+    default_agent: str | None
+    allowed_agents: list[str] | None
     created_at: datetime
     # Pipeline config
     stt_language: str
@@ -71,7 +72,7 @@ class ClientResponse(BaseModel):
     tts_speed: float
     barge_in_enabled: bool
     barge_in_min_chars: int
-    output_mode: Optional[list[str]]
+    output_mode: list[str] | None
     silence_timeout_s: float
     max_silence_turns: int
     push_enabled: bool

--- a/src/models/schemas.py
+++ b/src/models/schemas.py
@@ -1,12 +1,15 @@
+from typing import Literal
+
 from pydantic import BaseModel, ConfigDict
-from typing import List, Literal, Optional
 
 # =====================================================================
 # jota-db — modelos que el gateway recibe de GET /auth/session
 # =====================================================================
 
+
 class Client(BaseModel):
     """Registro de cliente resuelto desde la BD local."""
+
     id: str
     client_key: str
     is_active: bool
@@ -17,6 +20,7 @@ class Client(BaseModel):
 
 class ClientConfig(BaseModel):
     """Configuración por cliente leída desde la BD local."""
+
     stt_language: str = "es"
     stt_vad_thold: float = 0.0
     tts_voice: str = "af_heart"
@@ -27,42 +31,49 @@ class ClientConfig(BaseModel):
     max_silence_turns: int = 3
     push_enabled: bool = True
     tool_calls_enabled: bool = False
-    default_agent: Optional[str] = None
-    allowed_agents: Optional[List[str]] = None
+    default_agent: str | None = None
+    allowed_agents: list[str] | None = None
 
     model_config = ConfigDict(extra="allow")
 
 
 class SessionResponse(BaseModel):
     """Respuesta de GET /auth/session en jota-db."""
+
     client: Client
     config: ClientConfig
+
 
 # =====================================================================
 # Gateway (Client <-> Gateway)
 # =====================================================================
+
 
 class Handshake(BaseModel):
     """
     Configuración inicial que el ESP32 o la Web envían al Gateway al conectar
     por WebSocket. Define qué patas internas del ecosistema se deben encender.
     """
+
     client_key: str
     input_mode: Literal["audio", "text"]
-    output_mode: List[Literal["audio", "text", "status"]]
-    agent: Optional[str] = None  # OpenClaw agent name; None → gateway default
+    output_mode: list[Literal["audio", "text", "status"]]
+    agent: str | None = None  # OpenClaw agent name; None → gateway default
 
     model_config = ConfigDict(extra="allow")
+
 
 # =====================================================================
 # Transcriber (Gateway <-> JotaTranscriber)
 # =====================================================================
+
 
 class TranscriberConfig(BaseModel):
     """
     Mensaje de handshake inicial requerido por el servidor de transcripción (C++)
     antes de aceptar recibir ráfagas de audio PCM float32.
     """
+
     type: Literal["config"] = "config"
     language: str = "es"
     token: str = ""
@@ -74,10 +85,10 @@ class TranscriberMessage(BaseModel):
     Formato de salida proveniente del Transcriptor C++.
     Tipos posibles: "transcription", "ready", "warning", "error".
     """
-    type: str
-    text: Optional[str] = None
-    is_final: Optional[bool] = None
-    message: Optional[str] = None   # descripción legible en warning/error
-    code: Optional[str] = None      # código de error/warning: AUTH_FAILED, buffer_full, etc.
-    session_id: Optional[str] = None  # presente en el mensaje "ready"
 
+    type: str
+    text: str | None = None
+    is_final: bool | None = None
+    message: str | None = None  # descripción legible en warning/error
+    code: str | None = None  # código de error/warning: AUTH_FAILED, buffer_full, etc.
+    session_id: str | None = None  # presente en el mensaje "ready"

--- a/src/services/bridge.py
+++ b/src/services/bridge.py
@@ -2,24 +2,24 @@ import asyncio
 import json
 import logging
 import time
-from typing import Optional
+
 from fastapi import WebSocket, WebSocketDisconnect
 
 from src.core.config import settings
 from src.models.schemas import Client, ClientConfig, Handshake
-from src.services.protocol import OrchestratorProtocol
 from src.services.openclaw.models import ToolCallEvent
+from src.services.openclaw.registry import ClientRegistry
 from src.services.pipeline_tracker import PipelineTracker
+from src.services.protocol import OrchestratorProtocol
 from src.services.reconnection import ConnectionState, to_wire_state
 from src.services.transcriber_reconnecting import ReconnectingTranscriberClient
 from src.services.tts_client import TTSClient
 from src.services.tts_reconnecting import ReconnectingTTSClient
-from src.services.openclaw.registry import ClientRegistry
 
 logger = logging.getLogger(__name__)
 
 
-def _tool_call_message(turn_id: Optional[str], tool_call: ToolCallEvent) -> dict:
+def _tool_call_message(turn_id: str | None, tool_call: ToolCallEvent) -> dict:
     return {
         "type": "tool_call",
         "turn_id": turn_id,
@@ -31,11 +31,13 @@ def _tool_call_message(turn_id: Optional[str], tool_call: ToolCallEvent) -> dict
         "is_error": tool_call.is_error,
     }
 
+
 class JotaBridge:
     """
     Titiritero principal. Gestiona la conexión de un cliente físico
     y enruta asincrónicamente los mensajes utilizando los adaptadores de microservicio.
     """
+
     def __init__(
         self,
         client: Client,
@@ -53,14 +55,14 @@ class JotaBridge:
         self.client_id = client.id  # nombre legible del cliente (hab_sito, jota_desktop…)
         self.client_ws = client_ws
         self.handshake: Handshake = handshake
-        self.orchestrator: OrchestratorProtocol = orchestrator   # injected, not created here
+        self.orchestrator: OrchestratorProtocol = orchestrator  # injected, not created here
         self.tts = tts
         self.tracker: PipelineTracker = tracker
         self._client_registry = client_registry
         self._default_agent = default_agent
-        self.transcriber: Optional[ReconnectingTranscriberClient] = None
+        self.transcriber: ReconnectingTranscriberClient | None = None
         self._push_tts = None
-        self._push_audio_task: Optional[asyncio.Task] = None
+        self._push_audio_task: asyncio.Task | None = None
 
         self.tasks: list[asyncio.Task] = []
         # Fire-and-forget notification tasks (e.g. _on_transcriber_state_change)
@@ -68,13 +70,13 @@ class JotaBridge:
         # they're short-lived and self-cleaning. Kept here only so the event
         # loop's weak reference doesn't let them get GC'd mid-flight.
         self._notification_tasks: set[asyncio.Task] = set()
-        self._active_turn: Optional[asyncio.Task] = None
+        self._active_turn: asyncio.Task | None = None
         self._session_start: float = 0.0
-        self._first_audio_at: Optional[float] = None
-        self._last_final_text: Optional[str] = None
+        self._first_audio_at: float | None = None
+        self._last_final_text: str | None = None
         self._turn_seq: int = 0
         self._push_turn_seq: int = 0
-        self._push_turn_id: Optional[str] = None
+        self._push_turn_id: str | None = None
         # Issue #84: OpenClaw emits multiple agent start/end pairs during a single
         # LLM response (tool use, multi-step reasoning). Track whether a push turn
         # is already open so we emit exactly one turn_start/turn_end to the client
@@ -190,11 +192,13 @@ class JotaBridge:
         pre-ready notification and the authoritative capabilities block.
         """
         if not await self.orchestrator.ping():
-            await self.client_ws.send_json({
-                "type": "status",
-                "service": "orchestrator",
-                "state": "unavailable",
-            })
+            await self.client_ws.send_json(
+                {
+                    "type": "status",
+                    "service": "orchestrator",
+                    "state": "unavailable",
+                }
+            )
             return None
 
         transcriber_requested = self.handshake.input_mode == "audio"
@@ -205,22 +209,26 @@ class JotaBridge:
                 self.transcriber and self.transcriber.state == ConnectionState.CONNECTED
             )
             if not transcriber_live:
-                await self.client_ws.send_json({
-                    "type": "status",
-                    "service": "transcriber",
-                    "state": "unavailable",
-                })
+                await self.client_ws.send_json(
+                    {
+                        "type": "status",
+                        "service": "transcriber",
+                        "state": "unavailable",
+                    }
+                )
         else:
             transcriber_live = False
 
         if tts_requested:
             tts_live = await TTSClient.ping(settings.TTS_WS_URL)
             if not tts_live:
-                await self.client_ws.send_json({
-                    "type": "status",
-                    "service": "tts",
-                    "state": "unavailable",
-                })
+                await self.client_ws.send_json(
+                    {
+                        "type": "status",
+                        "service": "tts",
+                        "state": "unavailable",
+                    }
+                )
         else:
             tts_live = False
 
@@ -253,7 +261,7 @@ class JotaBridge:
         silence_count = 0
         last_seen_transcription_at = self.transcriber._last_transcription_at
         was_connected = True
-        recovery_baseline: Optional[float] = None
+        recovery_baseline: float | None = None
 
         while True:
             await asyncio.sleep(2)
@@ -288,11 +296,13 @@ class JotaBridge:
                     f"({silence_count}/{self.config.max_silence_turns})"
                 )
                 try:
-                    await self.client_ws.send_json({
-                        "type": "status",
-                        "service": "transcriber",
-                        "state": "degraded",
-                    })
+                    await self.client_ws.send_json(
+                        {
+                            "type": "status",
+                            "service": "transcriber",
+                            "state": "degraded",
+                        }
+                    )
                 except Exception:
                     pass
                 if silence_count >= self.config.max_silence_turns:
@@ -312,12 +322,14 @@ class JotaBridge:
 
         # Loop del Transcriptor (solo si hay audio de entrada)
         if self.transcriber:
-            self.tasks.append(asyncio.create_task(
-                self.transcriber.run(
-                    on_transcription_callback=self._on_transcription,
-                    on_warning_callback=self._on_transcriber_warning,
+            self.tasks.append(
+                asyncio.create_task(
+                    self.transcriber.run(
+                        on_transcription_callback=self._on_transcription,
+                        on_warning_callback=self._on_transcriber_warning,
+                    )
                 )
-            ))
+            )
             self.tasks.append(asyncio.create_task(self._transcription_watchdog()))
 
         # El ciclo de vida de la sesión lo marca _client_input_loop.
@@ -384,16 +396,18 @@ class JotaBridge:
         except Exception as e:
             logger.error(f"[{self.client_id}] Error en input loop: {e}")
 
-    async def _on_transcriber_warning(self, code: str, message: Optional[str]):
+    async def _on_transcriber_warning(self, code: str, message: str | None):
         """Reenvía warnings del transcriber al cliente (e.g. buffer_full)."""
         try:
-            await self.client_ws.send_json({
-                "type": "status",
-                "service": "transcriber",
-                "state": "degraded",
-                "code": code,
-                "message": message or code,
-            })
+            await self.client_ws.send_json(
+                {
+                    "type": "status",
+                    "service": "transcriber",
+                    "state": "degraded",
+                    "code": code,
+                    "message": message or code,
+                }
+            )
         except Exception:
             pass  # cliente desconectado
 
@@ -437,7 +451,9 @@ class JotaBridge:
             # Barge-in: interrupt active turn if enabled and partial is substantial enough
             if self.config.barge_in_enabled and len(text) >= self.config.barge_in_min_chars:
                 if await self._cancel_active_turn():
-                    logger.info(f"[{self.client_id}] Barge-in: turno cancelado por parcial '{text[:30]}'")
+                    logger.info(
+                        f"[{self.client_id}] Barge-in: turno cancelado por parcial '{text[:30]}'"
+                    )
                     await self.tracker.record("barge_in")
                     try:
                         await self.client_ws.send_json({"type": "interrupted"})
@@ -447,7 +463,9 @@ class JotaBridge:
 
         # Final: deduplicate — transcriber may emit the same text more than once
         if text == self._last_final_text:
-            logger.debug(f"[{self.client_id}] Transcripción final duplicada descartada: '{text[:40]}'")
+            logger.debug(
+                f"[{self.client_id}] Transcripción final duplicada descartada: '{text[:40]}'"
+            )
             return
         self._last_final_text = text
         await self.tracker.record("transcription_final", text=text[:60])
@@ -468,8 +486,8 @@ class JotaBridge:
         Si el cliente pidió audio, crea un TTSClient por petición y corre
         pipe_tokens + pipe_audio concurrentemente vía asyncio.gather.
         """
-        from src.services.orchestration import call_orchestrator
         from src.core.session_key import make_session_key
+        from src.services.orchestration import call_orchestrator
 
         self._turn_seq += 1
         turn_seq = self._turn_seq
@@ -478,13 +496,15 @@ class JotaBridge:
         self.tracker.start_turn()
 
         try:
-            await self.client_ws.send_json({"type": "turn_start", "turn_id": turn_id, "turn_seq": turn_seq})
+            await self.client_ws.send_json(
+                {"type": "turn_start", "turn_id": turn_id, "turn_seq": turn_seq}
+            )
         except Exception:
             return
 
         needs_audio = "audio" in self.handshake.output_mode
 
-        tts: Optional[TTSClient] = None
+        tts: TTSClient | None = None
         if needs_audio:
             tts = await self.tts.connect(
                 voice=self.config.tts_voice,
@@ -501,7 +521,9 @@ class JotaBridge:
         async def _on_token(token_text: str):
             try:
                 if "text" in self.handshake.output_mode:
-                    await self.client_ws.send_json({"type": "token", "turn_id": turn_id, "text": token_text})
+                    await self.client_ws.send_json(
+                        {"type": "token", "turn_id": turn_id, "text": token_text}
+                    )
             except Exception:
                 pass
             if tts:
@@ -518,7 +540,10 @@ class JotaBridge:
         async def pipe_tokens():
             try:
                 await call_orchestrator(
-                    self.orchestrator, text, session_key, self.client_id,
+                    self.orchestrator,
+                    text,
+                    session_key,
+                    self.client_id,
                     tracker=self.tracker,
                     on_token=_on_token,
                     on_tool_call=_on_tool_call,
@@ -526,13 +551,15 @@ class JotaBridge:
             except RuntimeError as e:
                 logger.error(f"[{self.client_id}] Orchestrator error: {e}")
                 try:
-                    await self.client_ws.send_json({
-                        "type": "error",
-                        "code": "TURN_ERROR",
-                        "message": str(e),
-                        "fatal": False,
-                        "turn_id": turn_id,
-                    })
+                    await self.client_ws.send_json(
+                        {
+                            "type": "error",
+                            "code": "TURN_ERROR",
+                            "message": str(e),
+                            "fatal": False,
+                            "turn_id": turn_id,
+                        }
+                    )
                 except Exception:
                     pass
             finally:
@@ -598,11 +625,13 @@ class JotaBridge:
         self._push_turn_open = True
 
         try:
-            await self.client_ws.send_json({
-                "type": "turn_start",
-                "turn_id": self._push_turn_id,
-                "turn_seq": self._turn_seq,
-            })
+            await self.client_ws.send_json(
+                {
+                    "type": "turn_start",
+                    "turn_id": self._push_turn_id,
+                    "turn_seq": self._turn_seq,
+                }
+            )
         except Exception:
             pass
 
@@ -634,11 +663,13 @@ class JotaBridge:
             return
         if "text" in self.handshake.output_mode:
             try:
-                await self.client_ws.send_json({
-                    "type": "token",
-                    "turn_id": self._push_turn_id,
-                    "text": delta,
-                })
+                await self.client_ws.send_json(
+                    {
+                        "type": "token",
+                        "turn_id": self._push_turn_id,
+                        "text": delta,
+                    }
+                )
             except Exception:
                 pass
         if self._push_tts:
@@ -661,9 +692,7 @@ class JotaBridge:
         # Issue #84: if no push turn is open, this agent end has no matching
         # turn_start on the client side. Ignoring it avoids orphan turn_end frames.
         if not self._push_turn_open:
-            logger.debug(
-                f"[{self.client_id}] push_turn_end ignored: no push turn open"
-            )
+            logger.debug(f"[{self.client_id}] push_turn_end ignored: no push turn open")
             return
 
         if self._push_tts:

--- a/src/services/bridge.py
+++ b/src/services/bridge.py
@@ -180,42 +180,55 @@ class JotaBridge:
             await self.tracker.close(status=status)
             self._closed = True
 
-    async def health_check(self) -> bool:
-        """Ping each microservice and notify the client of any issues.
+    async def health_check(self) -> dict[str, bool] | None:
+        """Ping each microservice and return a snapshot of live capabilities.
 
-        Returns True if the session can proceed, False if a critical service
-        is unavailable (caller should close the WebSocket) — the orchestrator
-        is the only service that can make this return False.
+        Returns None if the orchestrator is unavailable — the caller must close
+        the WebSocket and skip sending `ready`. For non-fatal services the
+        snapshot records their current availability, and the same `status`
+        warnings sent today are still emitted so the client sees both the
+        pre-ready notification and the authoritative capabilities block.
         """
-        # Orchestrator — always critical
         if not await self.orchestrator.ping():
             await self.client_ws.send_json({
                 "type": "status",
                 "service": "orchestrator",
                 "state": "unavailable",
             })
-            return False
+            return None
 
-        # Transcriber — non-critical (session continues degraded if unavailable;
-        # the client decides whether to keep going text-only)
-        if self.handshake.input_mode == "audio":
-            if not self.transcriber or self.transcriber.state != ConnectionState.CONNECTED:
+        transcriber_requested = self.handshake.input_mode == "audio"
+        tts_requested = "audio" in self.handshake.output_mode
+
+        if transcriber_requested:
+            transcriber_live = bool(
+                self.transcriber and self.transcriber.state == ConnectionState.CONNECTED
+            )
+            if not transcriber_live:
                 await self.client_ws.send_json({
                     "type": "status",
                     "service": "transcriber",
                     "state": "unavailable",
                 })
+        else:
+            transcriber_live = False
 
-        # TTS — non-critical; session continues in degraded mode
-        if "audio" in self.handshake.output_mode:
-            if not await TTSClient.ping(settings.TTS_WS_URL):
+        if tts_requested:
+            tts_live = await TTSClient.ping(settings.TTS_WS_URL)
+            if not tts_live:
                 await self.client_ws.send_json({
                     "type": "status",
                     "service": "tts",
                     "state": "unavailable",
                 })
+        else:
+            tts_live = False
 
-        return True
+        return {
+            "barge_in": bool(self.config.barge_in_enabled) and transcriber_live,
+            "tts": tts_live,
+            "transcriber": transcriber_live,
+        }
 
     async def _cancel_active_turn(self) -> bool:
         """Cancel the active orchestrator turn if one is running. Returns True if cancelled."""

--- a/src/services/db_client.py
+++ b/src/services/db_client.py
@@ -7,9 +7,9 @@ Interfaz pública invariante:
   db_client.get_session(client_key) → (Client, ClientConfig)
   db_client.invalidate(client_key)  → None
 """
+
 import json
 import logging
-from typing import List, Optional
 
 from sqlmodel import Session, select
 
@@ -22,7 +22,7 @@ from src.models.schemas import Client, ClientConfig
 logger = logging.getLogger(__name__)
 
 
-def _parse_allowed_agents(raw: Optional[str]) -> Optional[List[str]]:
+def _parse_allowed_agents(raw: str | None) -> list[str] | None:
     """Parse the JSON-encoded `allowed_agents` field from ClientRecord.
 
     - None / "" / "null"  → None   (sin restricción)
@@ -41,9 +41,7 @@ def _parse_allowed_agents(raw: Optional[str]) -> Optional[List[str]]:
         return None
     parsed = json.loads(raw)
     if not isinstance(parsed, list):
-        raise ValueError(
-            f"allowed_agents must be a JSON list, got {type(parsed).__name__}"
-        )
+        raise ValueError(f"allowed_agents must be a JSON list, got {type(parsed).__name__}")
     return [str(x) for x in parsed]
 
 
@@ -83,7 +81,7 @@ class DbClient:
             generation_before = self._generations.get(client_key, 0)
 
         with Session(self._get_engine()) as session:
-            record: Optional[ClientRecord] = session.exec(
+            record: ClientRecord | None = session.exec(
                 select(ClientRecord).where(ClientRecord.client_key == client_key)
             ).first()
 

--- a/src/services/openclaw/__init__.py
+++ b/src/services/openclaw/__init__.py
@@ -1,4 +1,14 @@
-from src.services.openclaw.models import GatewayInfo, AgentInfo
-from src.services.openclaw.registry import TurnRegistry, ClientRegistry, client_id_from_session_key
+from src.services.openclaw.models import AgentInfo, GatewayInfo
+from src.services.openclaw.registry import (
+    ClientRegistry,
+    TurnRegistry,
+    client_id_from_session_key,
+)
 
-__all__ = ["GatewayInfo", "AgentInfo", "TurnRegistry", "ClientRegistry", "client_id_from_session_key"]
+__all__ = [
+    "AgentInfo",
+    "ClientRegistry",
+    "GatewayInfo",
+    "TurnRegistry",
+    "client_id_from_session_key",
+]

--- a/src/services/openclaw/client.py
+++ b/src/services/openclaw/client.py
@@ -2,7 +2,7 @@ import asyncio
 import json
 import logging
 import uuid
-from typing import AsyncIterator, Callable, Optional
+from collections.abc import AsyncIterator, Callable
 
 import websockets
 from websockets.asyncio.client import ClientConnection
@@ -10,7 +10,11 @@ from websockets.asyncio.client import ClientConnection
 from src.services.openclaw import frames
 from src.services.openclaw.dispatcher import FrameDispatcher
 from src.services.openclaw.models import GatewayInfo, ToolCallEvent
-from src.services.openclaw.registry import TURN_IN_PROGRESS_ERROR, TurnInProgress, TurnRegistry
+from src.services.openclaw.registry import (
+    TURN_IN_PROGRESS_ERROR,
+    TurnInProgress,
+    TurnRegistry,
+)
 from src.services.protocol import OrchestratorEvent
 
 logger = logging.getLogger(__name__)
@@ -35,15 +39,15 @@ class OpenClawClient:
         self._token = token
         self._turn_registry = turn_registry
         self._dispatcher = dispatcher
-        self._ws: Optional[ClientConnection] = None
-        self._listener_task: Optional[asyncio.Task] = None
-        self._keepalive_task: Optional[asyncio.Task] = None
+        self._ws: ClientConnection | None = None
+        self._listener_task: asyncio.Task | None = None
+        self._keepalive_task: asyncio.Task | None = None
         self._connect_lock = asyncio.Lock()
         self._health_futures: dict[str, asyncio.Future] = {}
-        self.gateway_info: Optional[GatewayInfo] = None
+        self.gateway_info: GatewayInfo | None = None
         # Called only on unexpected disconnect (not on clean close()).
         # Set by ReconnectingOrchestrator after wrapping this client.
-        self.on_disconnect: Optional[Callable[[], None]] = None
+        self.on_disconnect: Callable[[], None] | None = None
 
     async def connect(self) -> GatewayInfo:
         async with self._connect_lock:
@@ -52,7 +56,7 @@ class OpenClawClient:
 
     async def _do_connect(self) -> GatewayInfo:
         self._ws = await websockets.connect(self._uri)
-        conn_err: Optional[Exception] = None
+        conn_err: Exception | None = None
         try:
             raw = await asyncio.wait_for(self._ws.recv(), timeout=15.0)
             frame = json.loads(raw)
@@ -108,7 +112,7 @@ class OpenClawClient:
         while True:
             remaining = deadline - loop.time()
             if remaining <= 0:
-                raise asyncio.TimeoutError(f"No response for req_id={req_id} within {timeout}s")
+                raise TimeoutError(f"No response for req_id={req_id} within {timeout}s")
             raw = await asyncio.wait_for(self._ws.recv(), timeout=remaining)
             frame = json.loads(raw)
             if frame.get("id") == req_id:
@@ -178,14 +182,16 @@ class OpenClawClient:
         self,
         text: str,
         user_id: str,
-        model_id: Optional[str] = None,
-        session_key: Optional[str] = None,
+        model_id: str | None = None,
+        session_key: str | None = None,
     ) -> AsyncIterator[OrchestratorEvent]:
         if not self._ws:
             yield OrchestratorEvent(type="error", content="not connected")
             return
         if not session_key:
-            raise ValueError("session_key is required — callers must provide it via make_session_key()")
+            raise ValueError(
+                "session_key is required — callers must provide it via make_session_key()"
+            )
 
         req_id = str(uuid.uuid4())
         try:
@@ -198,9 +204,9 @@ class OpenClawClient:
 
         try:
             try:
-                await self._ws.send(json.dumps(
-                    frames.chat_send(req_id, session_key, text, str(uuid.uuid4()))
-                ))
+                await self._ws.send(
+                    json.dumps(frames.chat_send(req_id, session_key, text, str(uuid.uuid4())))
+                )
                 _sent = True
             except Exception as e:
                 yield OrchestratorEvent(type="error", content=f"send failed: {e}")
@@ -242,9 +248,9 @@ class OpenClawClient:
             self._turn_registry.unregister(session_key, req_id)
             if _sent and not _finished and self._ws:
                 try:
-                    await asyncio.shield(self._ws.send(json.dumps(
-                        frames.chat_abort(str(uuid.uuid4()), session_key)
-                    )))
+                    await asyncio.shield(
+                        self._ws.send(json.dumps(frames.chat_abort(str(uuid.uuid4()), session_key)))
+                    )
                 except Exception:
                     pass
 

--- a/src/services/openclaw/dispatcher.py
+++ b/src/services/openclaw/dispatcher.py
@@ -1,5 +1,10 @@
 import logging
-from src.services.openclaw.registry import TurnRegistry, ClientRegistry, client_id_from_session_key
+
+from src.services.openclaw.registry import (
+    ClientRegistry,
+    TurnRegistry,
+    client_id_from_session_key,
+)
 
 logger = logging.getLogger(__name__)
 

--- a/src/services/openclaw/frames.py
+++ b/src/services/openclaw/frames.py
@@ -4,20 +4,25 @@ def _req(method: str, req_id: str, params: dict) -> dict:
 
 # ── Conexión ──────────────────────────────────────────────────────
 
+
 def connect_backend(req_id: str, token: str, client_id: str = "gateway-client") -> dict:
-    return _req("connect", req_id, {
-        "minProtocol": 3,
-        "maxProtocol": 4,
-        "client": {
-            "id": client_id,
-            "version": "1.0.0",
-            "platform": "linux",
-            "mode": "backend",
+    return _req(
+        "connect",
+        req_id,
+        {
+            "minProtocol": 3,
+            "maxProtocol": 4,
+            "client": {
+                "id": client_id,
+                "version": "1.0.0",
+                "platform": "linux",
+                "mode": "backend",
+            },
+            "role": "operator",
+            "scopes": ["operator.read", "operator.write"],
+            "auth": {"token": token},
         },
-        "role": "operator",
-        "scopes": ["operator.read", "operator.write"],
-        "auth": {"token": token},
-    })
+    )
 
 
 def sessions_subscribe(req_id: str) -> dict:
@@ -30,12 +35,17 @@ def health(req_id: str) -> dict:
 
 # ── Chat ──────────────────────────────────────────────────────────
 
+
 def chat_send(req_id: str, session_key: str, message: str, idempotency_key: str) -> dict:
-    return _req("chat.send", req_id, {
-        "sessionKey": session_key,
-        "message": message,
-        "idempotencyKey": idempotency_key,
-    })
+    return _req(
+        "chat.send",
+        req_id,
+        {
+            "sessionKey": session_key,
+            "message": message,
+            "idempotencyKey": idempotency_key,
+        },
+    )
 
 
 def chat_abort(req_id: str, session_key: str) -> dict:
@@ -43,27 +53,40 @@ def chat_abort(req_id: str, session_key: str) -> dict:
 
 
 def chat_history(req_id: str, session_key: str, limit: int = 50, offset: int = 0) -> dict:
-    return _req("chat.history", req_id, {
-        "sessionKey": session_key,
-        "limit": limit,
-        "offset": offset,
-    })
+    return _req(
+        "chat.history",
+        req_id,
+        {
+            "sessionKey": session_key,
+            "limit": limit,
+            "offset": offset,
+        },
+    )
 
 
 def chat_inject(req_id: str, session_key: str, content: str) -> dict:
-    return _req("chat.inject", req_id, {
-        "sessionKey": session_key,
-        "content": content,
-    })
+    return _req(
+        "chat.inject",
+        req_id,
+        {
+            "sessionKey": session_key,
+            "content": content,
+        },
+    )
 
 
 # ── Sessions ──────────────────────────────────────────────────────
 
+
 def sessions_steer(req_id: str, session_key: str, steer_text: str) -> dict:
-    return _req("sessions.steer", req_id, {
-        "key": session_key,
-        "steerText": steer_text,
-    })
+    return _req(
+        "sessions.steer",
+        req_id,
+        {
+            "key": session_key,
+            "steerText": steer_text,
+        },
+    )
 
 
 def sessions_list(req_id: str) -> dict:
@@ -71,6 +94,7 @@ def sessions_list(req_id: str) -> dict:
 
 
 # ── Agentes y modelos ─────────────────────────────────────────────
+
 
 def agents_list(req_id: str) -> dict:
     return _req("agents.list", req_id, {})

--- a/src/services/openclaw/models.py
+++ b/src/services/openclaw/models.py
@@ -69,7 +69,7 @@ class GatewayInfo:
         )
 
 
-def _flatten_tool_result_content(content: Optional[list]) -> Optional[str]:
+def _flatten_tool_result_content(content: list | None) -> str | None:
     """Join result.content[].text blocks from a session.tool 'result' payload.
 
     OpenClaw tool results carry a list of typed content blocks; jota-gateway
@@ -91,9 +91,9 @@ class ToolCallEvent:
     phase: Literal["start", "result"]
     name: str
     tool_call_id: str
-    args: Optional[dict] = None
-    result: Optional[str] = None
-    is_error: Optional[bool] = None
+    args: dict | None = None
+    result: str | None = None
+    is_error: bool | None = None
 
     @classmethod
     def from_session_tool_payload(cls, data: dict) -> Optional["ToolCallEvent"]:

--- a/src/services/openclaw/reconnecting.py
+++ b/src/services/openclaw/reconnecting.py
@@ -3,8 +3,8 @@ import contextlib
 import logging
 import time
 import uuid
-from datetime import datetime, timezone
-from typing import AsyncIterator, Optional
+from collections.abc import AsyncIterator
+from datetime import UTC, datetime
 
 from src.services.openclaw.client import OpenClawClient
 from src.services.openclaw.models import GatewayInfo
@@ -35,12 +35,12 @@ class ReconnectingOpenClawClient:
         self._max_backoff = max_backoff
         self._max_duration = max_duration
         self.state = ConnectionState.DEGRADED
-        self.gateway_info: Optional[GatewayInfo] = None
-        self._connected_at: Optional[datetime] = None
+        self.gateway_info: GatewayInfo | None = None
+        self._connected_at: datetime | None = None
         self._reconnect_attempts: int = 0
-        self._last_error: Optional[str] = None
-        self._reconnect_task: Optional[asyncio.Task] = None
-        self._reconnect_job_id: Optional[str] = None
+        self._last_error: str | None = None
+        self._reconnect_task: asyncio.Task | None = None
+        self._reconnect_job_id: str | None = None
         self._reconnect_exhausted: bool = False
         self.on_state_change = None
         # Register disconnect callback so the inner client notifies us on unexpected drops.
@@ -53,7 +53,7 @@ class ReconnectingOpenClawClient:
         try:
             self.gateway_info = await self._client.connect()
             self._set_state(ConnectionState.CONNECTED)
-            self._connected_at = datetime.now(timezone.utc)
+            self._connected_at = datetime.now(UTC)
             self._reconnect_attempts = 0
             self._last_error = None
             self._reconnect_exhausted = False
@@ -82,8 +82,8 @@ class ReconnectingOpenClawClient:
         self,
         text: str,
         user_id: str,
-        model_id: Optional[str] = None,
-        session_key: Optional[str] = None,
+        model_id: str | None = None,
+        session_key: str | None = None,
     ) -> AsyncIterator[OrchestratorEvent]:
         if self.state != ConnectionState.CONNECTED:
             if self.state == ConnectionState.DEGRADED:
@@ -97,12 +97,14 @@ class ReconnectingOpenClawClient:
             # gets a synchronous GeneratorExit when this generator is closed early,
             # instead of being abandoned for the asyncgen GC finalizer to eventually
             # close (issue #150, one layer removed from the #99/#147 fix).
-            async with contextlib.aclosing(self._client.stream_response(
-                text=text,
-                user_id=user_id,
-                model_id=model_id,
-                session_key=session_key,
-            )) as inner:
+            async with contextlib.aclosing(
+                self._client.stream_response(
+                    text=text,
+                    user_id=user_id,
+                    model_id=model_id,
+                    session_key=session_key,
+                )
+            ) as inner:
                 async for event in inner:
                     yield event
         except asyncio.CancelledError:
@@ -156,7 +158,7 @@ class ReconnectingOpenClawClient:
             try:
                 self.gateway_info = await self._client.connect()
                 self._set_state(ConnectionState.CONNECTED)
-                self._connected_at = datetime.now(timezone.utc)
+                self._connected_at = datetime.now(UTC)
                 self._reconnect_attempts = 0
                 self._last_error = None
                 logger.info("[%s] reconnected.", self._name)
@@ -168,7 +170,9 @@ class ReconnectingOpenClawClient:
                 self._last_error = str(e)
                 logger.warning(
                     "[%s] reconnect attempt %d failed: %s",
-                    self._name, self._reconnect_attempts, e,
+                    self._name,
+                    self._reconnect_attempts,
+                    e,
                 )
 
             if time.monotonic() - start >= self._max_duration:

--- a/src/services/openclaw/registry.py
+++ b/src/services/openclaw/registry.py
@@ -1,6 +1,6 @@
 import asyncio
 import logging
-from typing import Any, Optional
+from typing import Any
 
 logger = logging.getLogger(__name__)
 
@@ -61,10 +61,10 @@ class TurnRegistry:
             self._session_owner.pop(session_key, None)
         self._req_to_session.pop(req_id, None)
 
-    def get_queue_by_session(self, session_key: str) -> Optional[asyncio.Queue]:
+    def get_queue_by_session(self, session_key: str) -> asyncio.Queue | None:
         return self._sessions.get(session_key)
 
-    def get_queue_by_req(self, req_id: str) -> Optional[asyncio.Queue]:
+    def get_queue_by_req(self, req_id: str) -> asyncio.Queue | None:
         sk = self._req_to_session.get(req_id)
         return self._sessions.get(sk) if sk else None
 
@@ -91,7 +91,8 @@ class ClientRegistry:
         if self._clients.get(client_id) is not None:
             logger.warning(
                 "ClientRegistry: client_id=%s re-registered while a previous "
-                "bridge was still active (reconnect race)", client_id
+                "bridge was still active (reconnect race)",
+                client_id,
             )
         self._clients[client_id] = bridge
 
@@ -104,7 +105,7 @@ class ClientRegistry:
         if self._clients.get(client_id) is expected_bridge:
             self._clients.pop(client_id, None)
 
-    def get(self, client_id: str) -> Optional[Any]:
+    def get(self, client_id: str) -> Any | None:
         return self._clients.get(client_id)
 
     async def broadcast_status(self, service: str, state: str) -> None:

--- a/src/services/orchestration.py
+++ b/src/services/orchestration.py
@@ -1,10 +1,10 @@
 import contextlib
 import logging
-from typing import Awaitable, Callable, Optional
+from collections.abc import Awaitable, Callable
 
-from src.services.protocol import OrchestratorProtocol
 from src.services.openclaw.models import ToolCallEvent
 from src.services.pipeline_tracker import PipelineTracker
+from src.services.protocol import OrchestratorProtocol
 
 logger = logging.getLogger(__name__)
 
@@ -14,10 +14,10 @@ async def call_orchestrator(
     text: str,
     session_key: str,
     user_id: str,
-    model_id: Optional[str] = None,
-    tracker: Optional[PipelineTracker] = None,
-    on_token: Optional[Callable[[str], Awaitable[None]]] = None,
-    on_tool_call: Optional[Callable[[ToolCallEvent], Awaitable[None]]] = None,
+    model_id: str | None = None,
+    tracker: PipelineTracker | None = None,
+    on_token: Callable[[str], Awaitable[None]] | None = None,
+    on_tool_call: Callable[[ToolCallEvent], Awaitable[None]] | None = None,
 ) -> None:
     """Iterate orchestrator.stream_response(), record pipeline events, call on_token per token
     and on_tool_call per tool-call event.
@@ -36,12 +36,14 @@ async def call_orchestrator(
     # aclose() on its own, leaving it suspended and its `finally` (which
     # unregisters the turn in TurnRegistry) deferred to whenever Python's
     # asyncgen GC finalizer gets around to it (issue #99 follow-up).
-    async with contextlib.aclosing(orchestrator.stream_response(
-        text=text,
-        user_id=user_id,
-        model_id=model_id,
-        session_key=session_key,
-    )) as stream:
+    async with contextlib.aclosing(
+        orchestrator.stream_response(
+            text=text,
+            user_id=user_id,
+            model_id=model_id,
+            session_key=session_key,
+        )
+    ) as stream:
         async for event in stream:
             if event.type == "token":
                 if _first_token:

--- a/src/services/pipeline_tracker.py
+++ b/src/services/pipeline_tracker.py
@@ -1,7 +1,7 @@
 import logging
 import time
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from src.services.session_registry import SessionRegistry
@@ -53,22 +53,30 @@ class PipelineTracker:
         elapsed_ms = (now - self._last_event_at) * 1000
         self._last_event_at = now
 
-        event = PipelineEvent(stage=stage, ts_ms=ts_ms, elapsed_ms=elapsed_ms, turn=self._turn, meta=meta)
+        event = PipelineEvent(
+            stage=stage, ts_ms=ts_ms, elapsed_ms=elapsed_ms, turn=self._turn, meta=meta
+        )
         self.events.append(event)
 
         logger.info(
             "pipeline [%s] stage=%s ts_ms=%.0f elapsed_ms=%.0f %s",
-            self.session_id, stage, ts_ms, elapsed_ms, meta,
+            self.session_id,
+            stage,
+            ts_ms,
+            elapsed_ms,
+            meta,
         )
 
         if "status" in self.output_mode:
             try:
-                await self._ws.send_json({
-                    "type": "pipeline_event",
-                    "stage": stage,
-                    "elapsed_ms": round(elapsed_ms),
-                    "turn": self._turn,
-                })
+                await self._ws.send_json(
+                    {
+                        "type": "pipeline_event",
+                        "stage": stage,
+                        "elapsed_ms": round(elapsed_ms),
+                        "turn": self._turn,
+                    }
+                )
             except Exception:
                 pass
 
@@ -79,13 +87,13 @@ class PipelineTracker:
         await self.record("session_end", turn_count=self._turn, duration_s=duration_s)
         self._registry.close(self.session_id, status)
 
-    def _find_last(self, stage: str, turn: Optional[int] = None) -> Optional[PipelineEvent]:
+    def _find_last(self, stage: str, turn: int | None = None) -> PipelineEvent | None:
         for e in reversed(self.events):
             if e.stage == stage and (turn is None or e.turn == turn):
                 return e
         return None
 
-    def llm_first_token_ms(self) -> Optional[float]:
+    def llm_first_token_ms(self) -> float | None:
         first_token = self._find_last("llm_first_token")
         if first_token is None:
             return None
@@ -94,7 +102,7 @@ class PipelineTracker:
             return None
         return round(first_token.ts_ms - start.ts_ms, 1)
 
-    def tts_first_chunk_ms(self) -> Optional[float]:
+    def tts_first_chunk_ms(self) -> float | None:
         first_chunk = self._find_last("tts_first_chunk")
         if first_chunk is None:
             return None
@@ -103,7 +111,7 @@ class PipelineTracker:
             return None
         return round(first_chunk.ts_ms - start.ts_ms, 1)
 
-    def turn_e2e_ms(self) -> Optional[float]:
+    def turn_e2e_ms(self) -> float | None:
         done = self._find_last("tts_done")
         if done is None:
             return None

--- a/src/services/protocol.py
+++ b/src/services/protocol.py
@@ -1,5 +1,6 @@
+from collections.abc import AsyncIterator
 from dataclasses import dataclass
-from typing import Literal, AsyncIterator, Optional, Protocol, runtime_checkable
+from typing import Literal, Protocol, runtime_checkable
 
 from src.services.openclaw.models import ToolCallEvent
 
@@ -8,7 +9,7 @@ from src.services.openclaw.models import ToolCallEvent
 class OrchestratorEvent:
     type: Literal["token", "status", "error", "tool_call"]
     content: str = ""
-    tool_call: Optional[ToolCallEvent] = None
+    tool_call: ToolCallEvent | None = None
 
 
 @runtime_checkable
@@ -21,6 +22,6 @@ class OrchestratorProtocol(Protocol):
         self,
         text: str,
         user_id: str,
-        model_id: Optional[str] = None,
-        session_key: Optional[str] = None,
+        model_id: str | None = None,
+        session_key: str | None = None,
     ) -> AsyncIterator[OrchestratorEvent]: ...

--- a/src/services/reconnection.py
+++ b/src/services/reconnection.py
@@ -1,7 +1,6 @@
 from dataclasses import dataclass
 from datetime import datetime
 from enum import Enum
-from typing import Optional
 
 
 class ConnectionState(Enum):
@@ -14,9 +13,9 @@ class ConnectionState(Enum):
 class ServiceStatus:
     name: str
     state: ConnectionState
-    connected_at: Optional[datetime]
+    connected_at: datetime | None
     reconnect_attempts: int
-    last_error: Optional[str]
+    last_error: str | None
 
 
 def to_wire_state(state: ConnectionState) -> str:

--- a/src/services/session_registry.py
+++ b/src/services/session_registry.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
-from datetime import datetime, timezone
-from typing import TYPE_CHECKING, Literal, Optional
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Literal
 
 if TYPE_CHECKING:
     from src.services.pipeline_tracker import PipelineEvent, PipelineTracker
@@ -13,7 +13,7 @@ class SessionRecord:
     input_mode: str
     output_mode: list[str]
     started_at: datetime
-    ended_at: Optional[datetime]
+    ended_at: datetime | None
     status: Literal["active", "completed", "error"]
     events: "list[PipelineEvent]"
     tracker: "PipelineTracker"
@@ -32,7 +32,7 @@ class SessionRegistry:
             client_id=tracker.client_id,
             input_mode=tracker.input_mode,
             output_mode=tracker.output_mode,
-            started_at=datetime.now(timezone.utc),
+            started_at=datetime.now(UTC),
             ended_at=None,
             status="active",
             events=tracker.events,
@@ -42,16 +42,18 @@ class SessionRegistry:
         self._evict_if_needed()
         return record
 
-    def close(self, session_id: str, status: Literal["active", "completed", "error"] = "completed") -> None:
+    def close(
+        self, session_id: str, status: Literal["active", "completed", "error"] = "completed"
+    ) -> None:
         record = self._sessions.get(session_id)
         if record:
             record.status = status
-            record.ended_at = datetime.now(timezone.utc)
+            record.ended_at = datetime.now(UTC)
 
     def get_all(self) -> list[SessionRecord]:
         return list(reversed(self._sessions.values()))
 
-    def get(self, session_id: str) -> Optional[SessionRecord]:
+    def get(self, session_id: str) -> SessionRecord | None:
         return self._sessions.get(session_id)
 
     def _evict_if_needed(self) -> None:

--- a/src/services/transcriber_client.py
+++ b/src/services/transcriber_client.py
@@ -1,29 +1,32 @@
-import httpx
 import json
 import logging
 import time
+from collections.abc import Awaitable, Callable
+
+import httpx
 import websockets
 from websockets.asyncio.client import ClientConnection
 from websockets.exceptions import ConnectionClosed
-from typing import Optional, Callable, Awaitable
 
 from src.models.schemas import TranscriberConfig, TranscriberMessage
 
 logger = logging.getLogger(__name__)
+
 
 class TranscriberClient:
     """
     Maneja la conexión asíncrona hacia el servicio JotaTranscriber (C++).
     Realiza el Handshake (config) y manda/recibe audio bidireccionalmente.
     """
+
     def __init__(self, url: str, client_id: str):
         self.url = url
         self.client_id = client_id
-        self.ws: Optional[ClientConnection] = None
+        self.ws: ClientConnection | None = None
         self._is_ready = False
-        self._session_id: Optional[str] = None  # recibido en el mensaje "ready"
+        self._session_id: str | None = None  # recibido en el mensaje "ready"
         self._dropped_unexpectedly: bool = False
-        self._last_transcription_at: Optional[float] = None
+        self._last_transcription_at: float | None = None
 
     async def connect(self, language: str = "es", token: str = "", vad_thold: float = 0.0):
         """Abre el socket y manda el Handshake inicial de config."""
@@ -31,7 +34,9 @@ class TranscriberClient:
             self.ws = await websockets.connect(f"ws://{self.url}/api/stt")
 
             config = TranscriberConfig(language=language, token=token, vad_thold=vad_thold)
-            logger.info(f"[{self.client_id}] Conectando a Transcriber (ws://{self.url}/api/stt) lang={language!r} vad={vad_thold}")
+            logger.info(
+                f"[{self.client_id}] Conectando a Transcriber (ws://{self.url}/api/stt) lang={language!r} vad={vad_thold}"
+            )
             await self.ws.send(config.model_dump_json())
 
             response = await self.ws.recv()
@@ -41,7 +46,9 @@ class TranscriberClient:
             if msg.type == "ready":
                 self._is_ready = True
                 self._session_id = msg.session_id
-                logger.info(f"[{self.client_id}] Transcriber listo. session_id={self._session_id!r}")
+                logger.info(
+                    f"[{self.client_id}] Transcriber listo. session_id={self._session_id!r}"
+                )
             elif msg.type == "error":
                 raise Exception(f"Transcriber auth/config error [{msg.code}]: {msg.message}")
             else:
@@ -61,7 +68,7 @@ class TranscriberClient:
         """Envía ráfagas PCM crudas al transcriptor si está habilitado."""
         if not self._is_ready or not self.ws:
             return
-            
+
         try:
             await self.ws.send(audio_bytes)
         except ConnectionClosed:
@@ -71,7 +78,7 @@ class TranscriberClient:
     async def listen_loop(
         self,
         on_transcription_callback: Callable[[str, bool], Awaitable[None]],
-        on_warning_callback: Optional[Callable[[str, Optional[str]], Awaitable[None]]] = None,
+        on_warning_callback: Callable[[str, str | None], Awaitable[None]] | None = None,
     ):
         """
         Bucle que escucha mensajes del transcriber.
@@ -92,16 +99,22 @@ class TranscriberClient:
 
                     if t_msg.type == "transcription" and t_msg.text:
                         self._last_transcription_at = time.monotonic()
-                        logger.debug(f"[{self.client_id}] Transcripción: is_final={t_msg.is_final!r} text='{t_msg.text[:40]}'")
+                        logger.debug(
+                            f"[{self.client_id}] Transcripción: is_final={t_msg.is_final!r} text='{t_msg.text[:40]}'"
+                        )
                         await on_transcription_callback(t_msg.text, bool(t_msg.is_final))
 
                     elif t_msg.type == "warning":
-                        logger.warning(f"[{self.client_id}] Transcriber warning [{t_msg.code}]: {t_msg.message}")
+                        logger.warning(
+                            f"[{self.client_id}] Transcriber warning [{t_msg.code}]: {t_msg.message}"
+                        )
                         if on_warning_callback:
                             await on_warning_callback(t_msg.code or "unknown", t_msg.message)
 
                     elif t_msg.type == "error":
-                        logger.error(f"[{self.client_id}] Transcriber error [{t_msg.code}]: {t_msg.message}")
+                        logger.error(
+                            f"[{self.client_id}] Transcriber error [{t_msg.code}]: {t_msg.message}"
+                        )
 
                 except json.JSONDecodeError:
                     logger.warning(f"[{self.client_id}] Transcriber mandó un non-JSON: {message}")
@@ -110,7 +123,9 @@ class TranscriberClient:
             if self._is_ready and not clean_close:
                 self._dropped_unexpectedly = True
             self._is_ready = False
-            logger.info(f"[{self.client_id}] Loop de escucha del Transcriber finalizado (code={e.rcvd.code if e.rcvd else 'none'}).")
+            logger.info(
+                f"[{self.client_id}] Loop de escucha del Transcriber finalizado (code={e.rcvd.code if e.rcvd else 'none'})."
+            )
 
     async def send_end(self):
         """Señaliza al transcriber que el audio terminó, disparando la transcripción final."""

--- a/src/services/transcriber_reconnecting.py
+++ b/src/services/transcriber_reconnecting.py
@@ -1,8 +1,8 @@
 import asyncio
 import logging
 import time
-from datetime import datetime, timezone
-from typing import Awaitable, Callable, Optional
+from collections.abc import Awaitable, Callable
+from datetime import UTC, datetime
 
 from src.services.reconnection import ConnectionState, ServiceStatus
 from src.services.transcriber_client import TranscriberClient
@@ -32,18 +32,18 @@ class ReconnectingTranscriberClient:
         self._max_backoff = max_backoff
         self._max_duration = max_duration
         self.state = ConnectionState.DEGRADED
-        self._connected_at: Optional[datetime] = None
+        self._connected_at: datetime | None = None
         self._reconnect_attempts = 0
-        self._last_error: Optional[str] = None
+        self._last_error: str | None = None
         self._closed = False
-        self._run_task: Optional[asyncio.Task] = None
-        self.on_state_change: Optional[Callable[[ConnectionState], None]] = None
+        self._run_task: asyncio.Task | None = None
+        self.on_state_change: Callable[[ConnectionState], None] | None = None
         self._language = "es"
         self._token = ""
         self._vad_thold = 0.0
 
     @property
-    def _last_transcription_at(self) -> Optional[float]:
+    def _last_transcription_at(self) -> float | None:
         return self._client._last_transcription_at
 
     def _set_state(self, state: ConnectionState) -> None:
@@ -58,7 +58,7 @@ class ReconnectingTranscriberClient:
         try:
             await self._client.connect(language=language, token=token, vad_thold=vad_thold)
             self._set_state(ConnectionState.CONNECTED)
-            self._connected_at = datetime.now(timezone.utc)
+            self._connected_at = datetime.now(UTC)
             self._reconnect_attempts = 0
             self._last_error = None
         except Exception as e:
@@ -90,7 +90,7 @@ class ReconnectingTranscriberClient:
     async def run(
         self,
         on_transcription_callback: Callable[[str, bool], Awaitable[None]],
-        on_warning_callback: Optional[Callable[[str, Optional[str]], Awaitable[None]]] = None,
+        on_warning_callback: Callable[[str, str | None], Awaitable[None]] | None = None,
     ) -> None:
         """Supervises the listen loop for the session's lifetime: listens,
         and on an unexpected drop, reconnects with backoff and resumes
@@ -124,7 +124,7 @@ class ReconnectingTranscriberClient:
                     language=self._language, token=self._token, vad_thold=self._vad_thold
                 )
                 self._set_state(ConnectionState.CONNECTED)
-                self._connected_at = datetime.now(timezone.utc)
+                self._connected_at = datetime.now(UTC)
                 self._reconnect_attempts = 0
                 self._last_error = None
                 logger.info("[%s] transcriber reconnected.", self._client_id)
@@ -136,7 +136,9 @@ class ReconnectingTranscriberClient:
                 self._last_error = str(e)
                 logger.warning(
                     "[%s] transcriber reconnect attempt %d failed: %s",
-                    self._client_id, self._reconnect_attempts, e,
+                    self._client_id,
+                    self._reconnect_attempts,
+                    e,
                 )
 
             if time.monotonic() - start >= self._max_duration:

--- a/src/services/tts_client.py
+++ b/src/services/tts_client.py
@@ -1,7 +1,7 @@
 import asyncio
 import json
 import logging
-from typing import AsyncGenerator, Optional
+from collections.abc import AsyncGenerator
 
 import httpx
 import websockets
@@ -28,8 +28,8 @@ class TTSClient:
 
     async def connect(
         self,
-        voice: Optional[str] = None,
-        speed: Optional[float] = None,
+        voice: str | None = None,
+        speed: float | None = None,
     ) -> None:
         """Open WS and authenticate. Raises RuntimeError on auth failure."""
         ws_url = f"ws://{self.url}/ws"
@@ -116,7 +116,9 @@ class TTSClient:
                     elif msg_type == "error":
                         logger.warning(
                             "[%s] TTS error: %s — %s",
-                            self.client_id, data.get("code"), data.get("message"),
+                            self.client_id,
+                            data.get("code"),
+                            data.get("message"),
                         )
                         break
                     else:

--- a/src/services/tts_reconnecting.py
+++ b/src/services/tts_reconnecting.py
@@ -1,7 +1,6 @@
 import logging
 import time
-from datetime import datetime, timezone
-from typing import Optional
+from datetime import UTC, datetime
 
 from src.services.reconnection import ConnectionState, ServiceStatus
 from src.services.tts_client import TTSClient
@@ -32,11 +31,11 @@ class ReconnectingTTSClient:
         self._initial_backoff = initial_backoff
         self._max_backoff = max_backoff
         self._backoff = initial_backoff
-        self._last_failure_at: Optional[float] = None
-        self._last_success_at: Optional[datetime] = None
+        self._last_failure_at: float | None = None
+        self._last_success_at: datetime | None = None
         self.state = ConnectionState.CONNECTED
         self._reconnect_attempts = 0
-        self._last_error: Optional[str] = None
+        self._last_error: str | None = None
 
     def _should_attempt(self) -> bool:
         if self._last_failure_at is None:
@@ -44,8 +43,8 @@ class ReconnectingTTSClient:
         return (time.monotonic() - self._last_failure_at) >= self._backoff
 
     async def connect(
-        self, voice: Optional[str], speed: Optional[float], client_id: str
-    ) -> Optional[TTSClient]:
+        self, voice: str | None, speed: float | None, client_id: str
+    ) -> TTSClient | None:
         """Returns a connected TTSClient, or None if the backoff window
         hasn't elapsed yet or the attempt itself fails."""
         if not self._should_attempt():
@@ -74,7 +73,7 @@ class ReconnectingTTSClient:
         self._backoff = self._initial_backoff
         self._reconnect_attempts = 0
         self._last_error = None
-        self._last_success_at = datetime.now(timezone.utc)
+        self._last_success_at = datetime.now(UTC)
         self.state = ConnectionState.CONNECTED
 
     def status(self) -> ServiceStatus:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 """Global test fixtures shared across unit and integration tests."""
+
 import pytest
 from starlette.testclient import TestClient
 

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -4,6 +4,7 @@ excluded by default (see pytest.ini addopts). Run explicitly with:
 
     PYTHONPATH=. pytest tests/e2e -m e2e_real -v
 """
+
 import os
 import secrets
 

--- a/tests/e2e/test_admin_client_lifecycle.py
+++ b/tests/e2e/test_admin_client_lifecycle.py
@@ -1,5 +1,6 @@
 """Proves the ephemeral test-client fixtures actually create and clean up
 ClientRecords against the real, running Admin API."""
+
 import httpx
 
 from tests.e2e.conftest import GATEWAY_HTTP_URL
@@ -16,9 +17,7 @@ def test_single_ephemeral_client_created_and_cleaned_up(test_client_record, admi
 def test_three_ephemeral_clients_created_and_cleaned_up(test_client_records_x3, admin_headers):
     assert len(test_client_records_x3) == 3
     for record in test_client_records_x3:
-        resp = httpx.get(
-            f"{GATEWAY_HTTP_URL}/admin/clients/{record['id']}", headers=admin_headers
-        )
+        resp = httpx.get(f"{GATEWAY_HTTP_URL}/admin/clients/{record['id']}", headers=admin_headers)
         assert resp.status_code == 200
 
 

--- a/tests/e2e/test_cancel.py
+++ b/tests/e2e/test_cancel.py
@@ -1,5 +1,6 @@
 """Validates that {"type": "cancel"} really reaches chat.abort on the real
 OpenClaw orchestrator, and that a subsequent turn still works normally."""
+
 import asyncio
 import json
 
@@ -9,10 +10,14 @@ from tests.e2e.ws_helpers import cancel_active_turn, send_turn, ws_handshake
 async def test_cancel_stops_the_active_turn_on_real_openclaw(test_client_record, e2e_agent):
     ws, _ready = await ws_handshake(test_client_record["client_key"], e2e_agent)
     try:
-        await ws.send(json.dumps({
-            "type": "send",
-            "text": "Cuenta lentamente en voz alta del 1 al 100, un número por frase.",
-        }))
+        await ws.send(
+            json.dumps(
+                {
+                    "type": "send",
+                    "text": "Cuenta lentamente en voz alta del 1 al 100, un número por frase.",
+                }
+            )
+        )
         # Wait for turn_start to confirm the turn is actually running before cancelling.
         first = json.loads(await asyncio.wait_for(ws.recv(), timeout=10))
         assert first["type"] == "turn_start"
@@ -27,7 +32,7 @@ async def test_cancel_stops_the_active_turn_on_real_openclaw(test_client_record,
             while True:
                 raw = await asyncio.wait_for(ws.recv(), timeout=5)
                 leftover_frames.append(json.loads(raw))
-        except asyncio.TimeoutError:
+        except TimeoutError:
             pass
 
         assert not any(

--- a/tests/e2e/test_concurrent_sessions.py
+++ b/tests/e2e/test_concurrent_sessions.py
@@ -1,6 +1,7 @@
 """Validates that OpenClawClient's multiplexing keeps concurrent sessions
 isolated: N different clients, same test agent, turns in parallel, each
 gets back its own distinct response without cross-talk."""
+
 import asyncio
 
 from tests.e2e.ws_helpers import send_turn, ws_handshake

--- a/tests/e2e/test_tool_use.py
+++ b/tests/e2e/test_tool_use.py
@@ -10,6 +10,7 @@ hallucinated. Requires the test client to have tool_calls_enabled=True (see
 test_client_record_with_tools fixture) — otherwise the gateway never forwards
 tool_call messages at all (opt-in, see CLAUDE.md).
 """
+
 from tests.e2e.ws_helpers import send_turn_until_tool_call, ws_handshake
 
 EXPECTED_IDENTITY_SNIPPET = "This isn't just metadata. It's the start of figuring out who you are."

--- a/tests/e2e/ws_helpers.py
+++ b/tests/e2e/ws_helpers.py
@@ -17,12 +17,16 @@ async def ws_handshake(client_key: str, agent: str, ws_url: str = GATEWAY_WS_URL
         "output_mode": ["text"],
         "agent": agent,
     }))
-    raw = await asyncio.wait_for(ws.recv(), timeout=10)
-    ready = json.loads(raw)
-    if ready.get("type") != "ready":
-        await ws.close()
-        raise AssertionError(f"Handshake falló, esperaba 'ready': {ready}")
-    return ws, ready
+    deadline = asyncio.get_event_loop().time() + 10
+    while True:
+        remaining = deadline - asyncio.get_event_loop().time()
+        if remaining <= 0:
+            await ws.close()
+            raise AssertionError("Handshake falló: sin mensaje 'ready' en 10s")
+        raw = await asyncio.wait_for(ws.recv(), timeout=remaining)
+        frame = json.loads(raw)
+        if frame.get("type") == "ready":
+            return ws, frame
 
 
 async def send_turn(ws, text: str, timeout: float = 60.0) -> dict:

--- a/tests/e2e/ws_helpers.py
+++ b/tests/e2e/ws_helpers.py
@@ -17,14 +17,21 @@ async def ws_handshake(client_key: str, agent: str, ws_url: str = GATEWAY_WS_URL
         "output_mode": ["text"],
         "agent": agent,
     }))
-    deadline = asyncio.get_event_loop().time() + 10
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + 10
+    last_frame = None
     while True:
-        remaining = deadline - asyncio.get_event_loop().time()
+        remaining = deadline - loop.time()
         if remaining <= 0:
             await ws.close()
-            raise AssertionError("Handshake falló: sin mensaje 'ready' en 10s")
-        raw = await asyncio.wait_for(ws.recv(), timeout=remaining)
+            raise AssertionError(f"Handshake falló: sin mensaje 'ready' en 10s; último frame: {last_frame}")
+        try:
+            raw = await asyncio.wait_for(ws.recv(), timeout=remaining)
+        except asyncio.TimeoutError:
+            await ws.close()
+            raise AssertionError(f"Handshake falló: sin mensaje 'ready' en 10s; último frame: {last_frame}")
         frame = json.loads(raw)
+        last_frame = frame
         if frame.get("type") == "ready":
             return ws, frame
 

--- a/tests/e2e/ws_helpers.py
+++ b/tests/e2e/ws_helpers.py
@@ -1,6 +1,7 @@
 """Real WebSocket client helpers for tests/e2e — talk to the actual
 /ws/stream endpoint of the running production gateway, same wire protocol
 documented in docs/client-protocol.md."""
+
 import asyncio
 import json
 
@@ -9,14 +10,20 @@ import websockets
 from tests.e2e.conftest import GATEWAY_WS_URL
 
 
-async def ws_handshake(client_key: str, agent: str, ws_url: str = GATEWAY_WS_URL, input_mode: str = "text"):
+async def ws_handshake(
+    client_key: str, agent: str, ws_url: str = GATEWAY_WS_URL, input_mode: str = "text"
+):
     ws = await websockets.connect(ws_url, open_timeout=10)
-    await ws.send(json.dumps({
-        "client_key": client_key,
-        "input_mode": input_mode,
-        "output_mode": ["text"],
-        "agent": agent,
-    }))
+    await ws.send(
+        json.dumps(
+            {
+                "client_key": client_key,
+                "input_mode": input_mode,
+                "output_mode": ["text"],
+                "agent": agent,
+            }
+        )
+    )
     loop = asyncio.get_running_loop()
     deadline = loop.time() + 10
     last_frame = None
@@ -24,12 +31,16 @@ async def ws_handshake(client_key: str, agent: str, ws_url: str = GATEWAY_WS_URL
         remaining = deadline - loop.time()
         if remaining <= 0:
             await ws.close()
-            raise AssertionError(f"Handshake falló: sin mensaje 'ready' en 10s; último frame: {last_frame}")
+            raise AssertionError(
+                f"Handshake falló: sin mensaje 'ready' en 10s; último frame: {last_frame}"
+            )
         try:
             raw = await asyncio.wait_for(ws.recv(), timeout=remaining)
-        except asyncio.TimeoutError:
+        except TimeoutError:
             await ws.close()
-            raise AssertionError(f"Handshake falló: sin mensaje 'ready' en 10s; último frame: {last_frame}")
+            raise AssertionError(
+                f"Handshake falló: sin mensaje 'ready' en 10s; último frame: {last_frame}"
+            )
         frame = json.loads(raw)
         last_frame = frame
         if frame.get("type") == "ready":
@@ -58,7 +69,9 @@ async def send_turn(ws, text: str, timeout: float = 60.0) -> dict:
     while True:
         remaining = deadline - loop.time()
         if remaining <= 0:
-            raise AssertionError(f"turn_end no llegó en {timeout}s para turn_id={turn_id}: {frames}")
+            raise AssertionError(
+                f"turn_end no llegó en {timeout}s para turn_id={turn_id}: {frames}"
+            )
         raw = await asyncio.wait_for(ws.recv(), timeout=remaining)
         frame = json.loads(raw)
         frames.append(frame)
@@ -66,9 +79,9 @@ async def send_turn(ws, text: str, timeout: float = 60.0) -> dict:
             turn_id = frame["turn_id"]
         elif frame["type"] == "token" and frame.get("turn_id") == turn_id:
             tokens.append(frame["text"])
-        elif frame["type"] == "turn_end" and frame.get("turn_id") == turn_id:
-            break
-        elif frame["type"] == "error" and (frame.get("turn_id") == turn_id or frame.get("fatal")):
+        elif (frame["type"] == "turn_end" and frame.get("turn_id") == turn_id) or (
+            frame["type"] == "error" and (frame.get("turn_id") == turn_id or frame.get("fatal"))
+        ):
             break
     return {"turn_id": turn_id, "text": "".join(tokens), "frames": frames}
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -5,23 +5,25 @@ BD: SQLite en memoria inyectada por monkeypatch (reemplaza respx/jota-db).
 WebSocket: fake servers TTS/transcriber en hilos de background (sin cambios).
 Orchestrator: MockOrchestrator inyectado via monkeypatch (sin cambios).
 """
-import pytest
-import httpx
-import respx
-from datetime import datetime, timezone
+
+from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import pytest
+import respx
 from sqlalchemy.pool import StaticPool
 from sqlmodel import Session, SQLModel, create_engine
 from starlette.testclient import TestClient
 
 from src.core.config import settings
+from src.db.models import ClientRecord
 from src.main import app
 from src.services.db_client import db_client
-from src.services.protocol import OrchestratorProtocol, OrchestratorEvent
+from src.services.openclaw.models import AgentInfo, GatewayInfo
+from src.services.openclaw.registry import ClientRegistry, TurnRegistry
+from src.services.protocol import OrchestratorEvent, OrchestratorProtocol
 from src.services.reconnection import ConnectionState, ServiceStatus
-from src.services.openclaw.registry import TurnRegistry, ClientRegistry
-from src.services.openclaw.models import GatewayInfo, AgentInfo
-from src.db.models import ClientRecord
 
 # ---------------------------------------------------------------------------
 # Datos de test estándar
@@ -36,10 +38,12 @@ ADMIN_TOKEN = "test-admin-token"
 # BD SQLite en memoria
 # ---------------------------------------------------------------------------
 
+
 @pytest.fixture(autouse=True)
 def db_engine(monkeypatch):
     """SQLite in-memory inyectado en get_engine() para todos los integration tests."""
     from src import db
+
     engine = create_engine(
         "sqlite:///:memory:",
         connect_args={"check_same_thread": False},
@@ -54,12 +58,14 @@ def db_engine(monkeypatch):
 def seed_client(db_engine):
     """Inserta el cliente de prueba estándar en la BD."""
     with Session(db_engine) as s:
-        s.add(ClientRecord(
-            id=CLIENT_ID,
-            name=CLIENT_NAME,
-            client_key=VALID_KEY,
-            is_active=True,
-        ))
+        s.add(
+            ClientRecord(
+                id=CLIENT_ID,
+                name=CLIENT_NAME,
+                client_key=VALID_KEY,
+                is_active=True,
+            )
+        )
         s.commit()
 
 
@@ -86,9 +92,11 @@ def configure_admin_token():
 def admin_headers():
     return {"x-admin-token": ADMIN_TOKEN}
 
+
 # ---------------------------------------------------------------------------
 # Mock Orchestrator
 # ---------------------------------------------------------------------------
+
 
 def _make_default_gateway_info() -> GatewayInfo:
     return GatewayInfo(
@@ -125,13 +133,15 @@ def make_mock_orchestrator(tokens: list[str] = None) -> OrchestratorProtocol:
     mock.gateway_info = _make_default_gateway_info()
     mock._name = "openclaw"
     mock.get_name = MagicMock(return_value="openclaw")
-    mock.status = MagicMock(return_value=ServiceStatus(
-        name="openclaw",
-        state=ConnectionState.CONNECTED,
-        connected_at=datetime(2026, 6, 4, 10, 0, tzinfo=timezone.utc),
-        reconnect_attempts=0,
-        last_error=None,
-    ))
+    mock.status = MagicMock(
+        return_value=ServiceStatus(
+            name="openclaw",
+            state=ConnectionState.CONNECTED,
+            connected_at=datetime(2026, 6, 4, 10, 0, tzinfo=UTC),
+            reconnect_attempts=0,
+            last_error=None,
+        )
+    )
     return mock
 
 
@@ -141,9 +151,11 @@ def make_mock_registry(orchestrator=None):
         orchestrator = make_mock_orchestrator()
     return orchestrator
 
+
 # ---------------------------------------------------------------------------
 # Health-check HTTP mocks (transcriber + TTS — sin jota-db)
 # ---------------------------------------------------------------------------
+
 
 @pytest.fixture
 def mock_services():
@@ -152,9 +164,7 @@ def mock_services():
         router.get(f"http://{settings.TRANSCRIBER_WS_URL}/ready").mock(
             return_value=httpx.Response(200)
         )
-        router.get("http://localhost:8005/ready").mock(
-            return_value=httpx.Response(200)
-        )
+        router.get("http://localhost:8005/ready").mock(return_value=httpx.Response(200))
         yield router
 
 

--- a/tests/integration/test_admin_auth.py
+++ b/tests/integration/test_admin_auth.py
@@ -14,6 +14,7 @@ def test_admin_wrong_token_returns_401(client):
 
 def test_admin_no_token_configured_returns_503(client, monkeypatch):
     from src.core.config import settings
+
     monkeypatch.setattr(settings, "ADMIN_TOKEN", "")
     r = client.get("/admin/sessions", headers={"x-admin-token": "anything"})
     assert r.status_code == 503

--- a/tests/integration/test_admin_clients.py
+++ b/tests/integration/test_admin_clients.py
@@ -1,10 +1,10 @@
 """Tests para /admin/clients/* CRUD."""
+
 import pytest
 from sqlalchemy.pool import StaticPool
 from sqlmodel import Session, SQLModel, create_engine
 
 from src.services.db_client import db_client
-
 
 ADMIN_TOKEN = "test-admin-token"
 HEADERS = {"x-admin-token": ADMIN_TOKEN}
@@ -13,12 +13,14 @@ HEADERS = {"x-admin-token": ADMIN_TOKEN}
 @pytest.fixture(autouse=True)
 def override_admin_token(monkeypatch):
     from src.core import config
+
     monkeypatch.setattr(config.settings, "ADMIN_TOKEN", ADMIN_TOKEN)
 
 
 @pytest.fixture(autouse=True)
 def db_engine(monkeypatch):
     from src import db
+
     engine = create_engine(
         "sqlite:///:memory:",
         connect_args={"check_same_thread": False},
@@ -32,12 +34,15 @@ def db_engine(monkeypatch):
 @pytest.fixture()
 def http(db_engine):
     from starlette.testclient import TestClient
+
     from src.main import app
+
     with TestClient(app, raise_server_exceptions=True) as c:
         yield c
 
 
 # --- CREATE ---
+
 
 def test_create_client_minimal(http):
     r = http.post("/admin/clients", json={"name": "ESP32"}, headers=HEADERS)
@@ -83,6 +88,7 @@ def test_create_client_with_empty_allowed_agents_denies_all(http):
 
 # --- LIST ---
 
+
 def test_list_clients_empty(http):
     r = http.get("/admin/clients", headers=HEADERS)
     assert r.status_code == 200
@@ -99,6 +105,7 @@ def test_list_clients_after_creates(http):
 
 # --- GET ---
 
+
 def test_get_client(http):
     created = http.post("/admin/clients", json={"name": "X"}, headers=HEADERS).json()
     r = http.get(f"/admin/clients/{created['id']}", headers=HEADERS)
@@ -112,6 +119,7 @@ def test_get_client_not_found(http):
 
 
 # --- PATCH ---
+
 
 def test_patch_client_name(http):
     created = http.post("/admin/clients", json={"name": "Old"}, headers=HEADERS).json()
@@ -140,6 +148,7 @@ def test_patch_deactivate(http):
 
 # --- DELETE ---
 
+
 def test_delete_client(http):
     created = http.post("/admin/clients", json={"name": "Del"}, headers=HEADERS).json()
     r = http.delete(f"/admin/clients/{created['id']}", headers=HEADERS)
@@ -149,6 +158,7 @@ def test_delete_client(http):
 
 
 # --- ROTATE KEY ---
+
 
 def test_rotate_key(http):
     created = http.post("/admin/clients", json={"name": "R"}, headers=HEADERS).json()
@@ -161,6 +171,7 @@ def test_rotate_key(http):
 
 
 # --- INVALIDATE ORDERING (issue #107) ---
+
 
 def test_delete_client_commits_before_invalidating_cache(http, monkeypatch):
     created = http.post("/admin/clients", json={"name": "Del"}, headers=HEADERS).json()
@@ -212,6 +223,7 @@ def test_rotate_key_commits_before_invalidating_cache(http, monkeypatch):
 
 # --- AUTH ---
 
+
 def test_missing_token_returns_422(http):
     r = http.get("/admin/clients")
     assert r.status_code == 422
@@ -223,6 +235,7 @@ def test_wrong_token_returns_401(http):
 
 
 # --- tool_calls_enabled ---
+
 
 def test_create_client_tool_calls_enabled_defaults_false(http):
     r = http.post("/admin/clients", json={"name": "T"}, headers=HEADERS)
@@ -251,6 +264,7 @@ def test_patch_client_tool_calls_enabled(http):
 # `ClientCreate`/`ClientUpdate` have no `model_config` overriding pydantic's
 # default `extra="ignore"` behavior, so an unrecognized field in the request
 # body is silently dropped rather than rejected with 422.
+
 
 def test_create_client_ignores_system_prompt_extra(http):
     r = http.post(

--- a/tests/integration/test_agent_enforcement_rest.py
+++ b/tests/integration/test_agent_enforcement_rest.py
@@ -1,10 +1,12 @@
 """REST /v1/chat/completions enforces per-client default_agent and allowed_agents."""
+
 import json
+
 from sqlmodel import Session
 
 from src.db.models import ClientRecord
 from src.services.db_client import db_client
-from tests.integration.conftest import VALID_KEY, CLIENT_ID
+from tests.integration.conftest import CLIENT_ID, VALID_KEY
 
 
 def _patch_client(engine, **fields):
@@ -19,6 +21,7 @@ def _patch_client(engine, **fields):
 
 # --- Tests ----------------------------------------------------------------
 
+
 def test_rest_allowed_model_passes(client, db_engine, mock_orchestrator, ha_bearer_headers):
     _patch_client(db_engine, allowed_agents=json.dumps(["a"]))
     r = client.post(
@@ -29,7 +32,9 @@ def test_rest_allowed_model_passes(client, db_engine, mock_orchestrator, ha_bear
     assert r.status_code == 200
 
 
-def test_rest_disallowed_model_returns_403_with_reason(client, db_engine, mock_orchestrator, ha_bearer_headers):
+def test_rest_disallowed_model_returns_403_with_reason(
+    client, db_engine, mock_orchestrator, ha_bearer_headers
+):
     _patch_client(db_engine, allowed_agents=json.dumps(["a"]))
     r = client.post(
         "/v1/chat/completions",
@@ -43,13 +48,14 @@ def test_rest_disallowed_model_returns_403_with_reason(client, db_engine, mock_o
     assert "Agent 'b' not permitted" in body["message"]
 
 
-def test_rest_model_not_in_roster_returns_403(client, db_engine, mock_orchestrator, ha_bearer_headers):
+def test_rest_model_not_in_roster_returns_403(
+    client, db_engine, mock_orchestrator, ha_bearer_headers
+):
     _patch_client(db_engine, allowed_agents=None)
     r = client.post(
         "/v1/chat/completions",
         headers=ha_bearer_headers,
-        json={"model": "nonexistent-agent-xyz",
-              "messages": [{"role": "user", "content": "hi"}]},
+        json={"model": "nonexistent-agent-xyz", "messages": [{"role": "user", "content": "hi"}]},
     )
     assert r.status_code == 403
     body = r.json()
@@ -57,12 +63,15 @@ def test_rest_model_not_in_roster_returns_403(client, db_engine, mock_orchestrat
     assert "Agent 'nonexistent-agent-xyz' not available" in body["message"]
 
 
-def test_rest_default_agent_applied_when_model_missing(client, db_engine, mock_orchestrator, ha_bearer_headers):
+def test_rest_default_agent_applied_when_model_missing(
+    client, db_engine, mock_orchestrator, ha_bearer_headers
+):
     """default_agent='a' set, body.model='' → 200, session uses agent='a'."""
     _patch_client(db_engine, default_agent="a", allowed_agents=None)
 
-    from src.services.protocol import OrchestratorEvent
     from src.core.session_key import make_session_key
+    from src.services.protocol import OrchestratorEvent
+
     captured = {}
 
     async def _stream(text, user_id, model_id=None, session_key=None):
@@ -87,8 +96,9 @@ def test_rest_legacy_trusted_origin_still_uses_gateway_default(client, mock_orch
 
     Regression check: this path must keep working exactly as before.
     """
-    from src.services.protocol import OrchestratorEvent
     from src.core.session_key import make_session_key
+    from src.services.protocol import OrchestratorEvent
+
     captured = {}
 
     async def _stream(text, user_id, model_id=None, session_key=None):

--- a/tests/integration/test_agent_enforcement_ws.py
+++ b/tests/integration/test_agent_enforcement_ws.py
@@ -1,12 +1,14 @@
 """WS handshake enforces per-client default_agent and allowed_agents."""
+
 import json
+
 import pytest
 from sqlmodel import Session
 
 from src.db.models import ClientRecord
 from src.services.db_client import db_client
 from src.services.openclaw.models import AgentInfo
-from tests.integration.conftest import VALID_KEY, CLIENT_ID
+from tests.integration.conftest import CLIENT_ID, VALID_KEY
 
 
 def _patch_client(engine, **fields):
@@ -22,6 +24,7 @@ def _patch_client(engine, **fields):
 
 # --- Tests ----------------------------------------------------------------
 
+
 def test_ws_allowed_agent_passes(client, db_engine):
     """allowed_agents=['a'], handshake with agent='a' → ready.agent == 'a'."""
     _patch_client(db_engine, allowed_agents=json.dumps(["a"]))
@@ -32,12 +35,14 @@ def test_ws_allowed_agent_passes(client, db_engine):
     )
     try:
         with client.websocket_connect("/ws/stream") as ws:
-            ws.send_json({
-                "client_key": VALID_KEY,
-                "input_mode": "text",
-                "output_mode": ["text"],
-                "agent": "a",
-            })
+            ws.send_json(
+                {
+                    "client_key": VALID_KEY,
+                    "input_mode": "text",
+                    "output_mode": ["text"],
+                    "agent": "a",
+                }
+            )
             ready = ws.receive_json()
             assert ready["type"] == "ready"
             assert ready["agent"] == "a"
@@ -49,29 +54,31 @@ def test_ws_allowed_agent_passes(client, db_engine):
 def test_ws_disallowed_agent_closes_1008(client, db_engine):
     """allowed_agents=['a'], handshake with agent='b' → close 1008."""
     _patch_client(db_engine, allowed_agents=json.dumps(["a"]))
-    with pytest.raises(Exception):
-        with client.websocket_connect("/ws/stream") as ws:
-            ws.send_json({
+    with pytest.raises(Exception), client.websocket_connect("/ws/stream") as ws:
+        ws.send_json(
+            {
                 "client_key": VALID_KEY,
                 "input_mode": "text",
                 "output_mode": ["text"],
                 "agent": "b",
-            })
-            ws.receive_text()  # should raise on close frame
+            }
+        )
+        ws.receive_text()  # should raise on close frame
 
 
 def test_ws_agent_not_in_roster_closes_1008(client, db_engine):
     """allowed_agents=None, handshake with agent that doesn't exist anywhere → 1008."""
     _patch_client(db_engine, allowed_agents=None)
-    with pytest.raises(Exception):
-        with client.websocket_connect("/ws/stream") as ws:
-            ws.send_json({
+    with pytest.raises(Exception), client.websocket_connect("/ws/stream") as ws:
+        ws.send_json(
+            {
                 "client_key": VALID_KEY,
                 "input_mode": "text",
                 "output_mode": ["text"],
                 "agent": "nonexistent-agent-xyz",
-            })
-            ws.receive_text()
+            }
+        )
+        ws.receive_text()
 
 
 def test_ws_default_agent_applied_when_handshake_omits_agent(client, db_engine):
@@ -82,12 +89,14 @@ def test_ws_default_agent_applied_when_handshake_omits_agent(client, db_engine):
     """
     _patch_client(db_engine, default_agent="a", allowed_agents=None)
     with client.websocket_connect("/ws/stream") as ws:
-        ws.send_json({
-            "client_key": VALID_KEY,
-            "input_mode": "text",
-            "output_mode": ["text"],
-            # no "agent" key
-        })
+        ws.send_json(
+            {
+                "client_key": VALID_KEY,
+                "input_mode": "text",
+                "output_mode": ["text"],
+                # no "agent" key
+            }
+        )
         ready = ws.receive_json()
         assert ready["type"] == "ready"
         assert ready["agent"] == "a"
@@ -96,11 +105,12 @@ def test_ws_default_agent_applied_when_handshake_omits_agent(client, db_engine):
 def test_ws_empty_allowed_denies_everything(client, db_engine):
     """allowed_agents=[] (deny-all) without an agent in handshake → close 1008."""
     _patch_client(db_engine, allowed_agents=json.dumps([]))
-    with pytest.raises(Exception):
-        with client.websocket_connect("/ws/stream") as ws:
-            ws.send_json({
+    with pytest.raises(Exception), client.websocket_connect("/ws/stream") as ws:
+        ws.send_json(
+            {
                 "client_key": VALID_KEY,
                 "input_mode": "text",
                 "output_mode": ["text"],
-            })
-            ws.receive_text()
+            }
+        )
+        ws.receive_text()

--- a/tests/integration/test_bridge_audio_flow.py
+++ b/tests/integration/test_bridge_audio_flow.py
@@ -4,6 +4,7 @@ Tests para JotaBridge en modo audio.
 input_mode=audio: el bridge conecta al transcriber WS, manda PCM,
 recibe transcripción is_final, llama al orchestrator, devuelve tokens al cliente.
 """
+
 import asyncio
 import json
 import threading
@@ -12,16 +13,18 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 import websockets
-
 from sqlmodel import Session
+from starlette.testclient import TestClient
 
+from src.core.config import settings
 from src.db.models import ClientRecord
 from src.main import app
-from src.core.config import settings
-from starlette.testclient import TestClient
 from tests.integration.conftest import (
-    VALID_KEY, CLIENT_ID, CLIENT_NAME,
-    make_mock_orchestrator, make_mock_registry,
+    CLIENT_ID,
+    CLIENT_NAME,
+    VALID_KEY,
+    make_mock_orchestrator,
+    make_mock_registry,
 )
 
 HANDSHAKE_AUDIO = {
@@ -50,19 +53,27 @@ def _start_fake_transcriber():
         raw = await ws.recv()
         msg = json.loads(raw)
         assert msg["type"] == "config"
-        await ws.send(json.dumps({
-            "type": "ready",
-            "protocol_version": 1,
-            "session_id": "test-audio-session",
-        }))
+        await ws.send(
+            json.dumps(
+                {
+                    "type": "ready",
+                    "protocol_version": 1,
+                    "session_id": "test-audio-session",
+                }
+            )
+        )
         # Espera audio, responde con transcripción final
         async for chunk in ws:
             if isinstance(chunk, bytes) and len(chunk) > 0:
-                await ws.send(json.dumps({
-                    "type": "transcription",
-                    "text": "hola desde audio",
-                    "is_final": True,
-                }))
+                await ws.send(
+                    json.dumps(
+                        {
+                            "type": "transcription",
+                            "text": "hola desde audio",
+                            "is_final": True,
+                        }
+                    )
+                )
                 break
 
     loop = asyncio.new_event_loop()
@@ -94,7 +105,9 @@ def start_fake_transcriber():
 # ---------------------------------------------------------------------------
 
 
-def test_audio_chunk_transcribed_and_forwarded_to_orchestrator(mock_services, seed_client, monkeypatch):
+def test_audio_chunk_transcribed_and_forwarded_to_orchestrator(
+    mock_services, seed_client, monkeypatch
+):
     """PCM → transcriber fake emite is_final → cliente recibe transcripción
     → cliente envía {"type":"send"} → orchestrator llamado con el texto."""
     from src.services.protocol import OrchestratorEvent
@@ -110,32 +123,33 @@ def test_audio_chunk_transcribed_and_forwarded_to_orchestrator(mock_services, se
     mock_orch.stream_response = _stream
     mock_reg = make_mock_registry(mock_orch)
 
-    from unittest.mock import MagicMock, AsyncMock as _AM
+    from unittest.mock import AsyncMock as _AM
+    from unittest.mock import MagicMock
+
     monkeypatch.setattr("src.main.ReconnectingOpenClawClient", lambda *a, **kw: mock_reg)
     monkeypatch.setattr("src.main.OpenClawClient", lambda *a, **kw: MagicMock())
     monkeypatch.setattr("src.main.FrameDispatcher", lambda *a, **kw: MagicMock())
     mock_reg.connect = _AM()
     mock_reg.close = _AM()
 
-    with TestClient(app) as client:
-        with client.websocket_connect("/ws/stream") as ws:
-            ws.send_json(HANDSHAKE_AUDIO)
-            ws.send_bytes(b"\x00" * 512)  # PCM fake
-            # Esperar transcripción final (nuevo protocolo: gateway no auto-despacha)
-            for _ in range(10):
-                msg = ws.receive_json()
-                if msg.get("type") == "transcription":
-                    break
-            assert msg["type"] == "transcription"
-            assert msg["text"] == "hola desde audio"
-            # Cliente confirma y envía al orquestador
-            ws.send_json({"type": "send", "text": msg["text"]})
-            # Esperar token del orquestador
-            for _ in range(10):
-                msg = ws.receive_json()
-                if msg.get("type") == "token":
-                    break
-            assert msg["type"] == "token"
+    with TestClient(app) as client, client.websocket_connect("/ws/stream") as ws:
+        ws.send_json(HANDSHAKE_AUDIO)
+        ws.send_bytes(b"\x00" * 512)  # PCM fake
+        # Esperar transcripción final (nuevo protocolo: gateway no auto-despacha)
+        for _ in range(10):
+            msg = ws.receive_json()
+            if msg.get("type") == "transcription":
+                break
+        assert msg["type"] == "transcription"
+        assert msg["text"] == "hola desde audio"
+        # Cliente confirma y envía al orquestador
+        ws.send_json({"type": "send", "text": msg["text"]})
+        # Esperar token del orquestador
+        for _ in range(10):
+            msg = ws.receive_json()
+            if msg.get("type") == "token":
+                break
+        assert msg["type"] == "token"
 
     assert called_with_text.get("text") == "hola desde audio"
 
@@ -143,12 +157,21 @@ def test_audio_chunk_transcribed_and_forwarded_to_orchestrator(mock_services, se
 def test_transcriber_connect_uses_stt_language_from_config(mock_services, db_engine, monkeypatch):
     """stt_language de ClientConfig se pasa a TranscriberClient.connect()."""
     with Session(db_engine) as s:
-        s.add(ClientRecord(id=CLIENT_ID, name=CLIENT_NAME, client_key=VALID_KEY,
-                           is_active=True, stt_language="fr"))
+        s.add(
+            ClientRecord(
+                id=CLIENT_ID,
+                name=CLIENT_NAME,
+                client_key=VALID_KEY,
+                is_active=True,
+                stt_language="fr",
+            )
+        )
         s.commit()
 
     mock_reg = make_mock_registry()
-    from unittest.mock import MagicMock, AsyncMock as _AM
+    from unittest.mock import AsyncMock as _AM
+    from unittest.mock import MagicMock
+
     monkeypatch.setattr("src.main.ReconnectingOpenClawClient", lambda *a, **kw: mock_reg)
     monkeypatch.setattr("src.main.OpenClawClient", lambda *a, **kw: MagicMock())
     monkeypatch.setattr("src.main.FrameDispatcher", lambda *a, **kw: MagicMock())
@@ -181,12 +204,22 @@ def test_transcriber_connect_uses_stt_language_from_config(mock_services, db_eng
 def test_tts_connect_uses_voice_and_speed_from_config(mock_services, db_engine, monkeypatch):
     """tts_voice y tts_speed de ClientConfig se pasan a TTSClient.connect()."""
     with Session(db_engine) as s:
-        s.add(ClientRecord(id=CLIENT_ID, name=CLIENT_NAME, client_key=VALID_KEY,
-                           is_active=True, tts_voice="bf_emma", tts_speed=1.2))
+        s.add(
+            ClientRecord(
+                id=CLIENT_ID,
+                name=CLIENT_NAME,
+                client_key=VALID_KEY,
+                is_active=True,
+                tts_voice="bf_emma",
+                tts_speed=1.2,
+            )
+        )
         s.commit()
 
     mock_reg = make_mock_registry()
-    from unittest.mock import MagicMock, AsyncMock as _AM
+    from unittest.mock import AsyncMock as _AM
+    from unittest.mock import MagicMock
+
     monkeypatch.setattr("src.main.ReconnectingOpenClawClient", lambda *a, **kw: mock_reg)
     monkeypatch.setattr("src.main.OpenClawClient", lambda *a, **kw: MagicMock())
     monkeypatch.setattr("src.main.FrameDispatcher", lambda *a, **kw: MagicMock())
@@ -206,11 +239,13 @@ def test_tts_connect_uses_voice_and_speed_from_config(mock_services, db_engine, 
         with TestClient(app) as client:
             with client.websocket_connect("/ws/stream") as ws:
                 # output_mode=["audio"] para que el bridge instancie TTSClient
-                ws.send_json({
-                    "client_key": VALID_KEY,
-                    "input_mode": "text",
-                    "output_mode": ["audio", "text"],
-                })
+                ws.send_json(
+                    {
+                        "client_key": VALID_KEY,
+                        "input_mode": "text",
+                        "output_mode": ["audio", "text"],
+                    }
+                )
                 ws.send_text("test")
                 try:
                     ws.receive_json()

--- a/tests/integration/test_bridge_barge_in_flow.py
+++ b/tests/integration/test_bridge_barge_in_flow.py
@@ -2,6 +2,7 @@
 Integration test for #108: barge_in_enabled=False must not interrupt
 an in-flight orchestrator response when a partial transcription arrives.
 """
+
 import asyncio
 import json
 import threading
@@ -9,17 +10,19 @@ import time
 
 import pytest
 import websockets
-
 from sqlmodel import Session
 from starlette.testclient import TestClient
 
+from src.core.config import settings
 from src.db.models import ClientRecord
 from src.main import app
-from src.core.config import settings
 from src.services.protocol import OrchestratorEvent
 from tests.integration.conftest import (
-    VALID_KEY, CLIENT_ID, CLIENT_NAME,
-    make_mock_orchestrator, make_mock_registry,
+    CLIENT_ID,
+    CLIENT_NAME,
+    VALID_KEY,
+    make_mock_orchestrator,
+    make_mock_registry,
 )
 
 HANDSHAKE_AUDIO = {
@@ -47,27 +50,39 @@ def _start_fake_transcriber():
         raw = await ws.recv()
         msg = json.loads(raw)
         assert msg["type"] == "config"
-        await ws.send(json.dumps({
-            "type": "ready",
-            "protocol_version": 1,
-            "session_id": "test-barge-in-session",
-        }))
+        await ws.send(
+            json.dumps(
+                {
+                    "type": "ready",
+                    "protocol_version": 1,
+                    "session_id": "test-barge-in-session",
+                }
+            )
+        )
         chunk_count = 0
         async for chunk in ws:
             if isinstance(chunk, bytes) and len(chunk) > 0:
                 chunk_count += 1
                 if chunk_count == 1:
-                    await ws.send(json.dumps({
-                        "type": "transcription",
-                        "text": "hola audio",
-                        "is_final": True,
-                    }))
+                    await ws.send(
+                        json.dumps(
+                            {
+                                "type": "transcription",
+                                "text": "hola audio",
+                                "is_final": True,
+                            }
+                        )
+                    )
                 elif chunk_count == 2:
-                    await ws.send(json.dumps({
-                        "type": "transcription",
-                        "text": "esto es una interrupcion larga",
-                        "is_final": False,
-                    }))
+                    await ws.send(
+                        json.dumps(
+                            {
+                                "type": "transcription",
+                                "text": "esto es una interrupcion larga",
+                                "is_final": False,
+                            }
+                        )
+                    )
                     break
 
     loop = asyncio.new_event_loop()
@@ -98,15 +113,23 @@ def start_fake_transcriber():
 # ---------------------------------------------------------------------------
 
 
-def test_disabled_barge_in_does_not_interrupt_in_flight_response(mock_services, db_engine, monkeypatch):
+def test_disabled_barge_in_does_not_interrupt_in_flight_response(
+    mock_services, db_engine, monkeypatch
+):
     """#108: handshake with barge_in_enabled=False + a slow (long) agent response
     + a partial transcription mid-response → the response keeps streaming to
     completion, no {"type": "interrupted"} is ever sent."""
     with Session(db_engine) as s:
-        s.add(ClientRecord(
-            id=CLIENT_ID, name=CLIENT_NAME, client_key=VALID_KEY,
-            is_active=True, barge_in_enabled=False, barge_in_min_chars=5,
-        ))
+        s.add(
+            ClientRecord(
+                id=CLIENT_ID,
+                name=CLIENT_NAME,
+                client_key=VALID_KEY,
+                is_active=True,
+                barge_in_enabled=False,
+                barge_in_min_chars=5,
+            )
+        )
         s.commit()
 
     mock_orch = make_mock_orchestrator()
@@ -120,7 +143,9 @@ def test_disabled_barge_in_does_not_interrupt_in_flight_response(mock_services, 
     mock_orch.stream_response = _stream
     mock_reg = make_mock_registry(mock_orch)
 
-    from unittest.mock import MagicMock, AsyncMock as _AM
+    from unittest.mock import AsyncMock as _AM
+    from unittest.mock import MagicMock
+
     monkeypatch.setattr("src.main.ReconnectingOpenClawClient", lambda *a, **kw: mock_reg)
     monkeypatch.setattr("src.main.OpenClawClient", lambda *a, **kw: MagicMock())
     monkeypatch.setattr("src.main.FrameDispatcher", lambda *a, **kw: MagicMock())
@@ -129,43 +154,42 @@ def test_disabled_barge_in_does_not_interrupt_in_flight_response(mock_services, 
 
     received_types = []
 
-    with TestClient(app) as client:
-        with client.websocket_connect("/ws/stream") as ws:
-            ws.send_json(HANDSHAKE_AUDIO)
-            ws.send_bytes(b"\x00" * 512)  # chunk 1 -> final transcription
+    with TestClient(app) as client, client.websocket_connect("/ws/stream") as ws:
+        ws.send_json(HANDSHAKE_AUDIO)
+        ws.send_bytes(b"\x00" * 512)  # chunk 1 -> final transcription
 
-            msg = None
-            for _ in range(10):
-                msg = ws.receive_json()
-                if msg.get("type") == "transcription":
-                    break
-            assert msg["type"] == "transcription"
-            assert msg["text"] == "hola audio"
+        msg = None
+        for _ in range(10):
+            msg = ws.receive_json()
+            if msg.get("type") == "transcription":
+                break
+        assert msg["type"] == "transcription"
+        assert msg["text"] == "hola audio"
 
-            ws.send_json({"type": "send", "text": msg["text"]})  # starts the turn
+        ws.send_json({"type": "send", "text": msg["text"]})  # starts the turn
 
-            msg = ws.receive_json()  # turn_start
-            assert msg["type"] == "turn_start"
+        msg = ws.receive_json()  # turn_start
+        assert msg["type"] == "turn_start"
 
-            msg = ws.receive_json()  # first token
-            assert msg["type"] == "token"
-            assert msg["text"] == "respuesta "
+        msg = ws.receive_json()  # first token
+        assert msg["type"] == "token"
+        assert msg["text"] == "respuesta "
 
-            ws.send_bytes(b"\x00" * 512)  # chunk 2 -> partial while turn is active
+        ws.send_bytes(b"\x00" * 512)  # chunk 2 -> partial while turn is active
 
-            # The turn completes with a {"type": "turn_end"} wire frame (see
-            # bridge.py's pipe_tokens()) — the mock orchestrator's internal
-            # OrchestratorEvent(type="status", content="done") is consumed by
-            # call_orchestrator() and never reaches the client verbatim. Also
-            # break on "interrupted": if barge-in wrongly fires, the active
-            # turn is cancelled and turn_end never arrives, so waiting only
-            # for turn_end would hang until the silence watchdog force-closes
-            # the connection instead of failing the assertion below cleanly.
-            for _ in range(10):
-                msg = ws.receive_json()
-                received_types.append(msg.get("type"))
-                if msg.get("type") in ("turn_end", "interrupted"):
-                    break
+        # The turn completes with a {"type": "turn_end"} wire frame (see
+        # bridge.py's pipe_tokens()) — the mock orchestrator's internal
+        # OrchestratorEvent(type="status", content="done") is consumed by
+        # call_orchestrator() and never reaches the client verbatim. Also
+        # break on "interrupted": if barge-in wrongly fires, the active
+        # turn is cancelled and turn_end never arrives, so waiting only
+        # for turn_end would hang until the silence watchdog force-closes
+        # the connection instead of failing the assertion below cleanly.
+        for _ in range(10):
+            msg = ws.receive_json()
+            received_types.append(msg.get("type"))
+            if msg.get("type") in ("turn_end", "interrupted"):
+                break
 
     assert "interrupted" not in received_types
     assert "transcription_partial" in received_types

--- a/tests/integration/test_bridge_flow.py
+++ b/tests/integration/test_bridge_flow.py
@@ -3,8 +3,9 @@
 input_mode=text: sin transcriber. El cliente manda texto plano,
 recibe tokens del orchestrator.
 """
+
 from src.services.protocol import OrchestratorEvent
-from tests.integration.conftest import VALID_KEY, CLIENT_ID
+from tests.integration.conftest import CLIENT_ID, VALID_KEY
 
 HANDSHAKE_TEXT = {
     "client_key": VALID_KEY,

--- a/tests/integration/test_db_client_agent_fields.py
+++ b/tests/integration/test_db_client_agent_fields.py
@@ -1,6 +1,7 @@
 """Verify that db_client.get_session() propagates default_agent and
 allowed_agents (parsed from the JSON-stored field) into ClientConfig.
 """
+
 import pytest
 from sqlalchemy.pool import StaticPool
 from sqlmodel import SQLModel, create_engine
@@ -26,11 +27,17 @@ def db_engine(monkeypatch):
 
 async def _insert(engine, key, default_agent=None, allowed_agents=None):
     from sqlmodel import Session
+
     with Session(engine) as s:
-        s.add(ClientRecord(
-            name="t", client_key=key, is_active=True,
-            default_agent=default_agent, allowed_agents=allowed_agents,
-        ))
+        s.add(
+            ClientRecord(
+                name="t",
+                client_key=key,
+                is_active=True,
+                default_agent=default_agent,
+                allowed_agents=allowed_agents,
+            )
+        )
         s.commit()
 
 

--- a/tests/integration/test_openclaw_client.py
+++ b/tests/integration/test_openclaw_client.py
@@ -1,7 +1,6 @@
 import asyncio
 import json
 import uuid
-from typing import Optional
 from unittest.mock import patch
 
 import pytest
@@ -9,11 +8,16 @@ import pytest
 from src.services.openclaw.client import OpenClawClient
 from src.services.openclaw.dispatcher import FrameDispatcher
 from src.services.openclaw.reconnecting import ReconnectingOpenClawClient
-from src.services.openclaw.registry import TurnRegistry, ClientRegistry, TURN_IN_PROGRESS_ERROR
+from src.services.openclaw.registry import (
+    TURN_IN_PROGRESS_ERROR,
+    ClientRegistry,
+    TurnRegistry,
+)
 from src.services.reconnection import ConnectionState
 
 HELLO_OK_PAYLOAD = {
-    "type": "hello-ok", "protocol": 4,
+    "type": "hello-ok",
+    "protocol": 4,
     "server": {"version": "2026.6.6", "connId": "test-conn"},
     "policy": {"tickIntervalMs": 30000, "maxPayload": 26214400, "maxBufferedBytes": 0},
     "snapshot": {
@@ -30,7 +34,8 @@ HELLO_OK_PAYLOAD = {
 # Matches OpenClaw server 2026.6.11+: hello-ok's snapshot no longer embeds the
 # agent roster at all — it must be fetched separately via agents.list.
 HELLO_OK_PAYLOAD_NO_SNAPSHOT_AGENTS = {
-    "type": "hello-ok", "protocol": 4,
+    "type": "hello-ok",
+    "protocol": 4,
     "server": {"version": "2026.6.11", "connId": "test-conn-2"},
     "policy": {"tickIntervalMs": 30000, "maxPayload": 26214400, "maxBufferedBytes": 0},
     "snapshot": {
@@ -63,11 +68,11 @@ class SmartFakeWS:
 
     def __init__(
         self,
-        chat_responses: Optional[dict] = None,
+        chat_responses: dict | None = None,
         chat_response_delay: float = 0.0,
-        hello_ok_payload: Optional[dict] = None,
-        agents_list_payload: Optional[dict] = None,
-        tool_calls: Optional[dict] = None,
+        hello_ok_payload: dict | None = None,
+        agents_list_payload: dict | None = None,
+        tool_calls: dict | None = None,
     ):
         self.chat_responses: dict[str, list[str]] = chat_responses or {}
         self.chat_response_delay: float = chat_response_delay  # delay between chunks (in seconds)
@@ -78,7 +83,7 @@ class SmartFakeWS:
         self._from_client: asyncio.Queue = asyncio.Queue()
         self.sent_frames: list[dict] = []
         self.closed = False
-        self._handler: Optional[asyncio.Task] = None
+        self._handler: asyncio.Task | None = None
 
     async def start(self):
         self._handler = asyncio.create_task(self._auto_respond())
@@ -104,6 +109,7 @@ class SmartFakeWS:
         # Allows `await websockets.connect(...)` when patched with return_value=fake_ws
         async def _noop():
             return self
+
         return _noop().__await__()
 
     def __aiter__(self):
@@ -117,10 +123,15 @@ class SmartFakeWS:
 
     async def _auto_respond(self):
         # 1. Send challenge
-        await self._to_client.put(json.dumps({
-            "type": "event", "event": "connect.challenge",
-            "payload": {"nonce": "test-nonce", "ts": 1234567890},
-        }))
+        await self._to_client.put(
+            json.dumps(
+                {
+                    "type": "event",
+                    "event": "connect.challenge",
+                    "payload": {"nonce": "test-nonce", "ts": 1234567890},
+                }
+            )
+        )
 
         while True:
             raw = await self._from_client.get()
@@ -130,58 +141,99 @@ class SmartFakeWS:
             params = frame.get("params", {})
 
             if method == "connect":
-                await self._to_client.put(json.dumps({
-                    "type": "res", "id": req_id, "ok": True,
-                    "payload": self.hello_ok_payload,
-                }))
+                await self._to_client.put(
+                    json.dumps(
+                        {
+                            "type": "res",
+                            "id": req_id,
+                            "ok": True,
+                            "payload": self.hello_ok_payload,
+                        }
+                    )
+                )
 
             elif method == "agents.list":
-                await self._to_client.put(json.dumps({
-                    "type": "res", "id": req_id, "ok": True,
-                    "payload": self.agents_list_payload,
-                }))
+                await self._to_client.put(
+                    json.dumps(
+                        {
+                            "type": "res",
+                            "id": req_id,
+                            "ok": True,
+                            "payload": self.agents_list_payload,
+                        }
+                    )
+                )
 
             elif method == "sessions.subscribe":
-                await self._to_client.put(json.dumps({
-                    "type": "res", "id": req_id, "ok": True,
-                    "payload": {"subscribed": True},
-                }))
+                await self._to_client.put(
+                    json.dumps(
+                        {
+                            "type": "res",
+                            "id": req_id,
+                            "ok": True,
+                            "payload": {"subscribed": True},
+                        }
+                    )
+                )
 
             elif method == "chat.send":
                 sk = params.get("sessionKey", "")
                 run_id = str(uuid.uuid4())
                 chunks = self.chat_responses.get(sk, ["Hello"])
 
-                await self._to_client.put(json.dumps({
-                    "type": "res", "id": req_id, "ok": True,
-                    "payload": {"runId": run_id, "status": "started"},
-                }))
+                await self._to_client.put(
+                    json.dumps(
+                        {
+                            "type": "res",
+                            "id": req_id,
+                            "ok": True,
+                            "payload": {"runId": run_id, "status": "started"},
+                        }
+                    )
+                )
                 if self.chat_response_delay > 0:
                     await asyncio.sleep(self.chat_response_delay)
                 for tool_data in self.tool_calls.get(sk, []):
-                    await self._to_client.put(json.dumps({
-                        "type": "event", "event": "session.tool",
-                        "payload": {"sessionKey": sk, "runId": run_id, "data": tool_data},
-                    }))
+                    await self._to_client.put(
+                        json.dumps(
+                            {
+                                "type": "event",
+                                "event": "session.tool",
+                                "payload": {"sessionKey": sk, "runId": run_id, "data": tool_data},
+                            }
+                        )
+                    )
                 for i, chunk in enumerate(chunks):
                     is_last = i == len(chunks) - 1
-                    await self._to_client.put(json.dumps({
-                        "type": "event", "event": "chat",
-                        "payload": {
-                            "runId": run_id, "sessionKey": sk,
-                            "seq": i + 1,
-                            "state": "final" if is_last else "delta",
-                            "deltaText": chunk,
-                        },
-                    }))
+                    await self._to_client.put(
+                        json.dumps(
+                            {
+                                "type": "event",
+                                "event": "chat",
+                                "payload": {
+                                    "runId": run_id,
+                                    "sessionKey": sk,
+                                    "seq": i + 1,
+                                    "state": "final" if is_last else "delta",
+                                    "deltaText": chunk,
+                                },
+                            }
+                        )
+                    )
                     if self.chat_response_delay > 0:
                         await asyncio.sleep(self.chat_response_delay)
 
             elif method == "health":
-                await self._to_client.put(json.dumps({
-                    "type": "res", "id": req_id, "ok": True,
-                    "payload": {"ok": True},
-                }))
+                await self._to_client.put(
+                    json.dumps(
+                        {
+                            "type": "res",
+                            "id": req_id,
+                            "ok": True,
+                            "payload": {"ok": True},
+                        }
+                    )
+                )
 
             elif method == "chat.abort":
                 pass
@@ -271,9 +323,7 @@ async def test_stream_response_ends_with_status_done(fake_ws):
 @pytest.mark.asyncio
 async def test_stream_response_uses_sessionKey_format(fake_ws):
     client = await connected_client(fake_ws)
-    async for _ in client.stream_response(
-        "hola", "client-a", session_key="agent:main:client-a"
-    ):
+    async for _ in client.stream_response("hola", "client-a", session_key="agent:main:client-a"):
         pass
     chat_sends = [f for f in fake_ws.sent_frames if f.get("method") == "chat.send"]
     assert len(chat_sends) == 1
@@ -337,7 +387,7 @@ async def test_chat_abort_frame_schema(fake_ws):
     # Create a fake WS with delays so cancellation races an in-flight response (not a completed one).
     slow_fake_ws = SmartFakeWS(
         {"agent:main:client-a": ["Hola ", "mundo"]},
-        chat_response_delay=0.15  # 150ms delay between responses
+        chat_response_delay=0.15,  # 150ms delay between responses
     )
     client = await connected_client(slow_fake_ws)
 
@@ -373,10 +423,7 @@ async def test_stream_response_completes_without_second_res(fake_ws):
         "hola", "client-a", session_key="agent:main:client-a"
     ):
         events.append(event)
-    res_frames_after_started = [
-        f for f in fake_ws.sent_frames
-        if f.get("method") == "chat.send"
-    ]
+    res_frames_after_started = [f for f in fake_ws.sent_frames if f.get("method") == "chat.send"]
     assert len(res_frames_after_started) == 1  # only the request itself was sent by us
     assert events[-1].type == "status"
     assert events[-1].content == "done"
@@ -387,11 +434,23 @@ async def test_stream_response_completes_without_second_res(fake_ws):
 async def test_stream_response_yields_tool_call_events():
     fake_ws = SmartFakeWS(
         chat_responses={"agent:main:client-a": ["Listo."]},
-        tool_calls={"agent:main:client-a": [
-            {"phase": "start", "name": "exec", "toolCallId": "call-1", "args": {"command": "ls"}},
-            {"phase": "result", "name": "exec", "toolCallId": "call-1", "isError": False,
-             "result": {"content": [{"type": "text", "text": "file.txt"}]}},
-        ]},
+        tool_calls={
+            "agent:main:client-a": [
+                {
+                    "phase": "start",
+                    "name": "exec",
+                    "toolCallId": "call-1",
+                    "args": {"command": "ls"},
+                },
+                {
+                    "phase": "result",
+                    "name": "exec",
+                    "toolCallId": "call-1",
+                    "isError": False,
+                    "result": {"content": [{"type": "text", "text": "file.txt"}]},
+                },
+            ]
+        },
     )
     client = await connected_client(fake_ws)
     tool_events = []
@@ -515,7 +574,9 @@ async def test_terminal_event_then_generator_close_does_not_send_spurious_chat_a
         await stream.aclose()
 
     task = asyncio.create_task(drive_and_close())
-    await asyncio.sleep(0.01)  # let register() + chat.send happen before erroring it out, ahead of the first (delayed) token
+    await asyncio.sleep(
+        0.01
+    )  # let register() + chat.send happen before erroring it out, ahead of the first (delayed) token
     client._turn_registry.error_all("boom")
     await asyncio.wait_for(task, timeout=1.0)
 
@@ -631,10 +692,12 @@ async def test_concurrent_stream_response_different_session_keys_both_succeed():
     """Regression guard: rejecting duplicate session_keys must not affect
     unrelated sessions multiplexed on the same connection — both complete
     normally when run concurrently via asyncio.gather."""
-    fake_ws = SmartFakeWS({
-        "agent:main:client-a": ["Hola ", "mundo"],
-        "agent:main:client-b": ["Adios ", "mundo"],
-    })
+    fake_ws = SmartFakeWS(
+        {
+            "agent:main:client-a": ["Hola ", "mundo"],
+            "agent:main:client-b": ["Adios ", "mundo"],
+        }
+    )
     client = await connected_client(fake_ws)
 
     async def _consume(user_id, session_key):

--- a/tests/integration/test_pipeline_events.py
+++ b/tests/integration/test_pipeline_events.py
@@ -1,4 +1,5 @@
 """Integration: pipeline_event messages appear in WS stream when status in output_mode."""
+
 from tests.integration.conftest import VALID_KEY
 
 HANDSHAKE_WITH_STATUS = {

--- a/tests/integration/test_pipeline_tracker.py
+++ b/tests/integration/test_pipeline_tracker.py
@@ -1,5 +1,6 @@
 import asyncio
 from unittest.mock import AsyncMock, MagicMock
+
 from src.services.pipeline_tracker import PipelineTracker
 
 

--- a/tests/integration/test_reconnecting_openclaw.py
+++ b/tests/integration/test_reconnecting_openclaw.py
@@ -1,12 +1,14 @@
 import asyncio
 import contextlib
-import pytest
 from unittest.mock import AsyncMock
-from src.services.openclaw.reconnecting import ReconnectingOpenClawClient
-from src.services.reconnection import ConnectionState
+
+import pytest
+
 from src.services.openclaw.client import OpenClawClient
 from src.services.openclaw.models import GatewayInfo
+from src.services.openclaw.reconnecting import ReconnectingOpenClawClient
 from src.services.protocol import OrchestratorEvent
+from src.services.reconnection import ConnectionState
 
 
 def make_mock_client(gateway_info=None):
@@ -30,8 +32,13 @@ def make_mock_client(gateway_info=None):
 
 
 GATEWAY_INFO = GatewayInfo(
-    protocol_version=4, server_version="2026.6.6", conn_id="c1",
-    default_agent_id="main", agents={}, tick_interval_ms=30000, max_payload=26214400,
+    protocol_version=4,
+    server_version="2026.6.6",
+    conn_id="c1",
+    default_agent_id="main",
+    agents={},
+    tick_interval_ms=30000,
+    max_payload=26214400,
 )
 
 

--- a/tests/integration/test_rest_health.py
+++ b/tests/integration/test_rest_health.py
@@ -1,6 +1,8 @@
 """Tests for GET /healthz and GET /ready."""
-import httpx
+
 from unittest.mock import AsyncMock
+
+import httpx
 
 from src.core.config import settings
 
@@ -30,9 +32,7 @@ def test_ready_orchestrator_down_returns_503(client, mock_orchestrator):
 
 
 def test_ready_tts_down_returns_200_degraded(client, mock_services):
-    mock_services.get("http://localhost:8005/ready").mock(
-        side_effect=httpx.ConnectError("down")
-    )
+    mock_services.get("http://localhost:8005/ready").mock(side_effect=httpx.ConnectError("down"))
     r = client.get("/ready")
     assert r.status_code == 200
     body = r.json()

--- a/tests/integration/test_rest_openai.py
+++ b/tests/integration/test_rest_openai.py
@@ -1,7 +1,7 @@
 # tests/integration/test_rest_openai.py
-from src.services.protocol import OrchestratorEvent
-from src.main import app
 from src.core.config import settings
+from src.main import app
+from src.services.protocol import OrchestratorEvent
 from tests.integration.conftest import CLIENT_ID
 
 
@@ -15,11 +15,14 @@ def test_get_models_returns_list(client):
 
 def test_chat_completions_non_streaming_uses_orchestrator(client, mock_orchestrator):
     """Always routes through the orchestrator — no LLM bypass."""
-    r = client.post("/v1/chat/completions", json={
-        "model": "openclaw",
-        "messages": [{"role": "user", "content": "Hola"}],
-        "stream": False,
-    })
+    r = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "openclaw",
+            "messages": [{"role": "user", "content": "Hola"}],
+            "stream": False,
+        },
+    )
     assert r.status_code == 200
     body = r.json()
     assert body["object"] == "chat.completion"
@@ -30,6 +33,7 @@ def test_chat_completions_non_streaming_uses_orchestrator(client, mock_orchestra
 def test_chat_completions_uses_correct_session_key(client, mock_registry, mock_orchestrator):
     """session_key passed to stream_response matches agent:{default_agent}:ha."""
     from src.core.session_key import make_session_key
+
     captured = {}
 
     async def _stream(text, user_id, model_id=None, session_key=None):
@@ -39,11 +43,14 @@ def test_chat_completions_uses_correct_session_key(client, mock_registry, mock_o
 
     mock_orchestrator.stream_response = _stream
 
-    client.post("/v1/chat/completions", json={
-        "model": "openclaw",
-        "messages": [{"role": "user", "content": "test"}],
-        "stream": False,
-    })
+    client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "openclaw",
+            "messages": [{"role": "user", "content": "test"}],
+            "stream": False,
+        },
+    )
 
     # default_agent_id from GatewayInfo mock is "main"
     expected = make_session_key("main", "ha")
@@ -51,24 +58,31 @@ def test_chat_completions_uses_correct_session_key(client, mock_registry, mock_o
 
 
 def test_chat_completions_uses_last_user_message(client):
-    r = client.post("/v1/chat/completions", json={
-        "model": "openclaw",
-        "messages": [
-            {"role": "user", "content": "First"},
-            {"role": "assistant", "content": "Answer"},
-            {"role": "user", "content": "Second"},
-        ],
-        "stream": False,
-    })
+    r = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "openclaw",
+            "messages": [
+                {"role": "user", "content": "First"},
+                {"role": "assistant", "content": "Answer"},
+                {"role": "user", "content": "Second"},
+            ],
+            "stream": False,
+        },
+    )
     assert r.status_code == 200
 
 
 def test_chat_completions_streaming_returns_sse(client):
-    with client.stream("POST", "/v1/chat/completions", json={
-        "model": "openclaw",
-        "messages": [{"role": "user", "content": "Hi"}],
-        "stream": True,
-    }) as r:
+    with client.stream(
+        "POST",
+        "/v1/chat/completions",
+        json={
+            "model": "openclaw",
+            "messages": [{"role": "user", "content": "Hi"}],
+            "stream": True,
+        },
+    ) as r:
         assert r.status_code == 200
         assert "text/event-stream" in r.headers["content-type"]
         r.read()
@@ -80,13 +94,14 @@ def test_chat_completions_streaming_returns_sse(client):
 def _parse_sse_tokens(body: str) -> list[str]:
     """Extrae el contenido de cada delta token de un cuerpo SSE."""
     import json as _json
+
     tokens = []
     for frame in body.split("\n\n"):
         frame = frame.strip()
         if not frame.startswith("data:") or "[DONE]" in frame:
             continue
         try:
-            data = _json.loads(frame[len("data: "):])
+            data = _json.loads(frame[len("data: ") :])
             content = data["choices"][0]["delta"].get("content")
             if content:
                 tokens.append(content)
@@ -104,12 +119,13 @@ def _parse_sse_payloads(body: str) -> list[dict]:
         frame = frame.strip()
         if not frame.startswith("data: ") or frame == "data: [DONE]":
             continue
-        payloads.append(_json.loads(frame[len("data: "):]))
+        payloads.append(_json.loads(frame[len("data: ") :]))
     return payloads
 
 
 def test_streaming_each_token_maps_to_separate_sse_frame(client, mock_orchestrator):
     """Cada token del orquestador debe aparecer como un SSE frame separado con su contenido."""
+
     async def _stream(*args, **kwargs):
         yield OrchestratorEvent(type="token", content="Hola")
         yield OrchestratorEvent(type="token", content=" mundo")
@@ -117,11 +133,15 @@ def test_streaming_each_token_maps_to_separate_sse_frame(client, mock_orchestrat
 
     mock_orchestrator.stream_response = _stream
 
-    with client.stream("POST", "/v1/chat/completions", json={
-        "model": "openclaw",
-        "messages": [{"role": "user", "content": "test"}],
-        "stream": True,
-    }) as r:
+    with client.stream(
+        "POST",
+        "/v1/chat/completions",
+        json={
+            "model": "openclaw",
+            "messages": [{"role": "user", "content": "test"}],
+            "stream": True,
+        },
+    ) as r:
         r.read()
         body = r.text
 
@@ -139,19 +159,25 @@ def test_streaming_stop_frame_has_finish_reason_stop(client, mock_orchestrator):
 
     mock_orchestrator.stream_response = _stream
 
-    with client.stream("POST", "/v1/chat/completions", json={
-        "model": "openclaw",
-        "messages": [{"role": "user", "content": "test"}],
-        "stream": True,
-    }) as r:
+    with client.stream(
+        "POST",
+        "/v1/chat/completions",
+        json={
+            "model": "openclaw",
+            "messages": [{"role": "user", "content": "test"}],
+            "stream": True,
+        },
+    ) as r:
         r.read()
         body = r.text
 
-    frames = [f.strip() for f in body.split("\n\n") if f.strip().startswith("data:") and "[DONE]" not in f]
+    frames = [
+        f.strip() for f in body.split("\n\n") if f.strip().startswith("data:") and "[DONE]" not in f
+    ]
     stop_frames = []
     for frame in frames:
         try:
-            data = _json.loads(frame[len("data: "):])
+            data = _json.loads(frame[len("data: ") :])
             if data["choices"][0].get("finish_reason") == "stop":
                 stop_frames.append(data)
         except (KeyError, IndexError, _json.JSONDecodeError):
@@ -162,11 +188,15 @@ def test_streaming_stop_frame_has_finish_reason_stop(client, mock_orchestrator):
 
 def test_streaming_session_is_completed_after_response(client, mock_orchestrator):
     """La sesión HTTP debe estar marcada como 'completed' al terminar el stream."""
-    with client.stream("POST", "/v1/chat/completions", json={
-        "model": "openclaw",
-        "messages": [{"role": "user", "content": "test"}],
-        "stream": True,
-    }) as r:
+    with client.stream(
+        "POST",
+        "/v1/chat/completions",
+        json={
+            "model": "openclaw",
+            "messages": [{"role": "user", "content": "test"}],
+            "stream": True,
+        },
+    ) as r:
         r.read()
 
     sessions = app.state.session_registry.get_all()
@@ -179,33 +209,42 @@ def test_streaming_session_is_completed_after_response(client, mock_orchestrator
 
 def test_non_streaming_orchestrator_error_returns_502(client, mock_orchestrator):
     """Un error del orquestador en modo no-streaming debe devolver HTTP 502, no 200."""
+
     async def _error_stream(*args, **kwargs):
         yield OrchestratorEvent(type="error", content="orchestrator_unavailable")
 
     mock_orchestrator.stream_response = _error_stream
 
-    r = client.post("/v1/chat/completions", json={
-        "model": "openclaw",
-        "messages": [{"role": "user", "content": "Hola"}],
-        "stream": False,
-    })
+    r = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "openclaw",
+            "messages": [{"role": "user", "content": "Hola"}],
+            "stream": False,
+        },
+    )
 
     assert r.status_code == 502, f"Esperado 502, recibido {r.status_code}: {r.text}"
 
 
 def test_streaming_orchestrator_error_before_first_token_is_terminal_error(
-    client, mock_orchestrator,
+    client,
+    mock_orchestrator,
 ):
     async def _error_stream(*args, **kwargs):
         yield OrchestratorEvent(type="error", content="orchestrator_unavailable")
 
     mock_orchestrator.stream_response = _error_stream
 
-    with client.stream("POST", "/v1/chat/completions", json={
-        "model": "openclaw",
-        "messages": [{"role": "user", "content": "Hola"}],
-        "stream": True,
-    }) as response:
+    with client.stream(
+        "POST",
+        "/v1/chat/completions",
+        json={
+            "model": "openclaw",
+            "messages": [{"role": "user", "content": "Hola"}],
+            "stream": True,
+        },
+    ) as response:
         response.read()
         body = response.text
 
@@ -218,20 +257,21 @@ def test_streaming_orchestrator_error_before_first_token_is_terminal_error(
     }
     assert payloads[-1]["choices"][0]["finish_reason"] == "error"
     assert not any(
-        payload.get("choices", [{}])[0].get("finish_reason") == "stop"
-        for payload in payloads
+        payload.get("choices", [{}])[0].get("finish_reason") == "stop" for payload in payloads
     )
     assert "[DONE]" not in body
 
     http_sessions = [
-        session for session in app.state.session_registry.get_all()
+        session
+        for session in app.state.session_registry.get_all()
         if session.session_id.startswith("http:")
     ]
     assert http_sessions[-1].status == "error"
 
 
 def test_streaming_orchestrator_error_after_token_preserves_partial_output(
-    client, mock_orchestrator,
+    client,
+    mock_orchestrator,
 ):
     async def _partial_error_stream(*args, **kwargs):
         yield OrchestratorEvent(type="token", content="respuesta parcial")
@@ -239,11 +279,15 @@ def test_streaming_orchestrator_error_after_token_preserves_partial_output(
 
     mock_orchestrator.stream_response = _partial_error_stream
 
-    with client.stream("POST", "/v1/chat/completions", json={
-        "model": "openclaw",
-        "messages": [{"role": "user", "content": "Hola"}],
-        "stream": True,
-    }) as response:
+    with client.stream(
+        "POST",
+        "/v1/chat/completions",
+        json={
+            "model": "openclaw",
+            "messages": [{"role": "user", "content": "Hola"}],
+            "stream": True,
+        },
+    ) as response:
         response.read()
         body = response.text
 
@@ -257,13 +301,13 @@ def test_streaming_orchestrator_error_after_token_preserves_partial_output(
     }
     assert payloads[-1]["choices"][0]["finish_reason"] == "error"
     assert not any(
-        payload.get("choices", [{}])[0].get("finish_reason") == "stop"
-        for payload in payloads
+        payload.get("choices", [{}])[0].get("finish_reason") == "stop" for payload in payloads
     )
     assert "[DONE]" not in body
 
     http_sessions = [
-        session for session in app.state.session_registry.get_all()
+        session
+        for session in app.state.session_registry.get_all()
         if session.session_id.startswith("http:")
     ]
     assert http_sessions[-1].status == "error"
@@ -279,11 +323,14 @@ def test_non_streaming_turn_conflict_returns_409(client, mock_orchestrator):
 
     mock_orchestrator.stream_response = _conflict_stream
 
-    r = client.post("/v1/chat/completions", json={
-        "model": "openclaw",
-        "messages": [{"role": "user", "content": "Hola"}],
-        "stream": False,
-    })
+    r = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "openclaw",
+            "messages": [{"role": "user", "content": "Hola"}],
+            "stream": False,
+        },
+    )
 
     assert r.status_code == 409, f"Esperado 409, recibido {r.status_code}: {r.text}"
 
@@ -301,11 +348,15 @@ def test_streaming_done_delivered_when_tracker_close_raises(client, mock_orchest
 
     monkeypatch.setattr(pt_module.PipelineTracker, "close", _raising_close)
 
-    with client.stream("POST", "/v1/chat/completions", json={
-        "model": "openclaw",
-        "messages": [{"role": "user", "content": "test"}],
-        "stream": True,
-    }) as r:
+    with client.stream(
+        "POST",
+        "/v1/chat/completions",
+        json={
+            "model": "openclaw",
+            "messages": [{"role": "user", "content": "test"}],
+            "stream": True,
+        },
+    ) as r:
         r.read()
         body = r.text
 
@@ -314,35 +365,46 @@ def test_streaming_done_delivered_when_tracker_close_raises(client, mock_orchest
 
 def test_invalid_messages_type_returns_422(client):
     """messages como string (no lista) debe devolver 422, no 500."""
-    r = client.post("/v1/chat/completions", json={
-        "model": "openclaw",
-        "messages": "not a list",
-    })
+    r = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "openclaw",
+            "messages": "not a list",
+        },
+    )
     assert r.status_code == 422, f"Esperado 422, recibido {r.status_code}: {r.text}"
 
 
 def test_missing_body_returns_422(client):
     """Body completamente ausente debe devolver 422."""
-    r = client.post("/v1/chat/completions", content=b"", headers={"content-type": "application/json"})
+    r = client.post(
+        "/v1/chat/completions", content=b"", headers={"content-type": "application/json"}
+    )
     assert r.status_code == 422, f"Esperado 422, recibido {r.status_code}: {r.text}"
 
 
 def test_chat_completions_no_user_message_returns_empty(client):
-    r = client.post("/v1/chat/completions", json={
-        "model": "openclaw",
-        "messages": [{"role": "system", "content": "Be helpful"}],
-        "stream": False,
-    })
+    r = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "openclaw",
+            "messages": [{"role": "system", "content": "Be helpful"}],
+            "stream": False,
+        },
+    )
     assert r.status_code == 200
 
 
 def test_http_session_appears_in_registry(client):
     """After an HTTP call, a session record appears in app.state.session_registry."""
-    client.post("/v1/chat/completions", json={
-        "model": "openclaw",
-        "messages": [{"role": "user", "content": "ping"}],
-        "stream": False,
-    })
+    client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "openclaw",
+            "messages": [{"role": "user", "content": "ping"}],
+            "stream": False,
+        },
+    )
     sessions = app.state.session_registry.get_all()
     http_sessions = [s for s in sessions if s.session_id.startswith("http:")]
     assert len(http_sessions) >= 1
@@ -360,26 +422,38 @@ def test_get_models_from_untrusted_origin_without_auth_returns_401(client_untrus
 
 
 def test_chat_completions_from_untrusted_origin_without_auth_returns_401(client_untrusted):
-    r = client_untrusted.post("/v1/chat/completions", json={
-        "model": "openclaw",
-        "messages": [{"role": "user", "content": "Hola"}],
-        "stream": False,
-    })
+    r = client_untrusted.post(
+        "/v1/chat/completions",
+        json={
+            "model": "openclaw",
+            "messages": [{"role": "user", "content": "Hola"}],
+            "stream": False,
+        },
+    )
     assert r.status_code == 401
 
 
-def test_chat_completions_from_untrusted_origin_with_valid_key_passes(client_untrusted, ha_bearer_headers):
+def test_chat_completions_from_untrusted_origin_with_valid_key_passes(
+    client_untrusted, ha_bearer_headers
+):
     r = client_untrusted.post(
         "/v1/chat/completions",
-        json={"model": "openclaw", "messages": [{"role": "user", "content": "Hola"}], "stream": False},
+        json={
+            "model": "openclaw",
+            "messages": [{"role": "user", "content": "Hola"}],
+            "stream": False,
+        },
         headers=ha_bearer_headers,
     )
     assert r.status_code == 200
     assert r.json()["choices"][0]["message"]["content"] == "Hola"
 
 
-def test_chat_completions_with_valid_key_uses_real_client_session_key(client_untrusted, ha_bearer_headers, mock_registry):
+def test_chat_completions_with_valid_key_uses_real_client_session_key(
+    client_untrusted, ha_bearer_headers, mock_registry
+):
     from src.core.session_key import make_session_key
+
     captured = {}
 
     async def _stream(text, user_id, model_id=None, session_key=None):
@@ -392,7 +466,11 @@ def test_chat_completions_with_valid_key_uses_real_client_session_key(client_unt
 
     client_untrusted.post(
         "/v1/chat/completions",
-        json={"model": "openclaw", "messages": [{"role": "user", "content": "test"}], "stream": False},
+        json={
+            "model": "openclaw",
+            "messages": [{"role": "user", "content": "test"}],
+            "stream": False,
+        },
         headers=ha_bearer_headers,
     )
 
@@ -404,7 +482,11 @@ def test_chat_completions_with_valid_key_uses_real_client_session_key(client_unt
 def test_chat_completions_with_invalid_key_returns_401_even_from_loopback(client):
     r = client.post(
         "/v1/chat/completions",
-        json={"model": "openclaw", "messages": [{"role": "user", "content": "Hola"}], "stream": False},
+        json={
+            "model": "openclaw",
+            "messages": [{"role": "user", "content": "Hola"}],
+            "stream": False,
+        },
         headers={"authorization": "Bearer not-a-real-key"},
     )
     assert r.status_code == 401
@@ -412,20 +494,27 @@ def test_chat_completions_with_invalid_key_returns_401_even_from_loopback(client
 
 def test_chat_completions_with_inactive_client_key_returns_401(client, db_engine):
     from sqlmodel import Session
+
     from src.db.models import ClientRecord
 
     with Session(db_engine) as s:
-        s.add(ClientRecord(
-            id="inactive-client",
-            name="Inactive",
-            client_key="inactive-key",
-            is_active=False,
-        ))
+        s.add(
+            ClientRecord(
+                id="inactive-client",
+                name="Inactive",
+                client_key="inactive-key",
+                is_active=False,
+            )
+        )
         s.commit()
 
     r = client.post(
         "/v1/chat/completions",
-        json={"model": "openclaw", "messages": [{"role": "user", "content": "Hola"}], "stream": False},
+        json={
+            "model": "openclaw",
+            "messages": [{"role": "user", "content": "Hola"}],
+            "stream": False,
+        },
         headers={"authorization": "Bearer inactive-key"},
     )
     assert r.status_code == 401
@@ -437,7 +526,11 @@ def test_chat_completions_x_real_ip_alone_does_not_grant_trust(client, monkeypat
     monkeypatch.setattr(settings, "TRUSTED_NETWORKS", "")
     r = client.post(
         "/v1/chat/completions",
-        json={"model": "openclaw", "messages": [{"role": "user", "content": "Hola"}], "stream": False},
+        json={
+            "model": "openclaw",
+            "messages": [{"role": "user", "content": "Hola"}],
+            "stream": False,
+        },
         headers={"x-real-ip": "203.0.113.9"},
     )
     assert r.status_code == 401
@@ -447,7 +540,11 @@ def test_chat_completions_trusts_x_real_ip_within_trusted_networks(client, monke
     monkeypatch.setattr(settings, "TRUSTED_NETWORKS", "192.168.50.0/24")
     r = client.post(
         "/v1/chat/completions",
-        json={"model": "openclaw", "messages": [{"role": "user", "content": "Hola"}], "stream": False},
+        json={
+            "model": "openclaw",
+            "messages": [{"role": "user", "content": "Hola"}],
+            "stream": False,
+        },
         headers={"x-real-ip": "192.168.50.7"},
     )
     assert r.status_code == 200
@@ -458,7 +555,11 @@ def test_chat_completions_ignores_x_real_ip_from_untrusted_peer(client_untrusted
     spoofed X-Real-IP claiming to be loopback must be ignored."""
     r = client_untrusted.post(
         "/v1/chat/completions",
-        json={"model": "openclaw", "messages": [{"role": "user", "content": "Hola"}], "stream": False},
+        json={
+            "model": "openclaw",
+            "messages": [{"role": "user", "content": "Hola"}],
+            "stream": False,
+        },
         headers={"x-real-ip": "127.0.0.1"},
     )
     assert r.status_code == 401

--- a/tests/integration/test_service_status_routes.py
+++ b/tests/integration/test_service_status_routes.py
@@ -1,4 +1,5 @@
 """Integration tests for /admin/transcriber/status and /admin/tts/status."""
+
 from unittest.mock import patch
 
 

--- a/tests/integration/test_session_registry.py
+++ b/tests/integration/test_session_registry.py
@@ -1,6 +1,7 @@
 from unittest.mock import AsyncMock, MagicMock
-from src.services.session_registry import SessionRegistry
+
 from src.services.pipeline_tracker import PipelineTracker
+from src.services.session_registry import SessionRegistry
 
 
 def _make_tracker(session_id="s1", client_id="c1"):

--- a/tests/integration/test_sessions_api.py
+++ b/tests/integration/test_sessions_api.py
@@ -1,4 +1,5 @@
 from unittest.mock import AsyncMock, MagicMock
+
 from src.services.pipeline_tracker import PipelineTracker
 
 
@@ -33,6 +34,7 @@ def test_list_sessions_requires_admin_token(client):
 
 def test_list_sessions_shows_active_session(client, admin_headers):
     from src.main import app
+
     _make_live_tracker(app, "sess:active")
     try:
         r = client.get("/admin/sessions", headers=admin_headers)
@@ -49,6 +51,7 @@ def test_list_sessions_shows_active_session(client, admin_headers):
 
 def test_list_sessions_includes_completed(client, admin_headers):
     from src.main import app
+
     _make_live_tracker(app, "sess:done")
     app.state.session_registry.close("sess:done", "completed")
     r = client.get("/admin/sessions", headers=admin_headers)
@@ -64,6 +67,7 @@ def test_get_session_not_found(client, admin_headers):
 
 def test_get_session_returns_required_fields(client, admin_headers):
     from src.main import app
+
     _make_live_tracker(app, "sess:fields")
     r = client.get("/admin/sessions/sess:fields", headers=admin_headers)
     assert r.status_code == 200
@@ -79,6 +83,7 @@ def test_get_session_returns_required_fields(client, admin_headers):
 
 def test_get_session_last_latencies_fields_present(client, admin_headers):
     from src.main import app
+
     _make_live_tracker(app, "sess:lat")
     r = client.get("/admin/sessions/sess:lat", headers=admin_headers)
     data = r.json()
@@ -91,6 +96,7 @@ def test_get_session_last_latencies_fields_present(client, admin_headers):
 
 async def test_get_session_avg_latencies_computed_correctly(client, admin_headers):
     import asyncio
+
     from src.main import app
 
     ws = AsyncMock()
@@ -123,6 +129,7 @@ async def test_get_session_avg_latencies_computed_correctly(client, admin_header
 
 async def test_get_session_avg_latencies_exclude_cancelled_turns(client, admin_headers):
     import asyncio
+
     from src.main import app
 
     ws = AsyncMock()

--- a/tests/integration/test_ws_handshake.py
+++ b/tests/integration/test_ws_handshake.py
@@ -1,4 +1,5 @@
 """Tests para WebSocket handshake (/ws/stream)."""
+
 import logging
 import re
 from uuid import UUID
@@ -18,10 +19,9 @@ def _assert_request_id(message: str) -> None:
 
 def test_malformed_json_closes_ws(client):
     """JSON malformado como primer mensaje → WS se cierra (código 1008)."""
-    with pytest.raises(Exception):
-        with client.websocket_connect("/ws/stream") as ws:
-            ws.send_text("not-json{{")
-            ws.receive_text()  # debe lanzar excepción al recibir close frame
+    with pytest.raises(Exception), client.websocket_connect("/ws/stream") as ws:
+        ws.send_text("not-json{{")
+        ws.receive_text()  # debe lanzar excepción al recibir close frame
 
 
 def test_invalid_client_key_log_is_safe_and_correlatable(client, caplog, monkeypatch):
@@ -30,7 +30,8 @@ def test_invalid_client_key_log_is_safe_and_correlatable(client, caplog, monkeyp
     monkeypatch.setattr(settings, "TRUSTED_PROXIES", "127.0.0.1,::1")
 
     # Use a mock to capture the warning call since caplog isn't capturing
-    import unittest.mock as mock
+    from unittest import mock
+
     warning_calls = []
 
     def mock_warning(msg, *args, **kwargs):
@@ -43,11 +44,13 @@ def test_invalid_client_key_log_is_safe_and_correlatable(client, caplog, monkeyp
         )
         ws.__enter__()
         try:
-            ws.send_json({
-                "client_key": key,
-                "input_mode": "text",
-                "output_mode": ["text"],
-            })
+            ws.send_json(
+                {
+                    "client_key": key,
+                    "input_mode": "text",
+                    "output_mode": ["text"],
+                }
+            )
             ws.receive_text()
         except Exception:
             pass
@@ -68,15 +71,15 @@ def test_invalid_client_key_log_is_safe_and_correlatable(client, caplog, monkeyp
 
 def test_missing_required_handshake_field_closes_ws(client):
     """Handshake sin campo requerido (input_mode) → WS se cierra."""
-    with pytest.raises(Exception):
-        with client.websocket_connect("/ws/stream") as ws:
-            ws.send_json({"client_key": VALID_KEY, "output_mode": ["text"]})
-            ws.receive_text()
+    with pytest.raises(Exception), client.websocket_connect("/ws/stream") as ws:
+        ws.send_json({"client_key": VALID_KEY, "output_mode": ["text"]})
+        ws.receive_text()
 
 
 def test_valid_text_mode_handshake_connection_stays_open(client, caplog):
     """Handshake válido — gateway responde con ready y la conexión permanece abierta."""
-    import unittest.mock as mock
+    from unittest import mock
+
     info_calls = []
 
     def mock_info(msg, *args, **kwargs):
@@ -84,11 +87,13 @@ def test_valid_text_mode_handshake_connection_stays_open(client, caplog):
 
     with mock.patch.object(logging.getLogger("src.api.routes"), "info", mock_info):
         with client.websocket_connect("/ws/stream") as ws:
-            ws.send_json({
-                "client_key": VALID_KEY,
-                "input_mode": "text",
-                "output_mode": ["text"],
-            })
+            ws.send_json(
+                {
+                    "client_key": VALID_KEY,
+                    "input_mode": "text",
+                    "output_mode": ["text"],
+                }
+            )
             ready = ws.receive_json()
             assert ready["type"] == "ready"
             assert ready["input_mode"] == "text"
@@ -113,6 +118,7 @@ def test_valid_text_mode_handshake_connection_stays_open(client, caplog):
 def test_ready_carries_requested_and_live_capabilities_when_audio(client, monkeypatch):
     """#114 — `ready` divide capabilities en requested/live."""
     from unittest.mock import AsyncMock
+
     from src.services.reconnection import ConnectionState
 
     # TTS ping returns False (degraded), transcriber state is CONNECTED
@@ -120,6 +126,7 @@ def test_ready_carries_requested_and_live_capabilities_when_audio(client, monkey
         "src.services.bridge.TTSClient.ping",
         AsyncMock(return_value=False),
     )
+
     # Mock transcriber state directly on the bridge after it's created
     # by patching the ReconnectingTranscriberClient class to report CONNECTED
     class FakeTranscriber:
@@ -143,11 +150,13 @@ def test_ready_carries_requested_and_live_capabilities_when_audio(client, monkey
     )
 
     with client.websocket_connect("/ws/stream") as ws:
-        ws.send_json({
-            "client_key": VALID_KEY,
-            "input_mode": "audio",
-            "output_mode": ["audio", "text"],
-        })
+        ws.send_json(
+            {
+                "client_key": VALID_KEY,
+                "input_mode": "audio",
+                "output_mode": ["audio", "text"],
+            }
+        )
         frames = []
         for _ in range(10):
             try:
@@ -170,19 +179,20 @@ def test_ready_carries_requested_and_live_capabilities_when_audio(client, monkey
         "transcriber": True,
     }
     status_before_ready = [
-        f for f in frames
-        if f.get("type") == "status" and f.get("service") == "tts"
+        f for f in frames if f.get("type") == "status" and f.get("service") == "tts"
     ]
     assert status_before_ready, "Debe haber un status tts unavailable antes de ready"
 
 
 def test_ready_uses_both_sections_for_text_only_handshake(client):
     with client.websocket_connect("/ws/stream") as ws:
-        ws.send_json({
-            "client_key": VALID_KEY,
-            "input_mode": "text",
-            "output_mode": ["text"],
-        })
+        ws.send_json(
+            {
+                "client_key": VALID_KEY,
+                "input_mode": "text",
+                "output_mode": ["text"],
+            }
+        )
         ready = ws.receive_json()
 
     assert ready["type"] == "ready"

--- a/tests/integration/test_ws_handshake.py
+++ b/tests/integration/test_ws_handshake.py
@@ -95,7 +95,7 @@ def test_valid_text_mode_handshake_connection_stays_open(client, caplog):
             assert ready["output_mode"] == ["text"]
             assert "session_id" in ready
             assert "agent" in ready
-            assert "capabilities" in ready
+            assert "requested_capabilities" in ready
             ws.send_text('{"type":"end"}')
 
     handshake_msgs = [m for m in info_calls if "Handshake verificado" in m]
@@ -108,3 +108,91 @@ def test_valid_text_mode_handshake_connection_stays_open(client, caplog):
 
     # Also verify the full caplog text doesn't contain the key
     assert VALID_KEY not in caplog.text
+
+
+def test_ready_carries_requested_and_live_capabilities_when_audio(client, monkeypatch):
+    """#114 — `ready` divide capabilities en requested/live."""
+    from unittest.mock import AsyncMock
+    from src.services.reconnection import ConnectionState
+
+    # TTS ping returns False (degraded), transcriber state is CONNECTED
+    monkeypatch.setattr(
+        "src.services.bridge.TTSClient.ping",
+        AsyncMock(return_value=False),
+    )
+    # Mock transcriber state directly on the bridge after it's created
+    # by patching the ReconnectingTranscriberClient class to report CONNECTED
+    class FakeTranscriber:
+        state = ConnectionState.CONNECTED
+
+        async def connect(self, *, language: str, vad_thold: float, **kw):
+            pass
+
+        async def run(self):
+            pass
+
+        async def close(self):
+            pass
+
+    def fake_transcriber_factory(*a, **kw):
+        return FakeTranscriber()
+
+    monkeypatch.setattr(
+        "src.services.bridge.ReconnectingTranscriberClient",
+        fake_transcriber_factory,
+    )
+
+    with client.websocket_connect("/ws/stream") as ws:
+        ws.send_json({
+            "client_key": VALID_KEY,
+            "input_mode": "audio",
+            "output_mode": ["audio", "text"],
+        })
+        frames = []
+        for _ in range(10):
+            try:
+                frames.append(ws.receive_json())
+            except Exception:
+                break
+            if any(f.get("type") == "ready" for f in frames):
+                break
+        ready = next(f for f in frames if f.get("type") == "ready")
+
+    assert "capabilities" not in ready
+    assert ready["requested_capabilities"] == {
+        "barge_in": True,
+        "tts": True,
+        "transcriber": True,
+    }
+    assert ready["live_capabilities"] == {
+        "barge_in": True,
+        "tts": False,
+        "transcriber": True,
+    }
+    status_before_ready = [
+        f for f in frames
+        if f.get("type") == "status" and f.get("service") == "tts"
+    ]
+    assert status_before_ready, "Debe haber un status tts unavailable antes de ready"
+
+
+def test_ready_uses_both_sections_for_text_only_handshake(client):
+    with client.websocket_connect("/ws/stream") as ws:
+        ws.send_json({
+            "client_key": VALID_KEY,
+            "input_mode": "text",
+            "output_mode": ["text"],
+        })
+        ready = ws.receive_json()
+
+    assert ready["type"] == "ready"
+    assert ready["requested_capabilities"] == {
+        "barge_in": True,
+        "tts": False,
+        "transcriber": False,
+    }
+    assert ready["live_capabilities"] == {
+        "barge_in": False,
+        "tts": False,
+        "transcriber": False,
+    }

--- a/tests/integration/test_ws_setup_cleanup.py
+++ b/tests/integration/test_ws_setup_cleanup.py
@@ -6,6 +6,7 @@ early without calling `bridge.close_all()` or `tracker.close()` — the bridge
 stayed registered in `ClientRegistry` forever, and the session stayed
 "active" forever in `SessionRegistry` (which never evicts active entries).
 """
+
 from unittest.mock import AsyncMock
 
 import pytest

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,5 +1,7 @@
-import pytest
 from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
 from src.services.pipeline_tracker import PipelineTracker
 
 

--- a/tests/unit/test_agent_policy.py
+++ b/tests/unit/test_agent_policy.py
@@ -3,15 +3,15 @@
 Pure helper — no DB, WS, or FastAPI. Stubs for ClientConfig and GatewayInfo
 live inline to avoid coupling to other modules' internals.
 """
+
 from dataclasses import dataclass, field
-from typing import List, Optional
 
 import pytest
 
 from src.core.agent_policy import AgentPolicyError, resolve_agent
 
-
 # --- Stubs ----------------------------------------------------------------
+
 
 @dataclass
 class _StubGatewayInfo:
@@ -21,11 +21,12 @@ class _StubGatewayInfo:
 
 @dataclass
 class _StubClientConfig:
-    default_agent: Optional[str] = None
-    allowed_agents: Optional[List[str]] = None
+    default_agent: str | None = None
+    allowed_agents: list[str] | None = None
 
 
 # --- Tests ----------------------------------------------------------------
+
 
 def test_none_allowed_requested_in_roster():
     gi = _StubGatewayInfo(agents={"x": None})

--- a/tests/unit/test_bridge_barge_in.py
+++ b/tests/unit/test_bridge_barge_in.py
@@ -1,11 +1,14 @@
 """Tests for barge-in: _cancel_active_turn, _on_transcription, close_all."""
+
 import asyncio
 import logging
-import pytest
 from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from src.models.schemas import Client, ClientConfig, Handshake
 from src.services.bridge import JotaBridge
 from src.services.openclaw.registry import ClientRegistry
-from src.models.schemas import Client, ClientConfig, Handshake
 
 _CLIENT = Client(id="test-uuid", client_key="test-key", is_active=True)
 _CONFIG = ClientConfig()
@@ -17,18 +20,30 @@ def make_bridge(mock_tracker):
         if output_mode is None:
             output_mode = ["audio", "text", "status"]
         ws = AsyncMock()
-        bridge = JotaBridge(client=_CLIENT, config=_CONFIG, client_ws=ws, orchestrator=AsyncMock(), tts=AsyncMock(), tracker=mock_tracker,
-                            handshake=Handshake(client_key="test-key", input_mode=input_mode, output_mode=output_mode),
-                            client_registry=ClientRegistry(), default_agent="main")
+        bridge = JotaBridge(
+            client=_CLIENT,
+            config=_CONFIG,
+            client_ws=ws,
+            orchestrator=AsyncMock(),
+            tts=AsyncMock(),
+            tracker=mock_tracker,
+            handshake=Handshake(
+                client_key="test-key", input_mode=input_mode, output_mode=output_mode
+            ),
+            client_registry=ClientRegistry(),
+            default_agent="main",
+        )
         bridge.orchestrator = AsyncMock()
         bridge.orchestrator.close = AsyncMock()
         bridge.transcriber = MagicMock()
         bridge.transcriber.close = AsyncMock()
         return bridge
+
     return _make
 
 
 # ── _cancel_active_turn ──────────────────────────────────────────────────────
+
 
 async def test_cancel_active_turn_returns_false_when_no_task(make_bridge):
     bridge = make_bridge()
@@ -42,7 +57,9 @@ async def test_cancel_active_turn_returns_false_when_no_task(make_bridge):
 async def test_cancel_active_turn_returns_false_when_task_already_done(make_bridge):
     bridge = make_bridge()
 
-    async def quick(): pass
+    async def quick():
+        pass
+
     bridge._active_turn = asyncio.create_task(quick())
     await asyncio.sleep(0)  # let task complete naturally
     assert bridge._active_turn.done()
@@ -75,6 +92,7 @@ async def test_cancel_active_turn_clears_active_turn(make_bridge):
 
 # ── _on_transcription ────────────────────────────────────────────────────────
 
+
 async def test_partial_below_threshold_forwarded_but_no_barge_in(make_bridge):
     """Partials shorter than BARGE_IN_MIN_CHARS are forwarded to client but don't trigger barge-in."""
     bridge = make_bridge()
@@ -82,7 +100,9 @@ async def test_partial_below_threshold_forwarded_but_no_barge_in(make_bridge):
 
     await bridge._on_transcription("hi", False)  # 2 chars
 
-    bridge.client_ws.send_json.assert_called_once_with({"type": "transcription_partial", "text": "hi"})
+    bridge.client_ws.send_json.assert_called_once_with(
+        {"type": "transcription_partial", "text": "hi"}
+    )
     assert bridge._active_turn is None
 
 
@@ -92,7 +112,9 @@ async def test_partial_above_threshold_with_no_active_turn_forwarded_only(make_b
 
     await bridge._on_transcription("hello world", False)
 
-    bridge.client_ws.send_json.assert_called_once_with({"type": "transcription_partial", "text": "hello world"})
+    bridge.client_ws.send_json.assert_called_once_with(
+        {"type": "transcription_partial", "text": "hello world"}
+    )
     assert bridge._active_turn is None
 
 
@@ -164,11 +186,7 @@ async def test_final_transcription_is_debug_only_and_truncated(make_bridge, capl
     with caplog.at_level(logging.DEBUG, logger="src.services.bridge"):
         await bridge._on_transcription(text, True)
 
-    records = [
-        record
-        for record in caplog.records
-        if "Transcripción final:" in record.getMessage()
-    ]
+    records = [record for record in caplog.records if "Transcripción final:" in record.getMessage()]
     assert len(records) == 1
     assert records[0].levelno == logging.DEBUG
     assert text[:40] in records[0].getMessage()
@@ -226,6 +244,7 @@ async def test_barge_in_interrupted_send_failure_is_silent(make_bridge):
 
 # ── close_all ────────────────────────────────────────────────────────────────
 
+
 async def test_close_all_awaits_active_turn(make_bridge):
     """close_all() awaits _active_turn to completion (does not cancel it),
     so the orchestrator response is delivered before tearing down clients."""
@@ -247,11 +266,22 @@ async def test_close_all_awaits_active_turn(make_bridge):
 async def test_barge_in_uses_config_threshold_not_global(mock_tracker):
     """Bridge uses config.barge_in_min_chars, not settings.BARGE_IN_MIN_CHARS."""
     from src.models.schemas import ClientConfig
+
     ws = AsyncMock()
     config = ClientConfig(barge_in_min_chars=50)
-    bridge = JotaBridge(client=_CLIENT, config=config, client_ws=ws, orchestrator=AsyncMock(), tts=AsyncMock(), tracker=mock_tracker,
-                        handshake=Handshake(client_key="test-key", input_mode="audio", output_mode=["audio", "text", "status"]),
-                        client_registry=ClientRegistry(), default_agent="main")
+    bridge = JotaBridge(
+        client=_CLIENT,
+        config=config,
+        client_ws=ws,
+        orchestrator=AsyncMock(),
+        tts=AsyncMock(),
+        tracker=mock_tracker,
+        handshake=Handshake(
+            client_key="test-key", input_mode="audio", output_mode=["audio", "text", "status"]
+        ),
+        client_registry=ClientRegistry(),
+        default_agent="main",
+    )
     bridge._active_turn = asyncio.create_task(asyncio.sleep(60))
     await asyncio.sleep(0)
 
@@ -271,11 +301,22 @@ async def test_barge_in_uses_config_threshold_not_global(mock_tracker):
 async def test_barge_in_triggers_when_above_custom_threshold(mock_tracker):
     """Barge-in fires when partial >= config.barge_in_min_chars."""
     from src.models.schemas import ClientConfig
+
     ws = AsyncMock()
     config = ClientConfig(barge_in_min_chars=3)
-    bridge = JotaBridge(client=_CLIENT, config=config, client_ws=ws, orchestrator=AsyncMock(), tts=AsyncMock(), tracker=mock_tracker,
-                        handshake=Handshake(client_key="test-key", input_mode="audio", output_mode=["audio", "text", "status"]),
-                        client_registry=ClientRegistry(), default_agent="main")
+    bridge = JotaBridge(
+        client=_CLIENT,
+        config=config,
+        client_ws=ws,
+        orchestrator=AsyncMock(),
+        tts=AsyncMock(),
+        tracker=mock_tracker,
+        handshake=Handshake(
+            client_key="test-key", input_mode="audio", output_mode=["audio", "text", "status"]
+        ),
+        client_registry=ClientRegistry(),
+        default_agent="main",
+    )
     bridge._active_turn = asyncio.create_task(asyncio.sleep(60))
     await asyncio.sleep(0)
 
@@ -289,11 +330,22 @@ async def test_barge_in_disabled_forwards_partial_but_does_not_cancel(mock_track
     """#108: barge_in_enabled=False → partial still forwarded, but no cancellation
     and no 'interrupted' message, even when text is above barge_in_min_chars."""
     from src.models.schemas import ClientConfig
+
     ws = AsyncMock()
     config = ClientConfig(barge_in_enabled=False, barge_in_min_chars=3)
-    bridge = JotaBridge(client=_CLIENT, config=config, client_ws=ws, orchestrator=AsyncMock(), tts=AsyncMock(), tracker=mock_tracker,
-                        handshake=Handshake(client_key="test-key", input_mode="audio", output_mode=["audio", "text", "status"]),
-                        client_registry=ClientRegistry(), default_agent="main")
+    bridge = JotaBridge(
+        client=_CLIENT,
+        config=config,
+        client_ws=ws,
+        orchestrator=AsyncMock(),
+        tts=AsyncMock(),
+        tracker=mock_tracker,
+        handshake=Handshake(
+            client_key="test-key", input_mode="audio", output_mode=["audio", "text", "status"]
+        ),
+        client_registry=ClientRegistry(),
+        default_agent="main",
+    )
     bridge._active_turn = asyncio.create_task(asyncio.sleep(60))
     await asyncio.sleep(0)
 
@@ -315,16 +367,19 @@ async def test_barge_in_disabled_forwards_partial_but_does_not_cancel(mock_track
 
 # ── _on_transcriber_warning ──────────────────────────────────────────────────
 
+
 async def test_transcriber_warning_forwarded_to_client(make_bridge):
     bridge = make_bridge()
     await bridge._on_transcriber_warning("buffer_full", "Buffer full")
-    bridge.client_ws.send_json.assert_called_once_with({
-        "type": "status",
-        "service": "transcriber",
-        "state": "degraded",
-        "code": "buffer_full",
-        "message": "Buffer full",
-    })
+    bridge.client_ws.send_json.assert_called_once_with(
+        {
+            "type": "status",
+            "service": "transcriber",
+            "state": "degraded",
+            "code": "buffer_full",
+            "message": "Buffer full",
+        }
+    )
 
 
 async def test_transcriber_warning_uses_code_when_no_message(make_bridge):

--- a/tests/unit/test_bridge_close_all.py
+++ b/tests/unit/test_bridge_close_all.py
@@ -7,14 +7,15 @@ its own internal finally before that outer finally runs — so close_all()
 must tolerate being called twice without duplicating side effects, and the
 first call's status must win.
 """
-import asyncio
 
-import pytest
+import asyncio
 from unittest.mock import AsyncMock
 
+import pytest
+
+from src.models.schemas import Client, ClientConfig, Handshake
 from src.services.bridge import JotaBridge
 from src.services.openclaw.registry import ClientRegistry
-from src.models.schemas import Client, ClientConfig, Handshake
 
 _CLIENT = Client(id="test-uuid", client_key="test-key", is_active=True)
 _CONFIG = ClientConfig()
@@ -25,10 +26,15 @@ def bridge(mock_tracker):
     ws = AsyncMock()
     registry = ClientRegistry()
     b = JotaBridge(
-        client=_CLIENT, config=_CONFIG, client_ws=ws, orchestrator=AsyncMock(),
-        tts=AsyncMock(), tracker=mock_tracker,
+        client=_CLIENT,
+        config=_CONFIG,
+        client_ws=ws,
+        orchestrator=AsyncMock(),
+        tts=AsyncMock(),
+        tracker=mock_tracker,
         handshake=Handshake(client_key="test-key", input_mode="text", output_mode=["text"]),
-        client_registry=registry, default_agent="main",
+        client_registry=registry,
+        default_agent="main",
     )
     registry.register(b.client_id, b)
     return b
@@ -114,10 +120,15 @@ async def test_late_close_of_old_bridge_keeps_reconnected_session(mock_tracker):
 
     def _make_bridge():
         return JotaBridge(
-            client=_CLIENT, config=_CONFIG, client_ws=AsyncMock(),
-            orchestrator=AsyncMock(), tts=AsyncMock(), tracker=mock_tracker,
+            client=_CLIENT,
+            config=_CONFIG,
+            client_ws=AsyncMock(),
+            orchestrator=AsyncMock(),
+            tts=AsyncMock(),
+            tracker=mock_tracker,
             handshake=Handshake(client_key="test-key", input_mode="text", output_mode=["text"]),
-            client_registry=registry, default_agent="main",
+            client_registry=registry,
+            default_agent="main",
         )
 
     old_bridge = _make_bridge()

--- a/tests/unit/test_bridge_disconnect.py
+++ b/tests/unit/test_bridge_disconnect.py
@@ -1,9 +1,12 @@
 """Tests for _client_input_loop raw disconnect handling."""
-import pytest
+
 from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from src.models.schemas import Client, ClientConfig, Handshake
 from src.services.bridge import JotaBridge
 from src.services.openclaw.registry import ClientRegistry
-from src.models.schemas import Client, ClientConfig, Handshake
 
 _CLIENT = Client(id="test-uuid", client_key="test-key", is_active=True)
 _CONFIG = ClientConfig()
@@ -12,9 +15,17 @@ _CONFIG = ClientConfig()
 @pytest.fixture
 def bridge(mock_tracker):
     ws = AsyncMock()
-    b = JotaBridge(client=_CLIENT, config=_CONFIG, client_ws=ws, orchestrator=AsyncMock(), tts=AsyncMock(), tracker=mock_tracker,
-                   handshake=Handshake(client_key="test-key", input_mode="audio", output_mode=["text"]),
-                   client_registry=ClientRegistry(), default_agent="main")
+    b = JotaBridge(
+        client=_CLIENT,
+        config=_CONFIG,
+        client_ws=ws,
+        orchestrator=AsyncMock(),
+        tts=AsyncMock(),
+        tracker=mock_tracker,
+        handshake=Handshake(client_key="test-key", input_mode="audio", output_mode=["text"]),
+        client_registry=ClientRegistry(),
+        default_agent="main",
+    )
     b.transcriber = MagicMock()
     b.transcriber._is_ready = True
     return b
@@ -22,9 +33,7 @@ def bridge(mock_tracker):
 
 async def test_raw_disconnect_message_exits_loop_cleanly(bridge):
     """{"type":"websocket.disconnect"} must break the loop without raising."""
-    bridge.client_ws.receive = AsyncMock(
-        return_value={"type": "websocket.disconnect"}
-    )
+    bridge.client_ws.receive = AsyncMock(return_value={"type": "websocket.disconnect"})
 
     # Must complete without exception
     await bridge._client_input_loop()
@@ -36,9 +45,8 @@ async def test_raw_disconnect_message_exits_loop_cleanly(bridge):
 async def test_raw_disconnect_does_not_log_error(bridge, caplog):
     """Raw disconnect must not produce an ERROR log entry."""
     import logging
-    bridge.client_ws.receive = AsyncMock(
-        return_value={"type": "websocket.disconnect"}
-    )
+
+    bridge.client_ws.receive = AsyncMock(return_value={"type": "websocket.disconnect"})
 
     with caplog.at_level(logging.ERROR):
         await bridge._client_input_loop()
@@ -51,10 +59,12 @@ async def test_audio_message_is_still_processed(bridge):
     """bytes messages are still forwarded to the transcriber after the fix."""
     audio = b"\x00\x01\x02"
     bridge.transcriber.send_audio = AsyncMock()
-    bridge.client_ws.receive = AsyncMock(side_effect=[
-        {"bytes": audio},
-        {"type": "websocket.disconnect"},
-    ])
+    bridge.client_ws.receive = AsyncMock(
+        side_effect=[
+            {"bytes": audio},
+            {"type": "websocket.disconnect"},
+        ]
+    )
 
     await bridge._client_input_loop()
 

--- a/tests/unit/test_bridge_health_check.py
+++ b/tests/unit/test_bridge_health_check.py
@@ -1,9 +1,10 @@
-"""Tests for JotaBridge.health_check() — four paths."""
+"""Tests for JotaBridge.health_check() snapshot."""
 from unittest.mock import AsyncMock, MagicMock, patch
 from src.services.bridge import JotaBridge
 from src.services.openclaw.registry import ClientRegistry
 from src.models.schemas import Client, ClientConfig, Handshake
 from src.services.pipeline_tracker import PipelineTracker, _NullWS
+from src.services.reconnection import ConnectionState
 
 _CLIENT = Client(id="hab_sito", client_key="test-key", is_active=True)
 _CONFIG = ClientConfig()
@@ -28,44 +29,63 @@ def _make_bridge(input_mode="text", output_mode=None):
     return bridge, ws, orch
 
 
-async def test_health_check_returns_true_when_all_ok():
-    bridge, ws, orch = _make_bridge()
-    result = await bridge.health_check()
-    assert result is True
+async def test_health_check_returns_full_snapshot_when_audio_and_tts_ok():
+    bridge, ws, orch = _make_bridge(input_mode="audio", output_mode=["audio", "text"])
+    bridge.transcriber = MagicMock()
+    bridge.transcriber.state = ConnectionState.CONNECTED
+
+    with patch("src.services.bridge.TTSClient.ping", new=AsyncMock(return_value=True)):
+        result = await bridge.health_check()
+
+    assert result == {"barge_in": True, "tts": True, "transcriber": True}
 
 
-async def test_health_check_returns_false_when_orchestrator_unavailable():
-    bridge, ws, orch = _make_bridge()
-    orch.ping = AsyncMock(return_value=False)
-    result = await bridge.health_check()
-    assert result is False
-    ws.send_json.assert_called_once()
-    payload = ws.send_json.call_args[0][0]
-    assert payload["type"] == "status"
-    assert payload["service"] == "orchestrator"
-    assert payload["state"] == "unavailable"
+async def test_health_check_returns_tts_false_when_ping_fails():
+    bridge, ws, orch = _make_bridge(input_mode="audio", output_mode=["audio", "text"])
+    bridge.transcriber = MagicMock()
+    bridge.transcriber.state = ConnectionState.CONNECTED
+
+    with patch("src.services.bridge.TTSClient.ping", new=AsyncMock(return_value=False)):
+        result = await bridge.health_check()
+
+    assert result == {"barge_in": True, "tts": False, "transcriber": True}
+    status_calls = [c.args[0] for c in ws.send_json.call_args_list]
+    assert any(
+        call["type"] == "status" and call["service"] == "tts" and call["state"] == "unavailable"
+        for call in status_calls
+    )
 
 
-async def test_health_check_transcriber_unavailable_still_returns_true():
-    """Transcriber down no longer closes the session — client decides (issue #46)."""
-    from src.services.reconnection import ConnectionState
-    bridge, ws, orch = _make_bridge(input_mode="audio")
+async def test_health_check_returns_transcriber_false_when_degraded():
+    bridge, ws, orch = _make_bridge(input_mode="audio", output_mode=["audio", "text"])
     bridge.transcriber = MagicMock()
     bridge.transcriber.state = ConnectionState.DEGRADED
+
     result = await bridge.health_check()
-    assert result is True
-    payload = ws.send_json.call_args[0][0]
-    assert payload["type"] == "status"
-    assert payload["service"] == "transcriber"
-    assert payload["state"] == "unavailable"
+
+    assert result == {"barge_in": False, "tts": False, "transcriber": False}
+    status_calls = [c.args[0] for c in ws.send_json.call_args_list]
+    assert any(
+        call["type"] == "status" and call["service"] == "transcriber" and call["state"] == "unavailable"
+        for call in status_calls
+    )
 
 
-async def test_health_check_tts_unavailable_still_returns_true():
-    bridge, ws, orch = _make_bridge(output_mode=["audio", "text"])
-    with patch("src.services.tts_client.TTSClient.ping", new=AsyncMock(return_value=False)):
-        result = await bridge.health_check()
-    assert result is True
-    payload = ws.send_json.call_args[0][0]
-    assert payload["type"] == "status"
-    assert payload["service"] == "tts"
-    assert payload["state"] == "unavailable"
+async def test_health_check_returns_all_false_for_text_only_handshake():
+    bridge, ws, orch = _make_bridge(input_mode="text", output_mode=["text"])
+    bridge.transcriber = None
+
+    result = await bridge.health_check()
+
+    assert result == {"barge_in": False, "tts": False, "transcriber": False}
+
+
+async def test_health_check_returns_none_when_orchestrator_unavailable():
+    bridge, ws, orch = _make_bridge()
+    orch.ping = AsyncMock(return_value=False)
+
+    result = await bridge.health_check()
+
+    assert result is None
+    payload = ws.send_json.call_args_list[0].args[0]
+    assert payload == {"type": "status", "service": "orchestrator", "state": "unavailable"}

--- a/tests/unit/test_bridge_health_check.py
+++ b/tests/unit/test_bridge_health_check.py
@@ -57,7 +57,7 @@ async def test_health_check_returns_tts_false_when_ping_fails():
 
 
 async def test_health_check_returns_transcriber_false_when_degraded():
-    bridge, ws, orch = _make_bridge(input_mode="audio", output_mode=["audio", "text"])
+    bridge, ws, orch = _make_bridge(input_mode="audio", output_mode=["text"])
     bridge.transcriber = MagicMock()
     bridge.transcriber.state = ConnectionState.DEGRADED
 

--- a/tests/unit/test_bridge_health_check.py
+++ b/tests/unit/test_bridge_health_check.py
@@ -1,8 +1,10 @@
 """Tests for JotaBridge.health_check() snapshot."""
+
 from unittest.mock import AsyncMock, MagicMock, patch
+
+from src.models.schemas import Client, ClientConfig, Handshake
 from src.services.bridge import JotaBridge
 from src.services.openclaw.registry import ClientRegistry
-from src.models.schemas import Client, ClientConfig, Handshake
 from src.services.pipeline_tracker import PipelineTracker, _NullWS
 from src.services.reconnection import ConnectionState
 
@@ -16,16 +18,27 @@ def _make_bridge(input_mode="text", output_mode=None):
     ws = AsyncMock()
     registry = MagicMock()
     tracker = PipelineTracker(
-        session_id="test:hc", client_id="hab_sito",
-        input_mode=input_mode, output_mode=output_mode,
-        client_ws=_NullWS(), registry=registry,
+        session_id="test:hc",
+        client_id="hab_sito",
+        input_mode=input_mode,
+        output_mode=output_mode,
+        client_ws=_NullWS(),
+        registry=registry,
     )
     handshake = Handshake(client_key="test-key", input_mode=input_mode, output_mode=output_mode)
     orch = AsyncMock()
     orch.ping = AsyncMock(return_value=True)
-    bridge = JotaBridge(client=_CLIENT, config=_CONFIG, client_ws=ws,
-                        orchestrator=orch, tts=AsyncMock(), tracker=tracker, handshake=handshake,
-                        client_registry=ClientRegistry(), default_agent="main")
+    bridge = JotaBridge(
+        client=_CLIENT,
+        config=_CONFIG,
+        client_ws=ws,
+        orchestrator=orch,
+        tts=AsyncMock(),
+        tracker=tracker,
+        handshake=handshake,
+        client_registry=ClientRegistry(),
+        default_agent="main",
+    )
     return bridge, ws, orch
 
 
@@ -66,7 +79,9 @@ async def test_health_check_returns_transcriber_false_when_degraded():
     assert result == {"barge_in": False, "tts": False, "transcriber": False}
     status_calls = [c.args[0] for c in ws.send_json.call_args_list]
     assert any(
-        call["type"] == "status" and call["service"] == "transcriber" and call["state"] == "unavailable"
+        call["type"] == "status"
+        and call["service"] == "transcriber"
+        and call["state"] == "unavailable"
         for call in status_calls
     )
 

--- a/tests/unit/test_bridge_input_loop.py
+++ b/tests/unit/test_bridge_input_loop.py
@@ -1,9 +1,10 @@
 import asyncio
 import json
 from unittest.mock import AsyncMock, MagicMock
+
+from src.models.schemas import Client, ClientConfig, Handshake
 from src.services.bridge import JotaBridge
 from src.services.openclaw.registry import ClientRegistry
-from src.models.schemas import Client, ClientConfig, Handshake
 from src.services.pipeline_tracker import PipelineTracker, _NullWS
 
 _CLIENT = Client(id="hab_sito", client_key="test-key", is_active=True)
@@ -14,16 +15,27 @@ def _make_bridge(input_mode="audio"):
     ws = AsyncMock()
     registry = MagicMock()
     tracker = PipelineTracker(
-        session_id="test:loop", client_id="hab_sito",
-        input_mode=input_mode, output_mode=["text"],
-        client_ws=_NullWS(), registry=registry,
+        session_id="test:loop",
+        client_id="hab_sito",
+        input_mode=input_mode,
+        output_mode=["text"],
+        client_ws=_NullWS(),
+        registry=registry,
     )
     handshake = Handshake(client_key="test-key", input_mode=input_mode, output_mode=["text"])
     orch = AsyncMock()
     transcriber = AsyncMock()
-    bridge = JotaBridge(client=_CLIENT, config=_CONFIG, client_ws=ws,
-                        orchestrator=orch, tts=AsyncMock(), tracker=tracker, handshake=handshake,
-                        client_registry=ClientRegistry(), default_agent="main")
+    bridge = JotaBridge(
+        client=_CLIENT,
+        config=_CONFIG,
+        client_ws=ws,
+        orchestrator=orch,
+        tts=AsyncMock(),
+        tracker=tracker,
+        handshake=handshake,
+        client_registry=ClientRegistry(),
+        default_agent="main",
+    )
     bridge.transcriber = transcriber
     return bridge, ws, transcriber
 
@@ -31,10 +43,12 @@ def _make_bridge(input_mode="audio"):
 async def test_end_message_calls_transcriber_send_end_in_audio_mode():
     bridge, ws, transcriber = _make_bridge(input_mode="audio")
     # Simulate receiving {"type":"end"} then disconnect
-    ws.receive = AsyncMock(side_effect=[
-        {"type": "websocket.message", "text": json.dumps({"type": "end"})},
-        {"type": "websocket.disconnect"},
-    ])
+    ws.receive = AsyncMock(
+        side_effect=[
+            {"type": "websocket.message", "text": json.dumps({"type": "end"})},
+            {"type": "websocket.disconnect"},
+        ]
+    )
     await bridge._client_input_loop()
     transcriber.send_end.assert_called_once()
 
@@ -42,10 +56,12 @@ async def test_end_message_calls_transcriber_send_end_in_audio_mode():
 async def test_end_message_ignored_in_text_mode():
     bridge, ws, transcriber = _make_bridge(input_mode="text")
     bridge.transcriber = None
-    ws.receive = AsyncMock(side_effect=[
-        {"type": "websocket.message", "text": json.dumps({"type": "end"})},
-        {"type": "websocket.disconnect"},
-    ])
+    ws.receive = AsyncMock(
+        side_effect=[
+            {"type": "websocket.message", "text": json.dumps({"type": "end"})},
+            {"type": "websocket.disconnect"},
+        ]
+    )
     await bridge._client_input_loop()
     # no transcriber → no send_end call, no crash
 
@@ -54,10 +70,12 @@ async def test_send_message_dispatches_to_orchestrator():
     bridge, ws, transcriber = _make_bridge(input_mode="audio")
     bridge._active_turn = None
 
-    ws.receive = AsyncMock(side_effect=[
-        {"type": "websocket.message", "text": json.dumps({"type": "send", "text": "hola"})},
-        {"type": "websocket.disconnect"},
-    ])
+    ws.receive = AsyncMock(
+        side_effect=[
+            {"type": "websocket.message", "text": json.dumps({"type": "send", "text": "hola"})},
+            {"type": "websocket.disconnect"},
+        ]
+    )
     await bridge._client_input_loop()
     # _active_turn should have been created
     assert bridge._active_turn is not None
@@ -70,10 +88,12 @@ async def test_plain_text_sets_active_turn():
     bridge.transcriber = None
     bridge._active_turn = None
 
-    ws.receive = AsyncMock(side_effect=[
-        {"type": "websocket.message", "text": "hola mundo"},
-        {"type": "websocket.disconnect"},
-    ])
+    ws.receive = AsyncMock(
+        side_effect=[
+            {"type": "websocket.message", "text": "hola mundo"},
+            {"type": "websocket.disconnect"},
+        ]
+    )
 
     await bridge._client_input_loop()
 
@@ -96,10 +116,12 @@ async def test_plain_text_cancels_previous_active_turn():
     first_task = asyncio.create_task(_blocking())
     bridge._active_turn = first_task
 
-    ws.receive = AsyncMock(side_effect=[
-        {"type": "websocket.message", "text": "nuevo mensaje"},
-        {"type": "websocket.disconnect"},
-    ])
+    ws.receive = AsyncMock(
+        side_effect=[
+            {"type": "websocket.message", "text": "nuevo mensaje"},
+            {"type": "websocket.disconnect"},
+        ]
+    )
 
     await bridge._client_input_loop()
 
@@ -121,10 +143,12 @@ async def test_cancel_message_cancels_active_turn_without_new_turn():
     active = asyncio.create_task(_blocking())
     bridge._active_turn = active
 
-    ws.receive = AsyncMock(side_effect=[
-        {"type": "websocket.message", "text": json.dumps({"type": "cancel"})},
-        {"type": "websocket.disconnect"},
-    ])
+    ws.receive = AsyncMock(
+        side_effect=[
+            {"type": "websocket.message", "text": json.dumps({"type": "cancel"})},
+            {"type": "websocket.disconnect"},
+        ]
+    )
 
     await bridge._client_input_loop()
 
@@ -137,10 +161,12 @@ async def test_cancel_message_with_no_active_turn_is_harmless():
     bridge, ws, _ = _make_bridge(input_mode="audio")
     bridge._active_turn = None
 
-    ws.receive = AsyncMock(side_effect=[
-        {"type": "websocket.message", "text": json.dumps({"type": "cancel"})},
-        {"type": "websocket.disconnect"},
-    ])
+    ws.receive = AsyncMock(
+        side_effect=[
+            {"type": "websocket.message", "text": json.dumps({"type": "cancel"})},
+            {"type": "websocket.disconnect"},
+        ]
+    )
 
     await bridge._client_input_loop()  # no debe lanzar
 
@@ -158,10 +184,12 @@ async def test_second_send_cancels_first_active_turn():
     first_task = asyncio.create_task(_blocking())
     bridge._active_turn = first_task
 
-    ws.receive = AsyncMock(side_effect=[
-        {"type": "websocket.message", "text": json.dumps({"type": "send", "text": "segundo"})},
-        {"type": "websocket.disconnect"},
-    ])
+    ws.receive = AsyncMock(
+        side_effect=[
+            {"type": "websocket.message", "text": json.dumps({"type": "send", "text": "segundo"})},
+            {"type": "websocket.disconnect"},
+        ]
+    )
 
     await bridge._client_input_loop()
 

--- a/tests/unit/test_bridge_push.py
+++ b/tests/unit/test_bridge_push.py
@@ -1,10 +1,11 @@
-import pytest
 from unittest.mock import AsyncMock
 
+import pytest
+
+from src.models.schemas import Client, ClientConfig, Handshake
 from src.services.bridge import JotaBridge
 from src.services.openclaw.registry import ClientRegistry
 from src.services.reconnection import ConnectionState, ServiceStatus
-from src.models.schemas import Client, ClientConfig, Handshake
 
 
 def _connected_status() -> ServiceStatus:
@@ -13,8 +14,11 @@ def _connected_status() -> ServiceStatus:
     also stub tts.status() as a plain callable, or _maybe_notify_tts_state()
     receives an unawaited coroutine instead of a ServiceStatus."""
     return ServiceStatus(
-        name="tts", state=ConnectionState.CONNECTED,
-        connected_at=None, reconnect_attempts=0, last_error=None,
+        name="tts",
+        state=ConnectionState.CONNECTED,
+        connected_at=None,
+        reconnect_attempts=0,
+        last_error=None,
     )
 
 
@@ -36,9 +40,15 @@ def make_bridge(output_mode=("text",), client_id="hab_sito", tts=None):
         tts = AsyncMock()
         tts.connect = AsyncMock(return_value=None)
     bridge = JotaBridge(
-        client=client, config=config, client_ws=ws,
-        orchestrator=orchestrator, tts=tts, tracker=tracker, handshake=handshake,
-        client_registry=client_registry, default_agent="main",
+        client=client,
+        config=config,
+        client_ws=ws,
+        orchestrator=orchestrator,
+        tts=tts,
+        tracker=tracker,
+        handshake=handshake,
+        client_registry=client_registry,
+        default_agent="main",
     )
     return bridge, client_registry
 
@@ -66,11 +76,13 @@ async def test_deliver_push_text_sends_push_message():
     bridge._push_turn_open = True
     payload = {"sessionKey": "agent:main:hab_sito", "deltaText": "Buenos días!"}
     await bridge.deliver_push(payload)
-    bridge.client_ws.send_json.assert_awaited_once_with({
-        "type": "token",
-        "turn_id": "t-1",
-        "text": "Buenos días!",
-    })
+    bridge.client_ws.send_json.assert_awaited_once_with(
+        {
+            "type": "token",
+            "turn_id": "t-1",
+            "text": "Buenos días!",
+        }
+    )
 
 
 @pytest.mark.asyncio
@@ -127,6 +139,7 @@ async def test_on_push_turn_start_audio_creates_tts_and_pipe():
 async def test_push_audio_pipe_forwards_chunks_with_header():
     """Audio chunks from TTS include [0xA1][turn_seq uint16 BE] header."""
     import asyncio
+
     chunks = [b"\x00\x01", b"\x02\x03"]
     mock_tts_client = AsyncMock()
     mock_tts_client.get_audio_stream = lambda: aiter(chunks)
@@ -148,11 +161,13 @@ async def test_on_push_turn_start_sends_turn_start_message():
     """on_push_turn_start sends turn_start JSON message to client."""
     bridge, _ = make_bridge(output_mode=("text",))
     await bridge.on_push_turn_start("agent:main:hab_sito")
-    bridge.client_ws.send_json.assert_awaited_once_with({
-        "type": "turn_start",
-        "turn_id": "t-1",
-        "turn_seq": 1,
-    })
+    bridge.client_ws.send_json.assert_awaited_once_with(
+        {
+            "type": "turn_start",
+            "turn_id": "t-1",
+            "turn_seq": 1,
+        }
+    )
 
 
 @pytest.mark.asyncio
@@ -160,12 +175,16 @@ async def test_on_push_turn_end_sends_turn_end_message():
     """on_push_turn_end sends turn_end JSON message to client."""
     bridge, _ = make_bridge(output_mode=("text",))
     bridge._push_turn_id = "t-1"
-    bridge._push_turn_open = True  # a turn_end is only valid if a turn_start came before (issue #84)
+    bridge._push_turn_open = (
+        True  # a turn_end is only valid if a turn_start came before (issue #84)
+    )
     await bridge.on_push_turn_end("agent:main:hab_sito")
-    bridge.client_ws.send_json.assert_awaited_once_with({
-        "type": "turn_end",
-        "turn_id": "t-1",
-    })
+    bridge.client_ws.send_json.assert_awaited_once_with(
+        {
+            "type": "turn_end",
+            "turn_id": "t-1",
+        }
+    )
 
 
 @pytest.mark.asyncio
@@ -196,9 +215,15 @@ async def test_push_disabled_ignores_push_turn_start():
     ws = AsyncMock()
     handshake = Handshake(client_key="ha-key", input_mode="text", output_mode=["text"])
     bridge = JotaBridge(
-        client=client, config=config, client_ws=ws,
-        orchestrator=AsyncMock(), tts=AsyncMock(), tracker=AsyncMock(), handshake=handshake,
-        client_registry=ClientRegistry(), default_agent="main",
+        client=client,
+        config=config,
+        client_ws=ws,
+        orchestrator=AsyncMock(),
+        tts=AsyncMock(),
+        tracker=AsyncMock(),
+        handshake=handshake,
+        client_registry=ClientRegistry(),
+        default_agent="main",
     )
     await bridge.on_push_turn_start("agent:main:ha")
     ws.send_json.assert_not_awaited()
@@ -210,21 +235,36 @@ async def test_deliver_push_tool_call_forwarded_when_enabled():
     client = Client(id="hab_sito", client_key="key-123", is_active=True)
     config = ClientConfig(tool_calls_enabled=True)
     ws = AsyncMock()
-    handshake = Handshake(client_key="key-123", input_mode="text", output_mode=["text"], agent="main")
+    handshake = Handshake(
+        client_key="key-123", input_mode="text", output_mode=["text"], agent="main"
+    )
     bridge = JotaBridge(
-        client=client, config=config, client_ws=ws,
-        orchestrator=AsyncMock(), tts=AsyncMock(), tracker=AsyncMock(), handshake=handshake,
-        client_registry=ClientRegistry(), default_agent="main",
+        client=client,
+        config=config,
+        client_ws=ws,
+        orchestrator=AsyncMock(),
+        tts=AsyncMock(),
+        tracker=AsyncMock(),
+        handshake=handshake,
+        client_registry=ClientRegistry(),
+        default_agent="main",
     )
     bridge._push_turn_id = "t-1"
     bridge._push_turn_open = True
     data = {"phase": "start", "name": "exec", "toolCallId": "call-1", "args": {"command": "ls"}}
     await bridge.deliver_push_tool_call(data)
-    ws.send_json.assert_awaited_once_with({
-        "type": "tool_call", "turn_id": "t-1", "phase": "start",
-        "name": "exec", "tool_call_id": "call-1",
-        "args": {"command": "ls"}, "result": None, "is_error": None,
-    })
+    ws.send_json.assert_awaited_once_with(
+        {
+            "type": "tool_call",
+            "turn_id": "t-1",
+            "phase": "start",
+            "name": "exec",
+            "tool_call_id": "call-1",
+            "args": {"command": "ls"},
+            "result": None,
+            "is_error": None,
+        }
+    )
 
 
 @pytest.mark.asyncio
@@ -232,11 +272,19 @@ async def test_deliver_push_tool_call_not_forwarded_when_disabled():
     client = Client(id="hab_sito", client_key="key-123", is_active=True)
     config = ClientConfig(tool_calls_enabled=False)
     ws = AsyncMock()
-    handshake = Handshake(client_key="key-123", input_mode="text", output_mode=["text"], agent="main")
+    handshake = Handshake(
+        client_key="key-123", input_mode="text", output_mode=["text"], agent="main"
+    )
     bridge = JotaBridge(
-        client=client, config=config, client_ws=ws,
-        orchestrator=AsyncMock(), tts=AsyncMock(), tracker=AsyncMock(), handshake=handshake,
-        client_registry=ClientRegistry(), default_agent="main",
+        client=client,
+        config=config,
+        client_ws=ws,
+        orchestrator=AsyncMock(),
+        tts=AsyncMock(),
+        tracker=AsyncMock(),
+        handshake=handshake,
+        client_registry=ClientRegistry(),
+        default_agent="main",
     )
     bridge._push_turn_id = "t-1"
     bridge._push_turn_open = True
@@ -250,11 +298,19 @@ async def test_deliver_push_tool_call_malformed_payload_ignored():
     client = Client(id="hab_sito", client_key="key-123", is_active=True)
     config = ClientConfig(tool_calls_enabled=True)
     ws = AsyncMock()
-    handshake = Handshake(client_key="key-123", input_mode="text", output_mode=["text"], agent="main")
+    handshake = Handshake(
+        client_key="key-123", input_mode="text", output_mode=["text"], agent="main"
+    )
     bridge = JotaBridge(
-        client=client, config=config, client_ws=ws,
-        orchestrator=AsyncMock(), tts=AsyncMock(), tracker=AsyncMock(), handshake=handshake,
-        client_registry=ClientRegistry(), default_agent="main",
+        client=client,
+        config=config,
+        client_ws=ws,
+        orchestrator=AsyncMock(),
+        tts=AsyncMock(),
+        tracker=AsyncMock(),
+        handshake=handshake,
+        client_registry=ClientRegistry(),
+        default_agent="main",
     )
     bridge._push_turn_id = "t-1"
     bridge._push_turn_open = True
@@ -339,7 +395,8 @@ async def test_first_push_start_assigns_turn_seq_subsequent_does_not():
     # Wire-level check: after 3 starts, the client must see exactly one turn_start.
     # Strengthens the test — without the fix, three start frames would be sent.
     starts = [
-        c.args[0] for c in bridge.client_ws.send_json.await_args_list
+        c.args[0]
+        for c in bridge.client_ws.send_json.await_args_list
         if c.args[0].get("type") == "turn_start"
     ]
     assert len(starts) == 1, f"expected 1 turn_start after 3 starts, got {len(starts)}: {starts}"
@@ -377,11 +434,19 @@ async def test_deliver_push_rejected_when_push_disabled():
     client = Client(id="hab_sito", client_key="key-123", is_active=True)
     config = ClientConfig(push_enabled=False)
     ws = AsyncMock()
-    handshake = Handshake(client_key="key-123", input_mode="text", output_mode=["text"], agent="main")
+    handshake = Handshake(
+        client_key="key-123", input_mode="text", output_mode=["text"], agent="main"
+    )
     bridge = JotaBridge(
-        client=client, config=config, client_ws=ws,
-        orchestrator=AsyncMock(), tts=AsyncMock(), tracker=AsyncMock(), handshake=handshake,
-        client_registry=ClientRegistry(), default_agent="main",
+        client=client,
+        config=config,
+        client_ws=ws,
+        orchestrator=AsyncMock(),
+        tts=AsyncMock(),
+        tracker=AsyncMock(),
+        handshake=handshake,
+        client_registry=ClientRegistry(),
+        default_agent="main",
     )
     bridge._push_turn_id = "t-1"
     bridge._push_turn_open = True  # simulates stale/inconsistent state — must still be blocked
@@ -407,11 +472,19 @@ async def test_deliver_push_tool_call_rejected_when_push_disabled():
     client = Client(id="hab_sito", client_key="key-123", is_active=True)
     config = ClientConfig(push_enabled=False, tool_calls_enabled=True)
     ws = AsyncMock()
-    handshake = Handshake(client_key="key-123", input_mode="text", output_mode=["text"], agent="main")
+    handshake = Handshake(
+        client_key="key-123", input_mode="text", output_mode=["text"], agent="main"
+    )
     bridge = JotaBridge(
-        client=client, config=config, client_ws=ws,
-        orchestrator=AsyncMock(), tts=AsyncMock(), tracker=AsyncMock(), handshake=handshake,
-        client_registry=ClientRegistry(), default_agent="main",
+        client=client,
+        config=config,
+        client_ws=ws,
+        orchestrator=AsyncMock(),
+        tts=AsyncMock(),
+        tracker=AsyncMock(),
+        handshake=handshake,
+        client_registry=ClientRegistry(),
+        default_agent="main",
     )
     bridge._push_turn_id = "t-1"
     bridge._push_turn_open = True
@@ -425,11 +498,19 @@ async def test_deliver_push_tool_call_rejected_when_no_turn_open():
     client = Client(id="hab_sito", client_key="key-123", is_active=True)
     config = ClientConfig(tool_calls_enabled=True)  # push_enabled defaults True
     ws = AsyncMock()
-    handshake = Handshake(client_key="key-123", input_mode="text", output_mode=["text"], agent="main")
+    handshake = Handshake(
+        client_key="key-123", input_mode="text", output_mode=["text"], agent="main"
+    )
     bridge = JotaBridge(
-        client=client, config=config, client_ws=ws,
-        orchestrator=AsyncMock(), tts=AsyncMock(), tracker=AsyncMock(), handshake=handshake,
-        client_registry=ClientRegistry(), default_agent="main",
+        client=client,
+        config=config,
+        client_ws=ws,
+        orchestrator=AsyncMock(),
+        tts=AsyncMock(),
+        tracker=AsyncMock(),
+        handshake=handshake,
+        client_registry=ClientRegistry(),
+        default_agent="main",
     )
     assert bridge._push_turn_open is False
     data = {"phase": "start", "name": "exec", "toolCallId": "call-1", "args": {"command": "ls"}}

--- a/tests/unit/test_bridge_send_guards.py
+++ b/tests/unit/test_bridge_send_guards.py
@@ -1,11 +1,14 @@
 """Tests for send guards in _call_orchestrator closures."""
-import pytest
+
 from unittest.mock import AsyncMock
+
+import pytest
+
+from src.models.schemas import Client, ClientConfig, Handshake
 from src.services.bridge import JotaBridge
+from src.services.openclaw.models import ToolCallEvent
 from src.services.openclaw.registry import ClientRegistry
 from src.services.protocol import OrchestratorEvent
-from src.models.schemas import Client, ClientConfig, Handshake
-from src.services.openclaw.models import ToolCallEvent
 from src.services.reconnection import ConnectionState, ServiceStatus
 
 _CLIENT = Client(id="test-uuid", client_key="test-key", is_active=True)
@@ -18,55 +21,80 @@ def _connected_status() -> ServiceStatus:
     also stub tts.status() as a plain callable, or _maybe_notify_tts_state()
     receives an unawaited coroutine instead of a ServiceStatus."""
     return ServiceStatus(
-        name="tts", state=ConnectionState.CONNECTED,
-        connected_at=None, reconnect_attempts=0, last_error=None,
+        name="tts",
+        state=ConnectionState.CONNECTED,
+        connected_at=None,
+        reconnect_attempts=0,
+        last_error=None,
     )
 
 
 @pytest.fixture
 def bridge(mock_tracker):
     ws = AsyncMock()
-    b = JotaBridge(client=_CLIENT, config=_CONFIG, client_ws=ws, orchestrator=AsyncMock(), tts=AsyncMock(), tracker=mock_tracker,
-                   handshake=Handshake(client_key="test-key", input_mode="text", output_mode=["text", "status"]),
-                   client_registry=ClientRegistry(), default_agent="main")
+    b = JotaBridge(
+        client=_CLIENT,
+        config=_CONFIG,
+        client_ws=ws,
+        orchestrator=AsyncMock(),
+        tts=AsyncMock(),
+        tracker=mock_tracker,
+        handshake=Handshake(
+            client_key="test-key", input_mode="text", output_mode=["text", "status"]
+        ),
+        client_registry=ClientRegistry(),
+        default_agent="main",
+    )
     b.transcriber = None
     return b
 
 
 def make_stream_with_token(token: str):
     """Return an async generator that yields one token event."""
+
     async def _stream(*args, **kwargs):
         yield OrchestratorEvent(type="token", content=token)
+
     return _stream
 
 
 def make_stream_with_event(event_type: str, content: str):
     """Return an async generator that yields one non-token event."""
+
     async def _stream(*args, **kwargs):
         yield OrchestratorEvent(type=event_type, content=content)
+
     return _stream
 
 
 def make_stream_with_tool_call(tool_call: ToolCallEvent):
     async def _stream(*args, **kwargs):
         yield OrchestratorEvent(type="tool_call", tool_call=tool_call)
+
     return _stream
 
 
 async def test_tool_call_forwarded_when_enabled(mock_tracker):
     ws = AsyncMock()
     config = ClientConfig(tool_calls_enabled=True)
-    b = JotaBridge(client=_CLIENT, config=config, client_ws=ws, orchestrator=AsyncMock(), tts=AsyncMock(), tracker=mock_tracker,
-                   handshake=Handshake(client_key="test-key", input_mode="text", output_mode=["text"]),
-                   client_registry=ClientRegistry(), default_agent="main")
+    b = JotaBridge(
+        client=_CLIENT,
+        config=config,
+        client_ws=ws,
+        orchestrator=AsyncMock(),
+        tts=AsyncMock(),
+        tracker=mock_tracker,
+        handshake=Handshake(client_key="test-key", input_mode="text", output_mode=["text"]),
+        client_registry=ClientRegistry(),
+        default_agent="main",
+    )
     tc = ToolCallEvent(phase="start", name="exec", tool_call_id="call-1", args={"command": "ls"})
     b.orchestrator.stream_response = make_stream_with_tool_call(tc)
 
     await b._call_orchestrator("test")
 
     tool_call_msgs = [
-        c.args[0] for c in ws.send_json.await_args_list
-        if c.args[0].get("type") == "tool_call"
+        c.args[0] for c in ws.send_json.await_args_list if c.args[0].get("type") == "tool_call"
     ]
     assert len(tool_call_msgs) == 1
     assert tool_call_msgs[0]["phase"] == "start"
@@ -79,17 +107,24 @@ async def test_tool_call_forwarded_when_enabled(mock_tracker):
 async def test_tool_call_not_forwarded_when_disabled(mock_tracker):
     ws = AsyncMock()
     config = ClientConfig(tool_calls_enabled=False)
-    b = JotaBridge(client=_CLIENT, config=config, client_ws=ws, orchestrator=AsyncMock(), tts=AsyncMock(), tracker=mock_tracker,
-                   handshake=Handshake(client_key="test-key", input_mode="text", output_mode=["text"]),
-                   client_registry=ClientRegistry(), default_agent="main")
+    b = JotaBridge(
+        client=_CLIENT,
+        config=config,
+        client_ws=ws,
+        orchestrator=AsyncMock(),
+        tts=AsyncMock(),
+        tracker=mock_tracker,
+        handshake=Handshake(client_key="test-key", input_mode="text", output_mode=["text"]),
+        client_registry=ClientRegistry(),
+        default_agent="main",
+    )
     tc = ToolCallEvent(phase="start", name="exec", tool_call_id="call-1", args={"command": "ls"})
     b.orchestrator.stream_response = make_stream_with_tool_call(tc)
 
     await b._call_orchestrator("test")
 
     tool_call_msgs = [
-        c.args[0] for c in ws.send_json.await_args_list
-        if c.args[0].get("type") == "tool_call"
+        c.args[0] for c in ws.send_json.await_args_list if c.args[0].get("type") == "tool_call"
     ]
     assert tool_call_msgs == []
 
@@ -118,9 +153,15 @@ async def test_audio_send_failure_does_not_propagate(mock_tracker):
     ws.send_bytes = AsyncMock(side_effect=RuntimeError("disconnected"))
 
     class FakeTTS:
-        async def send_text_chunk(self, t): pass
-        async def end(self): pass
-        async def close(self): pass
+        async def send_text_chunk(self, t):
+            pass
+
+        async def end(self):
+            pass
+
+        async def close(self):
+            pass
+
         async def get_audio_stream(self):
             yield b"\xff\xfe"
 
@@ -128,10 +169,19 @@ async def test_audio_send_failure_does_not_propagate(mock_tracker):
     tts_wrapper.connect = AsyncMock(return_value=FakeTTS())
     tts_wrapper.status = lambda: _connected_status()
 
-    b = JotaBridge(client=_CLIENT, config=_CONFIG, client_ws=ws, orchestrator=AsyncMock(),
-                   tts=tts_wrapper, tracker=mock_tracker,
-                   handshake=Handshake(client_key="test-key", input_mode="audio", output_mode=["audio", "text"]),
-                   client_registry=ClientRegistry(), default_agent="main")
+    b = JotaBridge(
+        client=_CLIENT,
+        config=_CONFIG,
+        client_ws=ws,
+        orchestrator=AsyncMock(),
+        tts=tts_wrapper,
+        tracker=mock_tracker,
+        handshake=Handshake(
+            client_key="test-key", input_mode="audio", output_mode=["audio", "text"]
+        ),
+        client_registry=ClientRegistry(),
+        default_agent="main",
+    )
 
     async def stream_with_token(*args, **kwargs):
         yield OrchestratorEvent(type="token", content="hi")
@@ -155,7 +205,8 @@ async def test_turn_in_progress_error_event_sends_non_fatal_turn_error_frame(bri
     await bridge._call_orchestrator("test")  # must not raise — session stays open
 
     error_msgs = [
-        c.args[0] for c in bridge.client_ws.send_json.await_args_list
+        c.args[0]
+        for c in bridge.client_ws.send_json.await_args_list
         if c.args[0].get("type") == "error"
     ]
     assert len(error_msgs) == 1
@@ -171,11 +222,16 @@ async def test_tts_end_called_when_orchestrator_raises_non_runtime_error(mock_tr
     tts_end_called = False
 
     class FakeTTS:
-        async def send_text_chunk(self, t): pass
+        async def send_text_chunk(self, t):
+            pass
+
         async def end(self):
             nonlocal tts_end_called
             tts_end_called = True
-        async def close(self): pass
+
+        async def close(self):
+            pass
+
         async def get_audio_stream(self):
             if False:
                 yield b""  # async generator vacío — pipe_audio termina inmediatamente
@@ -185,15 +241,22 @@ async def test_tts_end_called_when_orchestrator_raises_non_runtime_error(mock_tr
     tts_wrapper.status = lambda: _connected_status()
 
     b = JotaBridge(
-        client=_CLIENT, config=_CONFIG, client_ws=ws, orchestrator=AsyncMock(),
-        tts=tts_wrapper, tracker=mock_tracker,
-        handshake=Handshake(client_key="test-key", input_mode="audio", output_mode=["audio", "text"]),
-        client_registry=ClientRegistry(), default_agent="main",
+        client=_CLIENT,
+        config=_CONFIG,
+        client_ws=ws,
+        orchestrator=AsyncMock(),
+        tts=tts_wrapper,
+        tracker=mock_tracker,
+        handshake=Handshake(
+            client_key="test-key", input_mode="audio", output_mode=["audio", "text"]
+        ),
+        client_registry=ClientRegistry(),
+        default_agent="main",
     )
 
     async def _crashing_stream(*args, **kwargs):
         raise OSError("connection reset by peer")
-        yield  # noqa: F501 — hace que Python lo trate como async generator
+        yield
 
     b.orchestrator.stream_response = _crashing_stream
 

--- a/tests/unit/test_bridge_watchdog.py
+++ b/tests/unit/test_bridge_watchdog.py
@@ -1,11 +1,14 @@
 """Tests for JotaBridge._transcription_watchdog."""
+
 import asyncio
 import time
-import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.models.schemas import Client, ClientConfig, Handshake
 from src.services.bridge import JotaBridge
 from src.services.openclaw.registry import ClientRegistry
-from src.models.schemas import Client, ClientConfig, Handshake
 from src.services.pipeline_tracker import PipelineTracker, _NullWS
 
 _CLIENT = Client(id="hab_sito", client_key="test-key", is_active=True)
@@ -16,19 +19,31 @@ def _make_bridge(config=None):
     ws = AsyncMock()
     registry = MagicMock()
     tracker = PipelineTracker(
-        session_id="test:wd", client_id="hab_sito",
-        input_mode="audio", output_mode=["text"],
-        client_ws=_NullWS(), registry=registry,
+        session_id="test:wd",
+        client_id="hab_sito",
+        input_mode="audio",
+        output_mode=["text"],
+        client_ws=_NullWS(),
+        registry=registry,
     )
     handshake = Handshake(client_key="test-key", input_mode="audio", output_mode=["text"])
     orch = AsyncMock()
     transcriber = MagicMock()
     from src.services.reconnection import ConnectionState
+
     transcriber.state = ConnectionState.CONNECTED
     transcriber._last_transcription_at = None
-    bridge = JotaBridge(client=_CLIENT, config=config or _CONFIG, client_ws=ws,
-                        orchestrator=orch, tts=AsyncMock(), tracker=tracker, handshake=handshake,
-                        client_registry=ClientRegistry(), default_agent="main")
+    bridge = JotaBridge(
+        client=_CLIENT,
+        config=config or _CONFIG,
+        client_ws=ws,
+        orchestrator=orch,
+        tts=AsyncMock(),
+        tracker=tracker,
+        handshake=handshake,
+        client_registry=ClientRegistry(),
+        default_agent="main",
+    )
     bridge.transcriber = transcriber
     return bridge, ws, transcriber
 
@@ -58,6 +73,7 @@ async def test_watchdog_exits_if_transcriber_disconnects():
     bridge, ws, transcriber = _make_bridge()
     bridge._first_audio_at = time.monotonic()
     from src.services.reconnection import ConnectionState
+
     transcriber.state = ConnectionState.DEGRADED
 
     with patch("src.services.bridge.asyncio.sleep", new=AsyncMock(return_value=None)):
@@ -73,6 +89,7 @@ async def test_watchdog_closes_session_after_max_silence_turns():
     transcriber._last_transcription_at = None
 
     close_called = []
+
     async def _fake_close():
         close_called.append(True)
 
@@ -94,6 +111,7 @@ async def test_watchdog_resets_count_when_transcription_arrives():
     transcriber._last_transcription_at = None
 
     close_called = []
+
     async def _fake_close():
         close_called.append(True)
 
@@ -108,6 +126,7 @@ async def test_watchdog_resets_count_when_transcription_arrives():
             transcriber._last_transcription_at = time.monotonic()
         elif ticks["n"] == 4:
             from src.services.reconnection import ConnectionState
+
             transcriber.state = ConnectionState.DEGRADED  # stop the loop cleanly
 
     with patch("src.services.bridge.asyncio.sleep", new=_controlled_sleep):
@@ -128,6 +147,7 @@ async def test_watchdog_pauses_but_does_not_exit_when_reconnecting():
     """A transient RECONNECTING must not permanently kill the watchdog (the bug
     this task fixes: the old `if not _is_ready: return` treated any drop as final)."""
     from src.services.reconnection import ConnectionState
+
     config = ClientConfig(silence_timeout_s=1, max_silence_turns=2)
     bridge, ws, transcriber = _make_bridge(config=config)
     bridge._first_audio_at = time.monotonic() - 2
@@ -146,6 +166,7 @@ async def test_watchdog_pauses_but_does_not_exit_when_reconnecting():
             transcriber.state = ConnectionState.DEGRADED  # stop the loop cleanly
 
     close_called = []
+
     async def _fake_close():
         close_called.append(True)
 
@@ -169,6 +190,7 @@ async def test_watchdog_does_not_close_immediately_after_reconnect_with_stale_ti
     baseline instead, exactly like a brand-new session would get via
     `_first_audio_at`."""
     from src.services.reconnection import ConnectionState
+
     config = ClientConfig(silence_timeout_s=1, max_silence_turns=2)
     bridge, ws, transcriber = _make_bridge(config=config)
     bridge._first_audio_at = time.monotonic() - 10

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -19,6 +19,7 @@ def _engine():
 
 def _run(args: list[str], engine) -> str:
     from src.cli import run
+
     out = StringIO()
     with patch("src.cli._get_engine", return_value=engine), patch("sys.stdout", out):
         run(args)

--- a/tests/unit/test_db_client_local.py
+++ b/tests/unit/test_db_client_local.py
@@ -99,7 +99,9 @@ async def test_invalidate_advances_generation_counter():
     assert client._generations["gen-key"] == 2
 
 
-def test_generation_guard_prevents_stale_repopulation_after_concurrent_invalidate(monkeypatch, tmp_path):
+def test_generation_guard_prevents_stale_repopulation_after_concurrent_invalidate(
+    monkeypatch, tmp_path
+):
     """Si invalidate() corre en otro hilo mientras get_session() está en
     vuelo (incluso antes de que la consulta a BD arranque), el resultado
     obsoleto no debe repoblar el caché compartido.

--- a/tests/unit/test_db_models.py
+++ b/tests/unit/test_db_models.py
@@ -1,8 +1,10 @@
 import json
+
 import pytest
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.pool import StaticPool
 from sqlmodel import Session, SQLModel, create_engine, select
+
 from src.db.models import ClientRecord
 
 
@@ -34,18 +36,18 @@ def test_defaults():
 
 def test_client_key_unique():
     engine = _mem_engine()
-    with pytest.raises(IntegrityError):
-        with Session(engine) as s:
-            s.add(ClientRecord(name="A", client_key="dup"))
-            s.add(ClientRecord(name="B", client_key="dup"))
-            s.commit()
+    with pytest.raises(IntegrityError), Session(engine) as s:
+        s.add(ClientRecord(name="A", client_key="dup"))
+        s.add(ClientRecord(name="B", client_key="dup"))
+        s.commit()
 
 
 def test_allowed_agents_json():
     engine = _mem_engine()
     with Session(engine) as s:
-        s.add(ClientRecord(name="X", client_key="k2",
-                           allowed_agents=json.dumps(["main", "helper"])))
+        s.add(
+            ClientRecord(name="X", client_key="k2", allowed_agents=json.dumps(["main", "helper"]))
+        )
         s.commit()
         rec = s.exec(select(ClientRecord)).first()
     assert json.loads(rec.allowed_agents) == ["main", "helper"]

--- a/tests/unit/test_migrations.py
+++ b/tests/unit/test_migrations.py
@@ -33,9 +33,7 @@ def test_legacy_db_gets_stamped_without_altering_schema(tmp_path, monkeypatch):
     db_path = tmp_path / "legacy.db"
     # Simular la BD de producción: esquema ya creado directamente (sin Alembic),
     # tal y como quedó tras el ALTER TABLE manual del incidente original.
-    legacy_engine = create_engine(
-        f"sqlite:///{db_path}", connect_args={"check_same_thread": False}
-    )
+    legacy_engine = create_engine(f"sqlite:///{db_path}", connect_args={"check_same_thread": False})
     SQLModel.metadata.create_all(legacy_engine)
     legacy_engine.dispose()
 

--- a/tests/unit/test_network.py
+++ b/tests/unit/test_network.py
@@ -74,18 +74,22 @@ def test_resolve_client_ip_accepts_websocket_connection():
     async def dummy_send(data):
         pass
 
-    websocket = WebSocket({
-        "type": "websocket",
-        "asgi": {"version": "3.0", "spec_version": "2.3"},
-        "scheme": "ws",
-        "path": "/ws/stream",
-        "raw_path": b"/ws/stream",
-        "query_string": b"",
-        "headers": [(b"x-real-ip", b"192.168.1.50")],
-        "client": ("127.0.0.1", 50000),
-        "server": ("testserver", 80),
-        "subprotocols": [],
-        "state": {},
-    }, receive=dummy_receive, send=dummy_send)
+    websocket = WebSocket(
+        {
+            "type": "websocket",
+            "asgi": {"version": "3.0", "spec_version": "2.3"},
+            "scheme": "ws",
+            "path": "/ws/stream",
+            "raw_path": b"/ws/stream",
+            "query_string": b"",
+            "headers": [(b"x-real-ip", b"192.168.1.50")],
+            "client": ("127.0.0.1", 50000),
+            "server": ("testserver", 80),
+            "subprotocols": [],
+            "state": {},
+        },
+        receive=dummy_receive,
+        send=dummy_send,
+    )
 
     assert resolve_client_ip(websocket) == "192.168.1.50"

--- a/tests/unit/test_openclaw_client_connect_leak.py
+++ b/tests/unit/test_openclaw_client_connect_leak.py
@@ -1,17 +1,20 @@
 """Tests for OpenClawClient.connect() socket leak on handshake failure (issue #96)."""
+
 import asyncio
 import json
+from unittest.mock import MagicMock, patch
+
 import pytest
-from unittest.mock import patch, MagicMock
 from websockets.exceptions import ConnectionClosed
 
 from src.services.openclaw.client import OpenClawClient
 from src.services.openclaw.dispatcher import FrameDispatcher
-from src.services.openclaw.registry import TurnRegistry, ClientRegistry
+from src.services.openclaw.registry import ClientRegistry, TurnRegistry
 
 
 class FakeOCSocket:
     """Fake websocket that simulates OpenClaw handshake failure at a given point."""
+
     def __init__(self, fail_at="challenge", fail_with=None):
         self._to_client = asyncio.Queue()
         self.closed = False
@@ -42,6 +45,7 @@ class FakeOCSocket:
     def __await__(self):
         async def _():
             return self
+
         return _().__await__()
 
 
@@ -60,8 +64,7 @@ async def test_connect_closes_socket_when_challenge_fails():
     with patch("websockets.connect", side_effect=fake_connect):
         with pytest.raises(RuntimeError):
             await OpenClawClient(
-                host="test", port=1, token="x",
-                turn_registry=turn_reg, dispatcher=dispatcher
+                host="test", port=1, token="x", turn_registry=turn_reg, dispatcher=dispatcher
             ).connect()
 
     assert fake_ws.closed, "Socket must be closed when challenge fails"

--- a/tests/unit/test_openclaw_dispatcher.py
+++ b/tests/unit/test_openclaw_dispatcher.py
@@ -1,10 +1,12 @@
-import pytest
 from unittest.mock import AsyncMock
-from src.services.openclaw.dispatcher import FrameDispatcher
-from src.services.openclaw.registry import TurnRegistry, ClientRegistry
-from src.services.bridge import JotaBridge
-from src.services.reconnection import ConnectionState, ServiceStatus
+
+import pytest
+
 from src.models.schemas import Client, ClientConfig, Handshake
+from src.services.bridge import JotaBridge
+from src.services.openclaw.dispatcher import FrameDispatcher
+from src.services.openclaw.registry import ClientRegistry, TurnRegistry
+from src.services.reconnection import ConnectionState, ServiceStatus
 
 
 def make_dispatcher():
@@ -16,8 +18,11 @@ def make_dispatcher():
 
 def _connected_status() -> ServiceStatus:
     return ServiceStatus(
-        name="tts", state=ConnectionState.CONNECTED,
-        connected_at=None, reconnect_attempts=0, last_error=None,
+        name="tts",
+        state=ConnectionState.CONNECTED,
+        connected_at=None,
+        reconnect_attempts=0,
+        last_error=None,
     )
 
 
@@ -31,13 +36,21 @@ def make_real_bridge(client_id="hab_sito", push_enabled=True, tool_calls_enabled
     orchestrator = AsyncMock()
     orchestrator.ping = AsyncMock(return_value=True)
     tracker = AsyncMock()
-    handshake = Handshake(client_key="key-123", input_mode="text", output_mode=["text"], agent="main")
+    handshake = Handshake(
+        client_key="key-123", input_mode="text", output_mode=["text"], agent="main"
+    )
     tts = AsyncMock()
     tts.connect = AsyncMock(return_value=None)
     bridge = JotaBridge(
-        client=client, config=config, client_ws=ws,
-        orchestrator=orchestrator, tts=tts, tracker=tracker, handshake=handshake,
-        client_registry=ClientRegistry(), default_agent="main",
+        client=client,
+        config=config,
+        client_ws=ws,
+        orchestrator=orchestrator,
+        tts=tts,
+        tracker=tracker,
+        handshake=handshake,
+        client_registry=ClientRegistry(),
+        default_agent="main",
     )
     return bridge, ws
 
@@ -46,7 +59,12 @@ def make_real_bridge(client_id="hab_sito", push_enabled=True, tool_calls_enabled
 async def test_res_started_ignored():
     dispatcher, turn_reg, _ = make_dispatcher()
     q = turn_reg.register("req-1", "agent:main:client-a")
-    frame = {"type": "res", "id": "req-1", "ok": True, "payload": {"status": "started", "runId": "r1"}}
+    frame = {
+        "type": "res",
+        "id": "req-1",
+        "ok": True,
+        "payload": {"status": "started", "runId": "r1"},
+    }
     await dispatcher.dispatch(frame)
     assert q.empty()
 
@@ -75,7 +93,9 @@ async def test_chat_event_routes_to_session_queue():
     q = turn_reg.register("req-1", "agent:main:client-a")
     payload = {
         "sessionKey": "agent:main:client-a",
-        "runId": "r1", "seq": 1, "state": "delta",
+        "runId": "r1",
+        "seq": 1,
+        "state": "delta",
         "deltaText": "Hola",
     }
     frame = {"type": "event", "event": "chat", "payload": payload}
@@ -92,7 +112,9 @@ async def test_chat_event_no_active_turn_routes_to_client_registry():
     client_reg.register("client-a", bridge)
     payload = {
         "sessionKey": "agent:main:client-a",
-        "runId": "r1", "seq": 1, "deltaText": "Push!",
+        "runId": "r1",
+        "seq": 1,
+        "deltaText": "Push!",
     }
     frame = {"type": "event", "event": "chat", "payload": payload}
     await dispatcher.dispatch(frame)
@@ -113,7 +135,8 @@ async def test_agent_lifecycle_start_calls_on_push_turn_start():
     client_reg.register("client-a", bridge)
     payload = {
         "sessionKey": "agent:main:client-a",
-        "runId": "r1", "seq": 1,
+        "runId": "r1",
+        "seq": 1,
         "data": {"phase": "start", "startedAt": 123},
     }
     frame = {"type": "event", "event": "agent", "payload": payload}
@@ -128,7 +151,8 @@ async def test_agent_lifecycle_end_calls_on_push_turn_end():
     client_reg.register("client-a", bridge)
     payload = {
         "sessionKey": "agent:main:client-a",
-        "runId": "r1", "seq": 2,
+        "runId": "r1",
+        "seq": 2,
         "data": {"phase": "end", "stopReason": "stop"},
     }
     frame = {"type": "event", "event": "agent", "payload": payload}
@@ -151,7 +175,12 @@ async def test_session_tool_start_routes_to_turn_queue():
     payload = {
         "sessionKey": "agent:main:client-a",
         "runId": "r1",
-        "data": {"phase": "start", "name": "exec", "toolCallId": "call-1", "args": {"command": "ls"}},
+        "data": {
+            "phase": "start",
+            "name": "exec",
+            "toolCallId": "call-1",
+            "args": {"command": "ls"},
+        },
     }
     frame = {"type": "event", "event": "session.tool", "payload": payload}
     await dispatcher.dispatch(frame)
@@ -168,8 +197,11 @@ async def test_session_tool_result_routes_to_turn_queue():
     payload = {
         "sessionKey": "agent:main:client-a",
         "data": {
-            "phase": "result", "name": "exec", "toolCallId": "call-1",
-            "isError": False, "result": {"content": [{"type": "text", "text": "ok"}]},
+            "phase": "result",
+            "name": "exec",
+            "toolCallId": "call-1",
+            "isError": False,
+            "result": {"content": [{"type": "text", "text": "ok"}]},
         },
     }
     frame = {"type": "event", "event": "session.tool", "payload": payload}
@@ -210,7 +242,8 @@ async def test_session_tool_no_active_turn_routes_to_client_registry():
 async def test_session_tool_no_session_key_ignored():
     dispatcher, _, _ = make_dispatcher()
     frame = {
-        "type": "event", "event": "session.tool",
+        "type": "event",
+        "event": "session.tool",
         "payload": {"data": {"phase": "start", "name": "exec", "toolCallId": "call-1"}},
     }
     await dispatcher.dispatch(frame)  # must not raise
@@ -240,7 +273,12 @@ async def test_dispatcher_session_tool_push_disabled_client_receives_nothing():
 
     payload = {
         "sessionKey": "agent:main:hab_sito",
-        "data": {"phase": "start", "name": "exec", "toolCallId": "call-1", "args": {"command": "ls"}},
+        "data": {
+            "phase": "start",
+            "name": "exec",
+            "toolCallId": "call-1",
+            "args": {"command": "ls"},
+        },
     }
     frame = {"type": "event", "event": "session.tool", "payload": payload}
     await dispatcher.dispatch(frame)
@@ -261,25 +299,37 @@ async def test_dispatcher_full_push_lifecycle_disabled_client_receives_nothing()
     bridge, ws = make_real_bridge(push_enabled=False, tool_calls_enabled=True)
     client_reg.register("hab_sito", bridge)
 
-    await dispatcher.dispatch({
-        "type": "event", "event": "agent",
-        "payload": {"sessionKey": "agent:main:hab_sito", "data": {"phase": "start"}},
-    })
-    await dispatcher.dispatch({
-        "type": "event", "event": "chat",
-        "payload": {"sessionKey": "agent:main:hab_sito", "deltaText": "Push!"},
-    })
-    await dispatcher.dispatch({
-        "type": "event", "event": "session.tool",
-        "payload": {
-            "sessionKey": "agent:main:hab_sito",
-            "data": {"phase": "start", "name": "exec", "toolCallId": "call-1", "args": {}},
-        },
-    })
-    await dispatcher.dispatch({
-        "type": "event", "event": "agent",
-        "payload": {"sessionKey": "agent:main:hab_sito", "data": {"phase": "end"}},
-    })
+    await dispatcher.dispatch(
+        {
+            "type": "event",
+            "event": "agent",
+            "payload": {"sessionKey": "agent:main:hab_sito", "data": {"phase": "start"}},
+        }
+    )
+    await dispatcher.dispatch(
+        {
+            "type": "event",
+            "event": "chat",
+            "payload": {"sessionKey": "agent:main:hab_sito", "deltaText": "Push!"},
+        }
+    )
+    await dispatcher.dispatch(
+        {
+            "type": "event",
+            "event": "session.tool",
+            "payload": {
+                "sessionKey": "agent:main:hab_sito",
+                "data": {"phase": "start", "name": "exec", "toolCallId": "call-1", "args": {}},
+            },
+        }
+    )
+    await dispatcher.dispatch(
+        {
+            "type": "event",
+            "event": "agent",
+            "payload": {"sessionKey": "agent:main:hab_sito", "data": {"phase": "end"}},
+        }
+    )
 
     ws.send_json.assert_not_awaited()
     assert bridge._push_turn_open is False

--- a/tests/unit/test_openclaw_frames.py
+++ b/tests/unit/test_openclaw_frames.py
@@ -1,7 +1,7 @@
 from src.services.openclaw import frames
 
-
 # ── Shape ─────────────────────────────────────────────────────────
+
 
 def test_every_frame_is_req_type():
     for fn, args in [
@@ -26,6 +26,7 @@ def test_every_frame_is_req_type():
 
 
 # ── connect_backend ───────────────────────────────────────────────
+
 
 def test_connect_backend_method():
     frame = frames.connect_backend("r1", "secret")
@@ -62,6 +63,7 @@ def test_connect_backend_operator_role():
 
 # ── sessions_subscribe ────────────────────────────────────────────
 
+
 def test_sessions_subscribe_method():
     assert frames.sessions_subscribe("r1")["method"] == "sessions.subscribe"
 
@@ -72,6 +74,7 @@ def test_sessions_subscribe_empty_params():
 
 # ── health ────────────────────────────────────────────────────────
 
+
 def test_health_method():
     assert frames.health("r1")["method"] == "health"
 
@@ -81,6 +84,7 @@ def test_health_empty_params():
 
 
 # ── chat_send ─────────────────────────────────────────────────────
+
 
 def test_chat_send_method():
     assert frames.chat_send("r", "sk", "msg", "idem")["method"] == "chat.send"
@@ -101,6 +105,7 @@ def test_chat_send_message_and_idempotency_key():
 
 # ── chat_abort ────────────────────────────────────────────────────
 
+
 def test_chat_abort_method():
     assert frames.chat_abort("r", "sk")["method"] == "chat.abort"
 
@@ -113,6 +118,7 @@ def test_chat_abort_uses_sessionkey_not_session():
 
 
 # ── chat_history ──────────────────────────────────────────────────
+
 
 def test_chat_history_method():
     assert frames.chat_history("r", "sk")["method"] == "chat.history"
@@ -132,6 +138,7 @@ def test_chat_history_custom_pagination():
 
 # ── chat_inject ───────────────────────────────────────────────────
 
+
 def test_chat_inject_method():
     assert frames.chat_inject("r", "sk", "ctx")["method"] == "chat.inject"
 
@@ -143,6 +150,7 @@ def test_chat_inject_content():
 
 
 # ── sessions_steer ────────────────────────────────────────────────
+
 
 def test_sessions_steer_method():
     assert frames.sessions_steer("r", "sk", "txt")["method"] == "sessions.steer"
@@ -156,11 +164,13 @@ def test_sessions_steer_params():
 
 # ── sessions_list ─────────────────────────────────────────────────
 
+
 def test_sessions_list_method():
     assert frames.sessions_list("r")["method"] == "sessions.list"
 
 
 # ── agents_list ───────────────────────────────────────────────────
+
 
 def test_agents_list_method():
     assert frames.agents_list("r")["method"] == "agents.list"
@@ -172,6 +182,7 @@ def test_agents_list_empty_params():
 
 # ── agent_identity_get ────────────────────────────────────────────
 
+
 def test_agent_identity_get_method():
     assert frames.agent_identity_get("r", "main")["method"] == "agent.identity.get"
 
@@ -181,6 +192,7 @@ def test_agent_identity_get_param():
 
 
 # ── models_list ───────────────────────────────────────────────────
+
 
 def test_models_list_method():
     assert frames.models_list("r")["method"] == "models.list"
@@ -195,6 +207,7 @@ def test_models_list_custom_view():
 
 
 # ── models_auth_status ────────────────────────────────────────────
+
 
 def test_models_auth_status_method():
     assert frames.models_auth_status("r")["method"] == "models.authStatus"

--- a/tests/unit/test_openclaw_models.py
+++ b/tests/unit/test_openclaw_models.py
@@ -55,13 +55,15 @@ def test_update_agents_from_list():
     """agents.list payload shape differs from snapshot.agents: 'id' not
     'agentId', no per-agent 'isDefault' — derived from top-level 'defaultId'."""
     info = GatewayInfo.from_hello_ok({})  # starts with empty agents, default "main"
-    info.update_agents_from_list({
-        "defaultId": "assistant",
-        "agents": [
-            {"id": "main", "name": "Main Agent"},
-            {"id": "assistant", "name": "Jota Voice"},
-        ],
-    })
+    info.update_agents_from_list(
+        {
+            "defaultId": "assistant",
+            "agents": [
+                {"id": "main", "name": "Main Agent"},
+                {"id": "assistant", "name": "Jota Voice"},
+            ],
+        }
+    )
     assert info.has_agent("main")
     assert info.has_agent("assistant")
     assert info.agents["assistant"].is_default is True
@@ -78,7 +80,9 @@ def test_update_agents_from_list_keeps_prior_default_if_missing():
 
 def test_tool_call_start_parses_name_and_args():
     data = {
-        "phase": "start", "name": "exec", "toolCallId": "call-1",
+        "phase": "start",
+        "name": "exec",
+        "toolCallId": "call-1",
         "args": {"command": "pwd && ls", "workdir": "/tmp"},
     }
     tc = ToolCallEvent.from_session_tool_payload(data)
@@ -92,7 +96,9 @@ def test_tool_call_start_parses_name_and_args():
 
 def test_tool_call_result_flattens_text_content():
     data = {
-        "phase": "result", "name": "exec", "toolCallId": "call-1",
+        "phase": "result",
+        "name": "exec",
+        "toolCallId": "call-1",
         "isError": False,
         "result": {"content": [{"type": "text", "text": "line1\nline2"}]},
     }
@@ -104,7 +110,13 @@ def test_tool_call_result_flattens_text_content():
 
 
 def test_tool_call_result_with_no_content_has_none_result():
-    data = {"phase": "result", "name": "exec", "toolCallId": "call-1", "isError": True, "result": {}}
+    data = {
+        "phase": "result",
+        "name": "exec",
+        "toolCallId": "call-1",
+        "isError": True,
+        "result": {},
+    }
     tc = ToolCallEvent.from_session_tool_payload(data)
     assert tc.result is None
     assert tc.is_error is True

--- a/tests/unit/test_openclaw_registry.py
+++ b/tests/unit/test_openclaw_registry.py
@@ -4,20 +4,22 @@ from unittest.mock import AsyncMock
 import pytest
 
 from src.services.openclaw.registry import (
-    TurnRegistry,
     ClientRegistry,
     TurnInProgress,
+    TurnRegistry,
     client_id_from_session_key,
 )
 
-
 # --- client_id_from_session_key ---
+
 
 def test_client_id_simple():
     assert client_id_from_session_key("agent:main:hab_sito") == "hab_sito"
 
+
 def test_client_id_with_colons():
     assert client_id_from_session_key("agent:plants:telegram:direct:5239228928") == "5239228928"
+
 
 def test_client_id_two_parts():
     assert client_id_from_session_key("agent:assistant:probe-test") == "probe-test"
@@ -25,25 +27,30 @@ def test_client_id_two_parts():
 
 # --- TurnRegistry ---
 
+
 def test_register_returns_queue():
     reg = TurnRegistry()
     q = reg.register("req-1", "agent:main:client-a")
     assert isinstance(q, asyncio.Queue)
+
 
 def test_get_queue_by_session():
     reg = TurnRegistry()
     q = reg.register("req-1", "agent:main:client-a")
     assert reg.get_queue_by_session("agent:main:client-a") is q
 
+
 def test_get_queue_by_req():
     reg = TurnRegistry()
     q = reg.register("req-1", "agent:main:client-a")
     assert reg.get_queue_by_req("req-1") is q
 
+
 def test_get_queue_missing_returns_none():
     reg = TurnRegistry()
     assert reg.get_queue_by_session("nonexistent") is None
     assert reg.get_queue_by_req("nonexistent") is None
+
 
 def test_unregister_clears_both():
     reg = TurnRegistry()
@@ -51,6 +58,7 @@ def test_unregister_clears_both():
     reg.unregister("agent:main:client-a", "req-1")
     assert reg.get_queue_by_session("agent:main:client-a") is None
     assert reg.get_queue_by_req("req-1") is None
+
 
 def test_register_rejects_duplicate_session_key():
     reg = TurnRegistry()
@@ -95,6 +103,7 @@ def test_two_sessions_independent():
     assert reg.get_queue_by_session("agent:main:client-b") is qb
     assert qa is not qb
 
+
 def test_error_all_notifies_and_clears():
     reg = TurnRegistry()
     qa = reg.register("req-a", "agent:main:client-a")
@@ -108,11 +117,13 @@ def test_error_all_notifies_and_clears():
 
 # --- ClientRegistry ---
 
+
 def test_client_registry_register_get():
     reg = ClientRegistry()
     bridge = object()
     reg.register("hab_sito", bridge)
     assert reg.get("hab_sito") is bridge
+
 
 def test_client_registry_unregister():
     reg = ClientRegistry()
@@ -156,6 +167,7 @@ def test_client_registry_unregister_is_noop_for_any_superseded_owner():
 
     reg.unregister("client-x", bridge_c)  # current owner tears down
     assert reg.get("client-x") is None
+
 
 def test_client_registry_missing_returns_none():
     reg = ClientRegistry()

--- a/tests/unit/test_orchestration.py
+++ b/tests/unit/test_orchestration.py
@@ -1,26 +1,32 @@
-import pytest
 from unittest.mock import MagicMock
+
+import pytest
+
+from src.services.openclaw.models import ToolCallEvent
 from src.services.orchestration import call_orchestrator
 from src.services.protocol import OrchestratorEvent
-from src.services.openclaw.models import ToolCallEvent
 
 
 def _make_orchestrator(events):
     async def _stream(**kwargs):
         for e in events:
             yield e
+
     mock = MagicMock()
     mock.stream_response = _stream
     return mock
 
 
 async def test_tokens_reach_callback():
-    orch = _make_orchestrator([
-        OrchestratorEvent(type="token", content="Hello"),
-        OrchestratorEvent(type="token", content=" world"),
-        OrchestratorEvent(type="status", content="done"),
-    ])
+    orch = _make_orchestrator(
+        [
+            OrchestratorEvent(type="token", content="Hello"),
+            OrchestratorEvent(type="token", content=" world"),
+            OrchestratorEvent(type="status", content="done"),
+        ]
+    )
     received = []
+
     async def on_token(t):
         received.append(t)
 
@@ -33,14 +39,19 @@ async def test_tracker_receives_llm_events():
 
     registry = MagicMock()
     tracker = PipelineTracker(
-        session_id="t1", client_id="ha",
-        input_mode="text", output_mode=[],
-        client_ws=_NullWS(), registry=registry,
+        session_id="t1",
+        client_id="ha",
+        input_mode="text",
+        output_mode=[],
+        client_ws=_NullWS(),
+        registry=registry,
     )
-    orch = _make_orchestrator([
-        OrchestratorEvent(type="token", content="hi"),
-        OrchestratorEvent(type="status", content="done"),
-    ])
+    orch = _make_orchestrator(
+        [
+            OrchestratorEvent(type="token", content="hi"),
+            OrchestratorEvent(type="status", content="done"),
+        ]
+    )
 
     await call_orchestrator(orch, "hi", "agent:main:ha", "ha", tracker=tracker)
 
@@ -56,10 +67,12 @@ async def test_no_tracker_does_not_raise():
 
 
 async def test_no_on_token_does_not_raise():
-    orch = _make_orchestrator([
-        OrchestratorEvent(type="token", content="t"),
-        OrchestratorEvent(type="status", content="done"),
-    ])
+    orch = _make_orchestrator(
+        [
+            OrchestratorEvent(type="token", content="t"),
+            OrchestratorEvent(type="status", content="done"),
+        ]
+    )
     await call_orchestrator(orch, "hi", "agent:main:ha", "ha", on_token=None)
 
 
@@ -98,13 +111,19 @@ async def test_error_event_closes_the_stream_response_generator():
 
 
 async def test_tool_call_reaches_callback():
-    tc_start = ToolCallEvent(phase="start", name="exec", tool_call_id="call-1", args={"command": "ls"})
-    tc_result = ToolCallEvent(phase="result", name="exec", tool_call_id="call-1", result="ok", is_error=False)
-    orch = _make_orchestrator([
-        OrchestratorEvent(type="tool_call", tool_call=tc_start),
-        OrchestratorEvent(type="tool_call", tool_call=tc_result),
-        OrchestratorEvent(type="status", content="done"),
-    ])
+    tc_start = ToolCallEvent(
+        phase="start", name="exec", tool_call_id="call-1", args={"command": "ls"}
+    )
+    tc_result = ToolCallEvent(
+        phase="result", name="exec", tool_call_id="call-1", result="ok", is_error=False
+    )
+    orch = _make_orchestrator(
+        [
+            OrchestratorEvent(type="tool_call", tool_call=tc_start),
+            OrchestratorEvent(type="tool_call", tool_call=tc_result),
+            OrchestratorEvent(type="status", content="done"),
+        ]
+    )
     received = []
 
     async def on_tool_call(tc):
@@ -116,26 +135,34 @@ async def test_tool_call_reaches_callback():
 
 async def test_no_on_tool_call_does_not_raise():
     tc = ToolCallEvent(phase="start", name="exec", tool_call_id="call-1")
-    orch = _make_orchestrator([
-        OrchestratorEvent(type="tool_call", tool_call=tc),
-        OrchestratorEvent(type="status", content="done"),
-    ])
+    orch = _make_orchestrator(
+        [
+            OrchestratorEvent(type="tool_call", tool_call=tc),
+            OrchestratorEvent(type="status", content="done"),
+        ]
+    )
     await call_orchestrator(orch, "hi", "agent:main:ha", "ha", on_tool_call=None)
 
 
 async def test_llm_done_meta_has_token_count():
     from src.services.pipeline_tracker import PipelineTracker, _NullWS
+
     registry = MagicMock()
     tracker = PipelineTracker(
-        session_id="t2", client_id="ha",
-        input_mode="text", output_mode=[],
-        client_ws=_NullWS(), registry=registry,
+        session_id="t2",
+        client_id="ha",
+        input_mode="text",
+        output_mode=[],
+        client_ws=_NullWS(),
+        registry=registry,
     )
-    orch = _make_orchestrator([
-        OrchestratorEvent(type="token", content="a"),
-        OrchestratorEvent(type="token", content="b"),
-        OrchestratorEvent(type="status", content="done"),
-    ])
+    orch = _make_orchestrator(
+        [
+            OrchestratorEvent(type="token", content="a"),
+            OrchestratorEvent(type="token", content="b"),
+            OrchestratorEvent(type="status", content="done"),
+        ]
+    )
     await call_orchestrator(orch, "hi", "agent:main:ha", "ha", tracker=tracker)
     done_event = next(e for e in tracker.events if e.stage == "llm_done")
     assert done_event.meta["token_count"] == 2

--- a/tests/unit/test_reconnecting_transcriber.py
+++ b/tests/unit/test_reconnecting_transcriber.py
@@ -1,8 +1,10 @@
 import asyncio
-import pytest
 from unittest.mock import AsyncMock, patch
-from src.services.transcriber_reconnecting import ReconnectingTranscriberClient
+
+import pytest
+
 from src.services.reconnection import ConnectionState
+from src.services.transcriber_reconnecting import ReconnectingTranscriberClient
 
 
 def _wrap(**kwargs):

--- a/tests/unit/test_reconnecting_tts.py
+++ b/tests/unit/test_reconnecting_tts.py
@@ -1,8 +1,10 @@
 import time
-import pytest
 from unittest.mock import AsyncMock, patch
-from src.services.tts_reconnecting import ReconnectingTTSClient
+
+import pytest
+
 from src.services.reconnection import ConnectionState
+from src.services.tts_reconnecting import ReconnectingTTSClient
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_reconnection.py
+++ b/tests/unit/test_reconnection.py
@@ -8,7 +8,12 @@ def test_to_wire_state_mapping():
 
 
 def test_service_status_is_a_plain_dataclass():
-    s = ServiceStatus(name="x", state=ConnectionState.CONNECTED, connected_at=None,
-                       reconnect_attempts=0, last_error=None)
+    s = ServiceStatus(
+        name="x",
+        state=ConnectionState.CONNECTED,
+        connected_at=None,
+        reconnect_attempts=0,
+        last_error=None,
+    )
     assert s.name == "x"
     assert s.state == ConnectionState.CONNECTED

--- a/tests/unit/test_routes_cleanup.py
+++ b/tests/unit/test_routes_cleanup.py
@@ -7,6 +7,7 @@ real ASGI transport: the pre-fix code path (ready-send failure) never called
 hangs forever — exercising it through a fake object sidesteps that entirely
 and lets us assert on cleanup deterministically.
 """
+
 import json
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
@@ -106,7 +107,8 @@ async def test_connect_internal_services_failure_leaves_no_zombie_session(monkey
     from src.services.bridge import JotaBridge
 
     monkeypatch.setattr(
-        JotaBridge, "connect_internal_services",
+        JotaBridge,
+        "connect_internal_services",
         AsyncMock(side_effect=RuntimeError("boom")),
     )
     app_state, _ = _make_app_state(orchestrator_ping_result=True)

--- a/tests/unit/test_service_ping_endpoints.py
+++ b/tests/unit/test_service_ping_endpoints.py
@@ -4,6 +4,7 @@
 jota-transcriber and jota-speaker. /ready reflects real capacity/readiness
 (503 when GPU-saturated / engine not loaded) — see issue #101.
 """
+
 import httpx
 import respx
 

--- a/tests/unit/test_transcriber_client_connect_leak.py
+++ b/tests/unit/test_transcriber_client_connect_leak.py
@@ -1,8 +1,10 @@
 """Tests for TranscriberClient.connect() socket leak on handshake failure (issue #96)."""
+
 import asyncio
 import json
+from unittest.mock import MagicMock, patch
+
 import pytest
-from unittest.mock import patch, MagicMock
 from websockets.exceptions import ConnectionClosed
 
 from src.services.transcriber_client import TranscriberClient
@@ -10,6 +12,7 @@ from src.services.transcriber_client import TranscriberClient
 
 class FakeSocket:
     """Fake websocket that records close() calls and simulates handshake failure."""
+
     def __init__(self, recv_payloads=None):
         self._to_client = asyncio.Queue()
         for p in recv_payloads or []:
@@ -34,6 +37,7 @@ class FakeSocket:
     def __await__(self):
         async def _():
             return self
+
         return _().__await__()
 
 
@@ -41,9 +45,9 @@ class FakeSocket:
 async def test_connect_closes_socket_when_handshake_fails():
     """If websockets.connect succeeds but the handshake fails, the socket must
     be closed before re-raising — otherwise it leaks (issue #96)."""
-    fake_ws = FakeSocket(recv_payloads=[
-        json.dumps({"type": "error", "code": "auth_failed", "message": "bad token"})
-    ])
+    fake_ws = FakeSocket(
+        recv_payloads=[json.dumps({"type": "error", "code": "auth_failed", "message": "bad token"})]
+    )
 
     with patch("websockets.connect", side_effect=lambda url: fake_ws):
         with pytest.raises(Exception) as exc_info:

--- a/tests/unit/test_transcriber_loop.py
+++ b/tests/unit/test_transcriber_loop.py
@@ -1,6 +1,9 @@
 """Tests for TranscriberClient.listen_loop callback signature change."""
+
 import json
+
 import pytest
+
 from src.services.transcriber_client import TranscriberClient
 
 
@@ -21,6 +24,7 @@ async def test_listen_loop_passes_text_and_is_final_true(client):
     client.ws = make_ws(msg)
 
     received = []
+
     async def callback(text: str, is_final: bool):
         received.append((text, is_final))
 
@@ -35,6 +39,7 @@ async def test_listen_loop_passes_text_and_is_final_false(client):
     client.ws = make_ws(msg)
 
     received = []
+
     async def callback(text: str, is_final: bool):
         received.append((text, is_final))
 
@@ -49,6 +54,7 @@ async def test_listen_loop_passes_is_final_none_as_false(client):
     client.ws = make_ws(msg)
 
     received = []
+
     async def callback(text: str, is_final: bool):
         received.append((text, is_final))
 
@@ -66,6 +72,7 @@ async def test_listen_loop_ignores_non_transcription_messages(client):
     client.ws = make_ws(*msgs)
 
     received = []
+
     async def callback(text: str, is_final: bool):
         received.append((text, is_final))
 
@@ -80,6 +87,7 @@ async def test_listen_loop_ignores_empty_text(client):
     client.ws = make_ws(msg)
 
     received = []
+
     async def callback(text: str, is_final: bool):
         received.append((text, is_final))
 
@@ -93,6 +101,7 @@ async def test_listen_loop_returns_immediately_when_ws_is_none(client):
     client.ws = None
 
     called = []
+
     async def callback(text: str, is_final: bool):
         called.append(True)
 

--- a/tests/unit/test_tts_client_connect_leak.py
+++ b/tests/unit/test_tts_client_connect_leak.py
@@ -1,16 +1,19 @@
 """Tests for TTSClient.connect() socket leak on handshake failure (issue #96)."""
+
 import asyncio
 import json
+from unittest.mock import MagicMock, patch
+
 import pytest
-from unittest.mock import patch, MagicMock
 from websockets.exceptions import ConnectionClosed
 
-from src.services.tts_client import TTSClient
 from src.core.config import settings
+from src.services.tts_client import TTSClient
 
 
 class FakeTTSSocket:
     """Fake websocket that records close() calls and simulates TTS handshake failure."""
+
     def __init__(self, recv_payloads=None):
         self._to_client = asyncio.Queue()
         for p in recv_payloads or []:
@@ -37,6 +40,7 @@ class FakeTTSSocket:
     def __await__(self):
         async def _():
             return self
+
         return _().__await__()
 
 
@@ -44,9 +48,9 @@ class FakeTTSSocket:
 async def test_connect_closes_socket_when_auth_fails():
     """If websockets.connect succeeds but TTS auth fails, the socket must
     be closed before re-raising — otherwise it leaks (issue #96)."""
-    fake_ws = FakeTTSSocket(recv_payloads=[
-        json.dumps({"type": "error", "code": "bad_token", "message": "invalid"})
-    ])
+    fake_ws = FakeTTSSocket(
+        recv_payloads=[json.dumps({"type": "error", "code": "bad_token", "message": "invalid"})]
+    )
 
     async def fake_connect(url):
         return fake_ws
@@ -90,13 +94,15 @@ async def test_connect_uses_configured_auth_timeout_and_closes_socket(monkeypatc
     monkeypatch.setattr(settings, "TTS_AUTH_TIMEOUT_S", 0.01)
     tts = TTSClient(url="test:1", token="token", client_id="c1")
 
-    with patch("websockets.connect", side_effect=fake_connect):
-        with patch(
+    with (
+        patch("websockets.connect", side_effect=fake_connect),
+        patch(
             "src.services.tts_client.asyncio.wait_for",
             wraps=asyncio.wait_for,
-        ) as wait_for:
-            with pytest.raises(asyncio.TimeoutError):
-                await tts.connect()
+        ) as wait_for,
+        pytest.raises(asyncio.TimeoutError),
+    ):
+        await tts.connect()
 
     wait_for.assert_awaited_once()
     assert wait_for.await_args.kwargs["timeout"] == 0.01


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
<think>
Let me analyze the code changes to understand what was implemented in this pull request.

Looking at the changes:

1. **ROADMAP.md**: Marked #114 as completed (was pending, now done)

2. **docs/client-protocol.md**: 
   - Changed `ready.capabilities` to `ready.requested_capabilities` + `ready.live_capabilities`
   - Added documentation explaining the difference between requested and live capabilities
   - Added protocol incompatibility notice about the change

3. **docs/superpowers/specs/2026-07-21-114-ready-capabilities-design.md**: Added detailed design specification

4. **src/api/routes.py**:
   - Changed health check call to capture the result (`live_capabilities`)
   - Changed the condition from `if not await bridge.health_check()` to `if live_capabilities is None`
   - Renamed `capabilities` to `requested_capabilities`
   - Added `live_capabilities` field to the ready message

5. **src/services/bridge.py**:
   - Changed `health_check()` return type from `bool` to `dict[str, bool] | None`
   - Now returns a dictionary with `barge_in`, `tts`, `transcriber` keys
   - Returns `None` only when orchestrator is unavailable (previously returned `False`)
   - Returns the snapshot dictionary for non-fatal services (previously returned `True`)

6. **tests/e2e/ws_helpers.py**:
   - Updated `ws_handshake()` to handle receiving messages before `ready` (like `status` messages)
   - Added timeout handling and iteration through frames until `ready` is found

7. **tests/integration/test_ws_handshake.py**:
   - Updated test to check for `requested_capabilities` instead of `capabilities`
   - Added new test `test_ready_carries_requested_and_live_capabilities_when_audio`
   - Added new test `test_ready_uses_both_sections_for_text_only_handshake`

8. **tests/unit/test_bridge_health_check.py**:
   - Rewrote tests to verify the new dictionary return type
   - Tests now check for specific dictionary values instead of boolean returns

The core change separates what the client requested in the handshake (`requested_capabilities`) from what's actually available at connection time (`live_capabilities`), allowing clients to understand both their original request and real-time service availability.
</think>

## Summary

This pull request implements fix #114 by splitting the `ready.capabilities` field into two distinct fields to resolve the contradiction between what the client requests and what services are actually available.

### Changes Made

1. **Renamed `capabilities` to `requested_capabilities`**: Reflects what the client requested in the handshake (based on `input_mode`, `output_mode`, and configuration).

2. **Added `live_capabilities`**: A snapshot of actual service availability at connection time, obtained from health check results (TTS ping, transcriber connection state).

3. **Modified `health_check()` return type**: Changed from `bool` to `dict[str, bool] | None`:
   - Returns `None` only when orchestrator is unavailable (critical failure)
   - Returns a dictionary with `barge_in`, `tts`, `transcriber` keys showing live availability

4. **Updated E2E helper**: `ws_handshake()` now handles receiving `status` messages before `ready`, since non-critical service unavailability is now communicated before the `ready` message.

5. **Documentation updates**: 
   - Added protocol incompatibility note in client-protocol.md
   - Marked #114 as completed in ROADMAP.md
   - Created detailed design specification document

The client can now distinguish between what it requested and what's actually operational, eliminating the confusion when `capabilities` showed a service as available but subsequent `status` messages indicated otherwise.
<!-- kody-pr-summary:end -->