### PR TITLE
chore(deps): sync pyproject.toml version floors with requirements.txt

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,9 +6,9 @@ readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
     "fastapi>=0.139.0",
-    "uvicorn>=0.49.0",
-    "websockets>=11.0.3",
-    "pydantic>=2.13.3",
+    "uvicorn>=0.51.0",
+    "websockets>=16.1",
+    "pydantic>=2.13.4",
     "pydantic-settings>=2.14.2",
     "python-multipart>=0.0.32",
     "httpx>=0.28.1",
@@ -20,9 +20,9 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
     "pytest>=9.1.1,<9.2.0",
-    "pytest-asyncio>=1.3.0,<1.4.0",
+    "pytest-asyncio>=1.4.0,<1.5.0",
     "respx>=0.23.1",
-    "ruff>=0.15.20",
+    "ruff>=0.15.21",
 ]
 
 [build-system]


### PR DESCRIPTION
## Summary
- Dependabot's pip scan only ever updates `requirements.txt`, never `pyproject.toml`'s dependency list, even though both declare the same packages and CLAUDE.md documents them as mirrors.
- The 5 pip bumps just merged (#90-#94) left `pyproject.toml` pointing at the old floors while `requirements.txt` had the new ones. This syncs them: `uvicorn>=0.51.0`, `websockets>=16.1`, `pydantic>=2.13.4`, `pytest-asyncio>=1.4.0,<1.5.0`, `ruff>=0.15.21`.
- Doesn't change runtime behavior today (Docker/CI both install from `requirements.txt`), but keeps `pip install -e .` from silently resolving stale floors.

## Test plan
- [x] `pip install -e ".[dev]"` (exercises the pyproject.toml path directly) → clean
- [x] `ruff check src/ tests/` → All checks passed
- [x] `PYTHONPATH=. pytest tests/ -q` → 434 passed, 7 deselected
- [x] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)